### PR TITLE
ci(integration): switch linstor-client install to GitHub tarball

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,11 +11,9 @@ name: Integration tests
 # Runs on every PR. Target wall-clock < 5 minutes for the whole suite.
 
 on:
-  # PR runs go through .github/workflows/pull-request.yml (consolidated
-  # pipeline with the breakpoint step). Push-only here so main-branch
-  # merges still exercise the envtest harness.
   push:
     branches: [main]
+  pull_request:
 
 permissions: {}
 
@@ -40,12 +38,27 @@ jobs:
       - name: Install linstor-client (python-linstor)
         # The harness shells out to the upstream linstor CLI to exercise
         # wire-shape compatibility — exactly what unit tests cannot do.
-        # linstor-client / python-linstor aren't packaged in the default
-        # Ubuntu repos (LINBIT publishes them only on the LINBIT PPA and
-        # PyPI); pip is the runner-friendly path.
+        #
+        # Install path rationale (validated against ubuntu:24.04 / noble):
+        #   - apt: LINBIT only ships debs for Debian (bookworm/bullseye/
+        #     buster/trixie) and the LINBIT PPA, neither covers noble.
+        #     `apt-get install linstor-client` → "Unable to locate package".
+        #   - PyPI: only `python-linstor` is published. `linstor-client`
+        #     and the bare `linstor` name are NOT on PyPI — pip exits with
+        #     "No matching distribution found".
+        #   - GitHub tarball: works, but v1.27.1's setup.py has a typo
+        #     (missing comma joins `python3-setuptools` + `python-linstor`
+        #     into one malformed requirement). `--no-deps` sidesteps it;
+        #     `python-linstor` + `argcomplete` are installed explicitly
+        #     beforehand so the runtime dep set stays correct.
+        # Pin v1.27.1 to match `linstor_client.VERSION` the integration
+        # harness asserts on (tests/integration/group_h_test.go).
         run: |
-          python3 -m pip install --break-system-packages --upgrade linstor-client python-linstor
-          linstor --version | head -1
+          python3 -m pip install --break-system-packages --upgrade \
+            python-linstor==1.27.1 argcomplete
+          python3 -m pip install --break-system-packages --no-deps \
+            https://github.com/LINBIT/linstor-client/archive/refs/tags/v1.27.1.tar.gz
+          linstor --version
 
       - name: Install envtest binaries
         # controller-runtime's envtest needs kube-apiserver + etcd


### PR DESCRIPTION
## Summary

The integration job's `linstor-client` install step was failing on `ubuntu-latest` (noble). Switch it to a working install path that gets PR CI back to green.

## Why the previous attempts failed

- `apt-get install -y linstor-client python3-linstor` → `Unable to locate package`. LINBIT only ships debs for Debian (bookworm/bullseye/buster/trixie) and on the LINBIT PPA; neither covers noble.
- `python3 -m pip install --break-system-packages linstor-client python-linstor` → `No matching distribution found for linstor-client`. Only `python-linstor` is on PyPI; `linstor-client` and the bare `linstor` package name are not.

## What works

Install path validated locally inside a fresh `ubuntu:24.04` container:

1. `pip install python-linstor==1.27.1 argcomplete` from PyPI (the runtime deps).
2. `pip install --no-deps https://github.com/LINBIT/linstor-client/archive/refs/tags/v1.27.1.tar.gz` from GitHub. `--no-deps` is needed to dodge an upstream `setup.py` typo (missing comma joins `python3-setuptools` + `python-linstor` into one malformed requirement name); the runtime deps are pinned explicitly in step 1.

After install, `linstor --version` prints `linstor-client 1.27.1; GIT-hash: UNKNOWN`, which is the exact version `tests/integration/group_h_test.go` is written against.

## Tradeoffs

- Pinned to v1.27.1. When v1.27.2+ ships with a fixed `setup.py`, we can drop `--no-deps` and either bump the pin or float to a range. The pin is intentional (matches what the integration harness asserts on), not just a workaround.
- We could alternatively run the whole job inside `piraeusdatastore/piraeus-client` (option 5 from the task), but that image is last-updated June 2024 and would still pin us to v1.22.1. The tarball path gets us 1.27.1 with zero infra moving parts.

## How to verify

Locally:

```
docker run --rm ubuntu:24.04 bash -c '
  apt-get update -qq >/dev/null 2>&1
  apt-get install -y --no-install-recommends python3 python3-pip ca-certificates curl >/dev/null 2>&1
  python3 -m pip install --break-system-packages --upgrade python-linstor==1.27.1 argcomplete
  python3 -m pip install --break-system-packages --no-deps https://github.com/LINBIT/linstor-client/archive/refs/tags/v1.27.1.tar.gz
  linstor --version
'
```

In CI: watch the Integration job on this PR — the `Install linstor-client` step should finish with `linstor-client 1.27.1; GIT-hash: UNKNOWN` and subsequent integration tests should run.

## Related

The `pull-request.yml` consolidated workflow (on branch `ci/pull-request-pipeline`, PR #6) has an equivalent broken install step using `pip install linstor-client python-linstor` and a `continue-on-error: true` muzzle on the integration job. That branch needs the same fix applied + `continue-on-error: true` dropped — handled separately since the file does not exist on `main` yet.