### PR TITLE
ci(pr): use CNCF Oracle runners for e2e

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -190,29 +190,22 @@ jobs:
 
   e2e:
     name: E2E
-    # GitHub-hosted runner. kind-based e2e (Tier 4 in the test strategy)
-    # runs fine on ubuntu-latest without nested virtualisation. Real-
-    # DRBD QEMU scenarios (.work/<stand> with Talos VMs) need KVM and
-    # ~50 GB RAM, so they stay manual on dedicated bare-metal stands —
-    # see stand/Makefile + reference_blockstor_stand.md.
-    #
-    # When the ephemeral self-hosted runner pool (ARC / namespace.so /
-    # equivalent) is wired up, swap the label to that pool's identifier
-    # and bring real-DRBD scenarios online here too.
-    runs-on: ubuntu-latest
+    # Runner selection mirrors cozystack/cozystack: a labelled `debug` PR
+    # lands on a long-lived `self-hosted` runner so the breakpoint step
+    # below has somewhere stable to attach SSH; regular PRs land on the
+    # CNCF-provided Oracle pool (24 CPU / 96 GB / x86-64) which has
+    # enough headroom for kind + real-DRBD QEMU stands (Talos VMs in
+    # .work/<stand>, ~50 GB RAM, KVM nested virt). The pool labels are
+    # org-wide on cozystack, so no extra setup is required here. Swap
+    # to oracle-vm-32cpu-128gb-x86-64 if a future scenario needs more
+    # RAM/CPU.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     needs: [detect-changes, lint, unit-test]
     if: needs.detect-changes.outputs.code == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 180
     permissions:
       contents: read
       checks: write
-    # TODO: drop continue-on-error once the kind-based e2e tier is
-    # confirmed stable on ubuntu-latest. The kustomize manifest fix
-    # (commit c2e716daf) unblocked `make deploy`, but the suite
-    # itself may surface other ubuntu-latest gaps. Until then the job
-    # surfaces issues via annotations + breakpoint but does not block
-    # PR approval.
-    continue-on-error: true
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Switch the e2e job from GitHub-hosted \`ubuntu-latest\` to the CNCF-provided Oracle runner pool on the cozystack org, mirroring the pattern in [cozystack/cozystack's pull-requests workflow](https://github.com/cozystack/cozystack/blob/main/.github/workflows/pull-requests.yaml).

\`\`\`yaml
runs-on: \${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
\`\`\`

| PR label | Runner | Why |
|---|---|---|
| _(default)_ | \`oracle-vm-24cpu-96gb-x86-64\` (24 CPU / 96 GB / x86-64, CNCF-funded Oracle pool) | Ephemeral, big enough for real-DRBD QEMU stands |
| \`debug\` | \`self-hosted\` | Long-lived so the breakpoint step can attach SSH |

## Why

\`ubuntu-latest\` (4 CPU / 16 GB / no KVM) only fits the kind-based tier. The real-DRBD QEMU stand (\`make e2e<N>\` → Talos VMs in \`.work/<stand>\`) needs ~50 GB RAM and KVM nested virt — Oracle 24 CPU / 96 GB has both. With this swap the e2e job can drive the cli-matrix suite end-to-end without a separate bare-metal stand.

## Also

- Drop \`continue-on-error: true\` from the e2e job. It was added when the runner was the cramped \`ubuntu-latest\`; with real hardware the job should gate the PR again.
- Bump \`timeout-minutes\` from 60 → 180 to match cozystack's e2e budget (real-DRBD scenarios can run long).

## Test plan

- [ ] CI picks the Oracle runner (regular PR).
- [ ] Add \`debug\` label → CI picks \`self-hosted\`; breakpoint step has somewhere to attach.
- [ ] e2e suite completes within 180 min.