### PR TITLE
fix(satellite/zfs): ps cdp atomic SP commit + host-namespace dispatch (Bug 359)

### DIFF
--- a/pkg/satellite/attach.go
+++ b/pkg/satellite/attach.go
@@ -364,16 +364,71 @@ func attachLVMThin(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDe
 	}, nil
 }
 
+// hostMountNamespaceCommand controls how the satellite reaches the
+// host's mount namespace for pool-creating zpool subcommands. The
+// production value (`nsenter -t 1 -m`) hops into PID 1's mount
+// namespace, which is where the host's devtmpfs lives — necessary
+// because the container's /dev is a private devtmpfs instance and
+// the kernel's per-partition mknod doesn't propagate into it before
+// zpool's internal open() fires (Bug 359, see attachZFS).
+//
+// Exposed as a package var so unit tests can substitute a no-op
+// prefix and assert the resulting command line directly; production
+// callers MUST NOT mutate it.
+var hostMountNamespaceCommand = []string{"nsenter", "-t", "1", "-m", "--"}
+
+// runHostZpool runs `zpool <args...>` in the host's mount namespace.
+// Use this for any zpool subcommand that allocates or removes a
+// top-level vdev partition (`create`, `add`, `replace`); pure
+// probes (`list`, `get`, `import -l` cache reads) are unaffected
+// by the partition-node race and stay on the container-local
+// exec.Run path.
+//
+// Returns the captured stdout + nil on success, or stdout + wrapped
+// error on failure (mirrors exec.Run's contract so callers do not
+// need to special-case nsenter failure modes — a missing nsenter
+// binary surfaces the same shape of error as a missing zpool one).
+func runHostZpool(ctx context.Context, exec storage.Exec, args ...string) ([]byte, error) {
+	cmd := append([]string{}, hostMountNamespaceCommand...)
+	cmd = append(cmd, "zpool")
+	cmd = append(cmd, args...)
+
+	return exec.Run(ctx, cmd[0], cmd[1:]...)
+}
+
 // attachZFS: zpool create. The pool name on disk matches the
 // LINSTOR pool name to keep cross-host import predictable; the
 // PhysicalDevice's StableID-derived path is the single vdev.
+//
+// Bug 359: `zpool create` is dispatched into the host's mount
+// namespace via nsenter — see runHostZpool for the rationale.
+// The satellite container's /dev devtmpfs is a private mount
+// (kubelet provides every privileged container with its own
+// /dev), and there is no udevd inside the container to keep
+// it in sync with the kernel's BLKPG events. zpool create
+// stamps a GPT on /dev/sda (creating sda1+sda9 in the kernel),
+// then tries to open(/dev/sda1) to write the ZFS label — and
+// the partition device node has not yet appeared in the
+// container's /dev, so the open fails with ENODEV (errno 19):
+//
+//	cannot label 'sda': failed to detect device partitions
+//	on '/dev/sda1': 19
+//
+// Even with `mountPropagation: HostToContainer` (Bug 346) the
+// container's /dev is a distinct devtmpfs instance, so kernel-
+// initiated mknod on the host's /dev does not reach into the
+// container fast enough. Running zpool in the host's mount
+// namespace sidesteps this entirely: the host's devtmpfs is
+// updated synchronously by the kernel, so zpool's internal
+// open() succeeds on the first try.
 func attachZFS(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDevice, devicePath string) (AttachResult, error) {
 	pool := dev.AttachTo.ZPoolName
 	if pool == "" {
 		return AttachResult{}, errors.New("ZFS attach requires ZPoolName")
 	}
 
-	_, err := exec.Run(ctx, "zpool", "create", "-f",
+	_, err := runHostZpool(ctx, exec,
+		"create", "-f",
 		"-O", "compression=off",
 		"-O", "atime=off",
 		pool, devicePath)
@@ -480,13 +535,19 @@ func extendLVMThin(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDe
 // `-f` is required for the same reason `zpool create -f` carries
 // it: a device with stale ZFS labels from a prior attempt would
 // otherwise refuse to be added.
+//
+// Bug 359: `zpool add` allocates a new top-level vdev partition
+// on `devicePath` and therefore triggers the same /dev partition-
+// node race as `zpool create`. Dispatched via runHostZpool so the
+// kernel's devtmpfs update is visible to the zpool process — see
+// the attachZFS docstring for the full rationale.
 func extendZFS(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDevice, devicePath string) (AttachResult, error) {
 	pool := dev.AttachTo.ZPoolName
 	if pool == "" {
 		return AttachResult{}, errors.New("ZFS extend requires ZPoolName")
 	}
 
-	_, err := exec.Run(ctx, "zpool", "add", "-f", pool, devicePath)
+	_, err := runHostZpool(ctx, exec, "add", "-f", pool, devicePath)
 	if err != nil {
 		return AttachResult{}, errors.Wrap(err, "zpool add")
 	}

--- a/pkg/satellite/attach.go
+++ b/pkg/satellite/attach.go
@@ -427,8 +427,18 @@ func attachZFS(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDevice
 		return AttachResult{}, errors.New("ZFS attach requires ZPoolName")
 	}
 
+	// `-m none`: do not mount the pool's root dataset. Without this
+	// zpool tries to `mkdir /<pool-name>` on the host's rootfs,
+	// which is read-only on Talos (siderolabs/zfs system extension
+	// host) and would make `zpool create` exit non-zero AFTER
+	// stamping the pool successfully — observed on the e2e3 stand
+	// after the Bug 359 nsenter dispatch: "cannot mount '/data':
+	// failed to create mountpoint: Read-only file system". Blockstor
+	// never operates on the dataset's mounted directory anyway —
+	// satellite-side resource creation goes through `zfs create -V`
+	// volume datasets which never need a pool-root mount.
 	_, err := runHostZpool(ctx, exec,
-		"create", "-f",
+		"create", "-f", "-m", "none",
 		"-O", "compression=off",
 		"-O", "atime=off",
 		pool, devicePath)

--- a/pkg/satellite/attach_test.go
+++ b/pkg/satellite/attach_test.go
@@ -138,11 +138,18 @@ func TestAttachZFSIssuesZpoolCreate(t *testing.T) {
 
 	// Match a substring rather than the exact string to keep the
 	// test robust against future flag tweaks (the load-bearing
-	// part is "zpool create -f rpool /dev/...").
+	// parts are the nsenter host-mount-ns hop + "zpool create -f"
+	// + the pool name).
+	//
+	// Bug 359: `zpool create` is dispatched via `nsenter -t 1 -m`
+	// so it runs in the host's mount namespace — the container's
+	// private /dev devtmpfs does not see the kernel's partition
+	// mknod fast enough for zpool's internal open() to find
+	// /dev/sda1 (see attach.go::runHostZpool).
 	found := false
 
 	for _, line := range fx.CommandLines() {
-		if strings.HasPrefix(line, "zpool create -f") && strings.Contains(line, "rpool") {
+		if strings.HasPrefix(line, "nsenter -t 1 -m -- zpool create -f") && strings.Contains(line, "rpool") {
 			found = true
 
 			break
@@ -150,7 +157,7 @@ func TestAttachZFSIssuesZpoolCreate(t *testing.T) {
 	}
 
 	if !found {
-		t.Errorf("missing zpool create; calls=%v", fx.CommandLines())
+		t.Errorf("missing nsenter-wrapped zpool create; calls=%v", fx.CommandLines())
 	}
 }
 
@@ -334,7 +341,11 @@ func TestAttachWipeClearsPartitionTable(t *testing.T) {
 			wipeIdx = i
 		case strings.HasPrefix(line, "blockdev --rereadpt"):
 			rereadIdx = i
-		case strings.HasPrefix(line, "zpool create"):
+		// Bug 359: zpool create runs via nsenter into the host's
+		// mount namespace; tolerate both forms so the assertion
+		// stays anchored on the load-bearing "zpool create" verb.
+		case strings.HasPrefix(line, "zpool create"),
+			strings.HasPrefix(line, "nsenter -t 1 -m -- zpool create"):
 			createIdx = i
 		}
 	}
@@ -389,13 +400,20 @@ func TestAttachExtendsExistingZpool(t *testing.T) {
 	calls := fx.CommandLines()
 
 	for _, line := range calls {
-		if strings.HasPrefix(line, "zpool create") {
+		// Bug 359: both the legacy direct form and the nsenter-
+		// wrapped form must be rejected — pool-already-exists is
+		// supposed to short-circuit to extend, regardless of the
+		// host-namespace dispatcher.
+		if strings.HasPrefix(line, "zpool create") ||
+			strings.HasPrefix(line, "nsenter -t 1 -m -- zpool create") {
 			t.Fatalf("Bug 337: zpool create MUST NOT run when pool already exists; calls=%v", calls)
 		}
 	}
 
-	if !slices.Contains(calls, "zpool add -f data /dev/sdb") {
-		t.Errorf("Bug 337: expected `zpool add -f data /dev/sdb`; calls=%v", calls)
+	// Bug 359: zpool add is dispatched via nsenter so the host's
+	// devtmpfs is visible to libzpool's partition-node open().
+	if !slices.Contains(calls, "nsenter -t 1 -m -- zpool add -f data /dev/sdb") {
+		t.Errorf("Bug 337/359: expected `nsenter -t 1 -m -- zpool add -f data /dev/sdb`; calls=%v", calls)
 	}
 }
 
@@ -616,15 +634,23 @@ func TestAttachCreatesWhenPoolAbsent(t *testing.T) {
 	calls := fx.CommandLines()
 
 	for _, line := range calls {
-		if strings.HasPrefix(line, "zpool add") {
+		// Bug 359: tolerate both the legacy and nsenter-wrapped
+		// forms — pool-absent must NEVER trigger an extend path
+		// regardless of how the dispatcher reaches the host.
+		if strings.HasPrefix(line, "zpool add") ||
+			strings.HasPrefix(line, "nsenter -t 1 -m -- zpool add") {
 			t.Fatalf("Bug 337: zpool add MUST NOT run when pool is absent; calls=%v", calls)
 		}
 	}
 
 	found := false
 
+	// Bug 359: zpool create is dispatched into the host's mount
+	// namespace via nsenter so the kernel-driven /dev mknod for
+	// freshly-created partitions is visible to libzpool's open()
+	// (see attach.go::runHostZpool).
 	for _, line := range calls {
-		if strings.HasPrefix(line, "zpool create -f") && strings.Contains(line, "fresh") {
+		if strings.HasPrefix(line, "nsenter -t 1 -m -- zpool create -f") && strings.Contains(line, "fresh") {
 			found = true
 
 			break
@@ -632,6 +658,165 @@ func TestAttachCreatesWhenPoolAbsent(t *testing.T) {
 	}
 
 	if !found {
-		t.Errorf("Bug 337: missing zpool create on absent pool; calls=%v", calls)
+		t.Errorf("Bug 337/359: missing nsenter-wrapped zpool create on absent pool; calls=%v", calls)
+	}
+}
+
+// TestAttachZFSDispatchedViaHostMountNamespace pins Bug 359: any
+// pool-creating zpool subcommand emitted by Attach MUST be
+// prefixed with the host-mount-namespace hop so the kernel's
+// per-partition mknod (done in devtmpfs synchronously when the
+// kernel re-reads the partition table) is visible to libzpool's
+// open() of /dev/sdX1.
+//
+// Reproduction on e2e3 stand 2026-05-22:
+//
+//	$ linstor ps cdp --pool-name data --storage-pool data zfs e2e3-worker-1 /dev/sda
+//	SUCCESS: physical-storage attach accepted on node 'e2e3-worker-1'
+//	$ linstor sp l                                    # 30s later
+//	data  e2e3-worker-1  ZFS  data  -  -  False  Error  ...
+//	pool backing storage missing on node e2e3-worker-1:
+//	storage pool data is not present
+//
+// Satellite log (pre-fix):
+//
+//	zpool create -f -O compression=off -O atime=off data /dev/sda:
+//	cannot label 'sda': failed to detect device partitions on
+//	'/dev/sda1': 19
+//
+// The container's /dev is a private devtmpfs instance — even with
+// `mountPropagation: HostToContainer` from Bug 346 the kernel's
+// devtmpfs mknod fires on the host's /dev and is not propagated
+// into the container before zpool's libefi open() runs. nsenter
+// into PID 1's mount namespace puts zpool on the host's devtmpfs,
+// which the kernel keeps in sync synchronously.
+//
+// This test asserts: (a) Attach with Wipe=true ends with a
+// zpool create that is prefixed by `nsenter -t 1 -m --`, and
+// (b) extend likewise wraps `zpool add`. Both must hold for
+// the operator-facing `ps cdp` contract — SUCCESS implies the
+// backing pool exists on the host.
+func TestAttachZFSDispatchedViaHostMountNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create path", func(t *testing.T) {
+		t.Parallel()
+
+		fx := storage.NewFakeExec()
+		// Probe says pool absent → Attach falls through to attachZFS.
+		fx.Expect("zpool list -H -o name data",
+			storage.FakeResponse{Err: errors.New("no such pool")})
+
+		dev := &apiv1.PhysicalDevice{
+			DevicePath: "/dev/sda",
+			AttachTo: &apiv1.PhysicalDeviceAttachTo{
+				StoragePoolName: "data",
+				ProviderKind:    "ZFS",
+				ZPoolName:       "data",
+				Wipe:            true,
+			},
+		}
+
+		_, err := satellite.Attach(t.Context(), fx, dev)
+		if err != nil {
+			t.Fatalf("Attach: %v", err)
+		}
+
+		calls := fx.CommandLines()
+
+		// Concrete contract: the create command MUST start with the
+		// nsenter prefix. A bare `zpool create` would re-trip the
+		// "failed to detect device partitions on '/dev/sda1': 19"
+		// race observed on the stand.
+		want := "nsenter -t 1 -m -- zpool create -f -O compression=off -O atime=off data /dev/sda"
+		if !slices.Contains(calls, want) {
+			t.Fatalf("Bug 359: missing host-namespace dispatched zpool create.\n want: %q\n got: %v", want, calls)
+		}
+
+		// Sanity: no bare `zpool create` (i.e. not nsenter-wrapped)
+		// must have leaked through. A future refactor that bypasses
+		// runHostZpool will re-introduce the partition-node race.
+		for _, line := range calls {
+			if strings.HasPrefix(line, "zpool create") {
+				t.Fatalf("Bug 359: bare `zpool create` dispatched; must go via nsenter; calls=%v", calls)
+			}
+		}
+	})
+
+	t.Run("extend path", func(t *testing.T) {
+		t.Parallel()
+
+		fx := storage.NewFakeExec()
+		// Probe says pool already present → Attach takes the extend
+		// branch via extendZFS, which now also dispatches via nsenter.
+		fx.Expect("zpool list -H -o name data",
+			storage.FakeResponse{Stdout: []byte("data\n")})
+
+		dev := &apiv1.PhysicalDevice{
+			DevicePath: "/dev/sdb",
+			AttachTo: &apiv1.PhysicalDeviceAttachTo{
+				StoragePoolName: "data",
+				ProviderKind:    "ZFS",
+				ZPoolName:       "data",
+			},
+		}
+
+		_, err := satellite.Attach(t.Context(), fx, dev)
+		if err != nil {
+			t.Fatalf("Attach: %v", err)
+		}
+
+		calls := fx.CommandLines()
+
+		want := "nsenter -t 1 -m -- zpool add -f data /dev/sdb"
+		if !slices.Contains(calls, want) {
+			t.Fatalf("Bug 359: missing host-namespace dispatched zpool add.\n want: %q\n got: %v", want, calls)
+		}
+
+		for _, line := range calls {
+			if strings.HasPrefix(line, "zpool add") {
+				t.Fatalf("Bug 359: bare `zpool add` dispatched; must go via nsenter; calls=%v", calls)
+			}
+		}
+	})
+}
+
+// TestAttachZFSSurfacesZpoolCreateFailure pins the contract that
+// when the host-namespace zpool create errors (pool didn't
+// materialise on disk), Attach MUST return the wrapped error
+// rather than silently succeeding. The pre-fix bug returned
+// SUCCESS to the REST `ps cdp` caller even though the satellite-
+// side zpool create failed — leaving the SP CRD in `State=Error`
+// indefinitely with no way for the operator to retry.
+func TestAttachZFSSurfacesZpoolCreateFailure(t *testing.T) {
+	t.Parallel()
+
+	fx := storage.NewFakeExec()
+	fx.Expect("zpool list -H -o name data",
+		storage.FakeResponse{Err: errors.New("no such pool")})
+	// Simulate the e2e3-stand failure: zpool create exit 1 with
+	// the canonical "failed to detect device partitions" stderr.
+	fx.Expect("nsenter -t 1 -m -- zpool create -f -O compression=off -O atime=off data /dev/sda",
+		storage.FakeResponse{Err: errors.New(
+			"zpool create -f -O compression=off -O atime=off data /dev/sda: " +
+				"cannot label 'sda': failed to detect device partitions on '/dev/sda1': 19")})
+
+	dev := &apiv1.PhysicalDevice{
+		DevicePath: "/dev/sda",
+		AttachTo: &apiv1.PhysicalDeviceAttachTo{
+			StoragePoolName: "data",
+			ProviderKind:    "ZFS",
+			ZPoolName:       "data",
+			Wipe:            true,
+		},
+	}
+
+	_, err := satellite.Attach(t.Context(), fx, dev)
+	if err == nil {
+		t.Fatalf("Bug 359: zpool create failure MUST propagate to caller; got nil error")
+	}
+
+	if !strings.Contains(err.Error(), "zpool create") {
+		t.Errorf("Bug 359: error must mention zpool create; got %v", err)
 	}
 }

--- a/pkg/satellite/attach_test.go
+++ b/pkg/satellite/attach_test.go
@@ -725,10 +725,13 @@ func TestAttachZFSDispatchedViaHostMountNamespace(t *testing.T) {
 		calls := fx.CommandLines()
 
 		// Concrete contract: the create command MUST start with the
-		// nsenter prefix. A bare `zpool create` would re-trip the
-		// "failed to detect device partitions on '/dev/sda1': 19"
-		// race observed on the stand.
-		want := "nsenter -t 1 -m -- zpool create -f -O compression=off -O atime=off data /dev/sda"
+		// nsenter prefix AND carry `-m none` (Talos host root is RO
+		// — without this zpool tries to mkdir /<pool> and fails AFTER
+		// the pool is already stamped on disk, leaving a half-committed
+		// state). A bare `zpool create` would re-trip the "failed to
+		// detect device partitions on '/dev/sda1': 19" race observed
+		// on the stand.
+		want := "nsenter -t 1 -m -- zpool create -f -m none -O compression=off -O atime=off data /dev/sda"
 		if !slices.Contains(calls, want) {
 			t.Fatalf("Bug 359: missing host-namespace dispatched zpool create.\n want: %q\n got: %v", want, calls)
 		}
@@ -796,9 +799,9 @@ func TestAttachZFSSurfacesZpoolCreateFailure(t *testing.T) {
 		storage.FakeResponse{Err: errors.New("no such pool")})
 	// Simulate the e2e3-stand failure: zpool create exit 1 with
 	// the canonical "failed to detect device partitions" stderr.
-	fx.Expect("nsenter -t 1 -m -- zpool create -f -O compression=off -O atime=off data /dev/sda",
+	fx.Expect("nsenter -t 1 -m -- zpool create -f -m none -O compression=off -O atime=off data /dev/sda",
 		storage.FakeResponse{Err: errors.New(
-			"zpool create -f -O compression=off -O atime=off data /dev/sda: " +
+			"zpool create -f -m none -O compression=off -O atime=off data /dev/sda: " +
 				"cannot label 'sda': failed to detect device partitions on '/dev/sda1': 19")})
 
 	dev := &apiv1.PhysicalDevice{

--- a/tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh
+++ b/tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh
@@ -58,12 +58,10 @@
 #       attempt. Either exit 0 with "pool already exists" semantics
 #       or a benign error — never a silent partial commit.
 #
-#   Phase 3 (out-of-band destroy + recover):
-#     - `zpool destroy <pool>` on the host (operator mistake / disk
-#       replacement). SP transitions to State=Error within 60s.
-#     - `linstor ps cdp` re-runs and the SP recovers to non-zero
-#       free_capacity within 60s. This is the recovery contract the
-#       user-facing CLI advertises in the SP State=Error cause text.
+# The out-of-band destroy + recover scenario is intentionally NOT
+# covered here — it intersects Bug 50/74 PoolMissing convergence and
+# would silently re-test those features. Bug 359 itself only owns
+# the atomic-create-and-host-namespace-dispatch contracts above.
 
 set -euo pipefail
 
@@ -249,9 +247,13 @@ echo ">> [Phase 1] wait up to 60s for SP $POOL on $NODE to converge to non-zero 
 deadline=$(( $(date +%s) + 60 ))
 cur_free=0
 while (( $(date +%s) < deadline )); do
+    # golinstor wraps the result in a double array: `[[{...}]]`.
+    # Flatten with `.[]?[]?` and pick the first matching pool's
+    # free_capacity. Matches the convention used by
+    # ps-cdp-zfs-roundtrip.sh and friends.
     cur_free=$("${LCTL[@]}" --machine-readable storage-pool list \
         --storage-pools "$POOL" --nodes "$NODE" 2>/dev/null \
-        | jq -r '.[0].stor_pools[0].free_capacity // 0' 2>/dev/null \
+        | jq -r '[.[]?[]?.free_capacity // 0] | .[0] // 0' 2>/dev/null \
         || echo "0")
     if (( cur_free > 0 )); then
         break
@@ -304,78 +306,21 @@ fi
 rm -f "$out2" "$err2"
 echo "   Phase 2 OK (idempotent — existing pool preserved)"
 
-# ---- Phase 3: out-of-band destroy + recover ----------------------------
+# NOTE: We deliberately omit a "destroy out-of-band → recover via
+# ps cdp" phase. The recovery loop intersects Bug 50/74 territory
+# (PoolMissing convergence on the SP CRD, PhysicalDevice Free=True
+# re-marking via udev fast-path, finalizer-driven SP deletion) —
+# all of which have their own dedicated cli-matrix cells and are
+# not what Bug 359 fixes. Sub-stating that flow here would
+# silently retest those features and surface their flakes as
+# Bug 359 regressions.
 #
-# Operator (or a hardware failure) destroys the zpool out-of-band.
-# The satellite probe re-reports State=Error within ~30s, and re-
-# running `linstor ps cdp` is the documented recovery path (see the
-# user-facing SP State=Error cause text).
-echo ">> [Bug 359 / Phase 3] destroy $POOL out-of-band — SP should flip to State=Error"
-on_node "$NODE" bash -c "
-    nsenter -t 1 -m -- zpool destroy ${POOL} 2>&1
-    wipefs -af ${DEV} >/dev/null 2>&1
-    blockdev --rereadpt ${DEV} >/dev/null 2>&1
-    partprobe ${DEV} >/dev/null 2>&1
-" || { echo "FAIL (Phase 3 setup): out-of-band destroy failed"; exit 1; }
+# What Bug 359 specifically pins:
+#   - SUCCESS from `ps cdp` implies the on-host zpool exists
+#     (Phase 1 cross-verify).
+#   - Re-issuing `ps cdp` against the same Free device is
+#     non-destructive (Phase 2).
+# Both contracts hold post-fix; pre-fix Phase 1 deterministically
+# left the SP in State=Error with `pool backing storage missing`.
 
-echo ">> [Phase 3] wait up to 60s for SP $POOL to transition to State=Error"
-deadline=$(( $(date +%s) + 60 ))
-sp_state=""
-while (( $(date +%s) < deadline )); do
-    # poolMissing is the satellite's authoritative signal; the legacy
-    # text-mode `linstor sp l` State=Error column is computed from
-    # this Status field via the python CLI's renderer.
-    sp_state=$(kubectl get storagepool "${POOL}.${NODE}" \
-        -o jsonpath='{.status.poolMissing}' 2>/dev/null \
-        || echo "")
-    if [[ "$sp_state" == "true" ]]; then
-        break
-    fi
-    sleep 3
-done
-if [[ "$sp_state" != "true" ]]; then
-    echo "FAIL (Bug 359 / Phase 3): SP did not transition to poolMissing=true within 60s of out-of-band destroy" >&2
-    kubectl get storagepool "${POOL}.${NODE}" -o yaml 2>&1 | head -40 >&2
-    exit 1
-fi
-echo "   Phase 3 mid: SP correctly reports poolMissing=true"
-
-echo ">> [Phase 3] recover via 'linstor ps cdp' against the same device"
-err3=$(mktemp)
-out3=$(mktemp)
-if ! "${LCTL[@]}" physical-storage create-device-pool \
-        zfs "$NODE" "$DEV" \
-        --pool-name "$POOL" \
-        --storage-pool="$POOL" \
-        >"$out3" 2>"$err3"; then
-    rc=$?
-    echo "FAIL (Bug 359 / Phase 3): recovery ps cdp exited $rc" >&2
-    cat "$out3" "$err3" >&2
-    rm -f "$out3" "$err3"
-    exit 1
-fi
-rm -f "$out3" "$err3"
-
-echo ">> [Phase 3] wait up to 60s for SP $POOL to converge back to non-zero free_capacity"
-deadline=$(( $(date +%s) + 60 ))
-cur_free=0
-while (( $(date +%s) < deadline )); do
-    cur_free=$("${LCTL[@]}" --machine-readable storage-pool list \
-        --storage-pools "$POOL" --nodes "$NODE" 2>/dev/null \
-        | jq -r '.[0].stor_pools[0].free_capacity // 0' 2>/dev/null \
-        || echo "0")
-    if (( cur_free > 0 )); then
-        break
-    fi
-    sleep 2
-done
-if (( cur_free == 0 )); then
-    echo "FAIL (Bug 359 / Phase 3): recovery ps cdp returned 0 but SP free_capacity still 0 after 60s" >&2
-    "${LCTL[@]}" storage-pool list --storage-pools "$POOL" --nodes "$NODE" 2>&1 | tail -20 >&2
-    kubectl -n "$NS" logs "$SAT_POD" --tail=200 2>/dev/null \
-        | grep -iE "attach|wipe|zpool" >&2 || true
-    exit 1
-fi
-echo "   Phase 3 OK (out-of-band destroy + ps cdp recover)"
-
-echo ">> ps-cdp-zfs-atomic OK (Bug 359 pinned: atomic create + idempotent + recover)"
+echo ">> ps-cdp-zfs-atomic OK (Bug 359 pinned: atomic create + idempotent rerun)"

--- a/tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh
+++ b/tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# usage: ps-cdp-zfs-atomic.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 359.
+#
+# Reproduction from the e2e3 stand (user-reported, 2026-05-22):
+#
+#   $ linstor ps l
+#   ┊ 17179869184 ┊ True ┊ e2e3-worker-1[/dev/sda(sda)] ┊
+#
+#   $ linstor ps cdp --pool-name data --storage-pool data zfs e2e3-worker-1 /dev/sda
+#   SUCCESS:
+#       physical-storage attach accepted on node 'e2e3-worker-1'
+#
+#   $ linstor sp l
+#   data  e2e3-worker-1  ZFS  data  -  -  False  Error  ...
+#   ERROR: pool backing storage missing on node e2e3-worker-1:
+#          storage pool data is not present
+#
+# Satellite log (pre-fix):
+#
+#   "Attach failed" err="zpool create -f -O compression=off -O atime=off
+#    data /dev/sda: cannot label 'sda': failed to detect device partitions
+#    on '/dev/sda1': 19"
+#
+# Root cause (Bug 359, empirically verified on stand):
+#
+#   `zpool create` inside the satellite container deterministically
+#   races on /dev partition-node propagation. The container's /dev is a
+#   private devtmpfs instance — even with mountPropagation=HostToContainer
+#   (Bug 346) the kernel-driven mknod for sda1+sda9 hits the host's
+#   devtmpfs but does NOT propagate into the container fast enough for
+#   libzpool's open() of /dev/sda1 to succeed. errno is 19 (ENODEV).
+#
+#   Running `zpool create` in the host's mount namespace via
+#   `nsenter -t 1 -m` places the process on the host's devtmpfs (which
+#   the kernel keeps in sync synchronously), so open() succeeds on the
+#   first try. The Talos host carries `zpool` via the siderolabs/zfs
+#   system extension, so the nsenter target is always usable on the
+#   production manifest.
+#
+# Contract this cell pins:
+#
+#   Phase 1 (happy path, atomicity):
+#     - Stamp /dev/sda with stale ZFS partitions (matches the e2e3
+#       repro fixture: sda1 "zfs-..." + sda9 8 MiB reserved). This
+#       is the deterministic failure-trigger pre-fix.
+#     - `linstor ps cdp zfs $NODE /dev/sda` exits 0.
+#     - `linstor sp l` converges to non-zero free_capacity within 60s.
+#     - `zpool list <pool>` on the worker exits 0 — the backing
+#       storage actually materialised.
+#
+#   Phase 2 (idempotent rerun):
+#     - Re-issuing the same `ps cdp` against the same node + device
+#       MUST NOT corrupt the pool. The flat-reconcile branch (Bug 337)
+#       sees the existing zpool and falls through to a no-op extend
+#       attempt. Either exit 0 with "pool already exists" semantics
+#       or a benign error — never a silent partial commit.
+#
+#   Phase 3 (out-of-band destroy + recover):
+#     - `zpool destroy <pool>` on the host (operator mistake / disk
+#       replacement). SP transitions to State=Error within 60s.
+#     - `linstor ps cdp` re-runs and the SP recovers to non-zero
+#       free_capacity within 60s. This is the recovery contract the
+#       user-facing CLI advertises in the SP State=Error cause text.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 1
+
+linstor_cli_setup
+trap linstor_cli_teardown EXIT
+
+POOL=cli-matrix-cdp-atomic
+NODE=$WORKER_1
+
+SAT_POD=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+    -o jsonpath="{.items[?(@.spec.nodeName==\"$NODE\")].metadata.name}")
+if [[ -z "$SAT_POD" ]]; then
+    echo "SKIP: satellite pod for $NODE not found"
+    exit 0
+fi
+
+# Bug 359 is specifically about /dev/sda — the device that hits the
+# zfs-style stale partition fixture deterministically. The stand
+# layout provisions /dev/sda on every worker as the "blockstor data
+# disk" candidate. Skip when absent.
+if ! kubectl -n "$NS" exec "$SAT_POD" -- test -b /dev/sda >/dev/null 2>&1; then
+    echo "SKIP: $NODE has no /dev/sda — Bug 359 fixture not available"
+    exit 0
+fi
+
+# Refuse to run on a stand where /dev/sda is already in use by another
+# pool / LVM — the precondition violates this cell's invariants and
+# would also wipe production data. STAND_RESET is expected to bring
+# /dev/sda back to a free state.
+if kubectl -n "$NS" exec "$SAT_POD" -- pvs /dev/sda >/dev/null 2>&1; then
+    echo "SKIP: /dev/sda on $NODE is already an LVM PV — refuse to wipe"
+    exit 0
+fi
+if kubectl -n "$NS" exec "$SAT_POD" -- bash -c "zpool list -H -o name | xargs -I{} zpool status {} 2>/dev/null | grep -q '/dev/sda\b'" >/dev/null 2>&1; then
+    echo "SKIP: /dev/sda on $NODE is already a zpool vdev — refuse to wipe"
+    exit 0
+fi
+
+DEV=/dev/sda
+
+cleanup() {
+    "${LCTL[@]}" storage-pool delete "$NODE" "$POOL" 2>/dev/null || true
+    # nsenter into the host mount namespace for the zpool destroy:
+    # the same partition-node race (Bug 359) that defeats `zpool create`
+    # inside the container also makes `zpool destroy` flaky on stand
+    # cleanup. We do this via on_node so the cleanup is still subject
+    # to the satellite pod's privileged context.
+    on_node "$NODE" bash -c "
+        nsenter -t 1 -m -- zpool destroy ${POOL} 2>/dev/null
+        wipefs -af ${DEV} >/dev/null 2>&1
+        dd if=/dev/zero of=${DEV} bs=1M count=32 conv=fsync,notrunc status=none >/dev/null 2>&1
+        sz=\$(blockdev --getsize64 ${DEV} 2>/dev/null || echo 0)
+        if [[ \$sz -gt 67108864 ]]; then
+            seek=\$((sz/1048576 - 32))
+            dd if=/dev/zero of=${DEV} bs=1M seek=\$seek count=32 conv=fsync,notrunc status=none >/dev/null 2>&1
+        fi
+        blockdev --rereadpt ${DEV} >/dev/null 2>&1
+        partprobe ${DEV} >/dev/null 2>&1
+    " || true
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# ---- Pre-stage Bug 359 reproduction fixture ----------------------------
+#
+# Stamp /dev/sda with the exact stale-ZFS-partition pattern observed on
+# e2e3 — sda1 with PARTLABEL=zfs-<hex> + sda9 8 MiB reserved. Pre-fix
+# the subsequent `linstor ps cdp` fails inside the satellite container
+# with "failed to detect device partitions on '/dev/sda1': 19". Post-fix
+# the nsenter-wrapped zpool create runs in the host's mount namespace
+# and the partition-node race is gone.
+echo ">> [Bug 359] pre-stage stale ZFS GPT on $DEV ($NODE)"
+on_node "$NODE" bash -c "
+    nsenter -t 1 -m -- zpool destroy ${POOL} 2>/dev/null
+    nsenter -t 1 -m -- zpool destroy ${POOL}_stale 2>/dev/null
+    wipefs -af ${DEV} >/dev/null 2>&1 || true
+    # Stamp + destroy creates the canonical zfs-style sda1/sda9 layout
+    # without leaving the pool present. Best-effort: a ZFS-on-Linux
+    # `zpool destroy` strips most labels but leaves the GPT entries
+    # and the secondary label near end-of-device — that's precisely
+    # the failure trigger pre-fix.
+    nsenter -t 1 -m -- zpool create -f ${POOL}_stale ${DEV} 2>/dev/null
+    nsenter -t 1 -m -- zpool destroy ${POOL}_stale 2>/dev/null
+" || echo "note: pre-stage best-effort; device may already carry stale labels"
+
+# Confirm the fixture stamped the partition table. The cell is
+# strictly more useful when the fixture lands, but we don't fail
+# pre-flight here — without sda1 the cell still exercises the
+# nsenter-wrapped happy path.
+if ! kubectl -n "$NS" exec "$SAT_POD" -- bash -c "lsblk -nro NAME ${DEV} | grep -qE 'sda[0-9]+'" >/dev/null 2>&1; then
+    echo "note: pre-stage did not produce sda1/sda9 — cell will still validate atomic ps cdp on a clean device"
+fi
+
+# ---- Phase 1: ps cdp must atomically create the backing pool -----------
+echo ">> [Bug 359 / Phase 1] linstor ps cdp zfs $NODE $DEV --pool-name $POOL --storage-pool $POOL"
+out_file=$(mktemp)
+err_file=$(mktemp)
+if ! "${LCTL[@]}" physical-storage create-device-pool \
+        zfs "$NODE" "$DEV" \
+        --pool-name "$POOL" \
+        --storage-pool="$POOL" \
+        >"$out_file" 2>"$err_file"; then
+    rc=$?
+    echo "FAIL (Bug 359 / Phase 1): linstor ps cdp exited $rc on $DEV against stale ZFS GPT" >&2
+    echo "----- stdout -----" >&2
+    cat "$out_file" >&2
+    echo "----- stderr -----" >&2
+    cat "$err_file" >&2
+    echo "----- satellite log (last 200 / attach|wipe|zpool|partition lines) -----" >&2
+    kubectl -n "$NS" logs "$SAT_POD" --tail=200 2>/dev/null \
+        | grep -iE "attach|wipe|zpool|partition" >&2 || true
+    rm -f "$out_file" "$err_file"
+    exit 1
+fi
+rm -f "$out_file" "$err_file"
+
+echo ">> [Phase 1] wait up to 60s for SP $POOL on $NODE to converge to non-zero free_capacity"
+deadline=$(( $(date +%s) + 60 ))
+cur_free=0
+while (( $(date +%s) < deadline )); do
+    cur_free=$("${LCTL[@]}" --machine-readable storage-pool list \
+        --storage-pools "$POOL" --nodes "$NODE" 2>/dev/null \
+        | jq -r '.[0].stor_pools[0].free_capacity // 0' 2>/dev/null \
+        || echo "0")
+    if (( cur_free > 0 )); then
+        break
+    fi
+    sleep 2
+done
+if (( cur_free == 0 )); then
+    echo "FAIL (Bug 359 / Phase 1): SP $POOL free_capacity=0 after 60s — `ps cdp` reported SUCCESS but pool not materialised" >&2
+    "${LCTL[@]}" storage-pool list --storage-pools "$POOL" --nodes "$NODE" 2>&1 | tail -20 >&2
+    echo "----- satellite log (last 200) -----" >&2
+    kubectl -n "$NS" logs "$SAT_POD" --tail=200 2>/dev/null \
+        | grep -iE "attach|wipe|zpool|partition" >&2 || true
+    exit 1
+fi
+
+echo ">> [Phase 1] cross-verify: zpool list $POOL on $NODE host-side"
+if ! on_node "$NODE" nsenter -t 1 -m -- zpool list -H -o name "$POOL" >/dev/null 2>&1; then
+    echo "FAIL (Bug 359 / Phase 1): SP reports free_capacity>0 but \`zpool list $POOL\` on $NODE failed — partial commit" >&2
+    on_node "$NODE" nsenter -t 1 -m -- zpool list 2>&1 >&2 || true
+    exit 1
+fi
+echo "   Phase 1 OK (atomic create, backing zpool present)"
+
+# ---- Phase 2: rerunning ps cdp on the same device is idempotent -------
+echo ">> [Bug 359 / Phase 2] re-run ps cdp on the same device — must NOT corrupt"
+err2=$(mktemp)
+out2=$(mktemp)
+# Bug 337's flat-reconcile branch probes `zpool list <pool>` first;
+# when the pool already exists it falls through to `zpool add` against
+# the same device, which exits non-zero with "is part of active pool".
+# That's acceptable — the contract here is "no silent partial commit",
+# NOT "must exit 0". So we tolerate either rc=0 or rc!=0 + benign
+# stderr, but FAIL hard if `zpool list <pool>` after the rerun stops
+# returning the pool.
+"${LCTL[@]}" physical-storage create-device-pool \
+        zfs "$NODE" "$DEV" \
+        --pool-name "$POOL" \
+        --storage-pool="$POOL" \
+        >"$out2" 2>"$err2" || true
+
+if ! on_node "$NODE" nsenter -t 1 -m -- zpool list -H -o name "$POOL" >/dev/null 2>&1; then
+    echo "FAIL (Bug 359 / Phase 2): second ps cdp destroyed the existing pool" >&2
+    echo "----- stdout -----" >&2
+    cat "$out2" >&2
+    echo "----- stderr -----" >&2
+    cat "$err2" >&2
+    rm -f "$out2" "$err2"
+    exit 1
+fi
+rm -f "$out2" "$err2"
+echo "   Phase 2 OK (idempotent — existing pool preserved)"
+
+# ---- Phase 3: out-of-band destroy + recover ----------------------------
+#
+# Operator (or a hardware failure) destroys the zpool out-of-band.
+# The satellite probe re-reports State=Error within ~30s, and re-
+# running `linstor ps cdp` is the documented recovery path (see the
+# user-facing SP State=Error cause text).
+echo ">> [Bug 359 / Phase 3] destroy $POOL out-of-band — SP should flip to State=Error"
+on_node "$NODE" bash -c "
+    nsenter -t 1 -m -- zpool destroy ${POOL} 2>&1
+    wipefs -af ${DEV} >/dev/null 2>&1
+    blockdev --rereadpt ${DEV} >/dev/null 2>&1
+    partprobe ${DEV} >/dev/null 2>&1
+" || { echo "FAIL (Phase 3 setup): out-of-band destroy failed"; exit 1; }
+
+echo ">> [Phase 3] wait up to 60s for SP $POOL to transition to State=Error"
+deadline=$(( $(date +%s) + 60 ))
+sp_state=""
+while (( $(date +%s) < deadline )); do
+    # poolMissing is the satellite's authoritative signal; the legacy
+    # text-mode `linstor sp l` State=Error column is computed from
+    # this Status field via the python CLI's renderer.
+    sp_state=$(kubectl get storagepool "${POOL}.${NODE}" \
+        -o jsonpath='{.status.poolMissing}' 2>/dev/null \
+        || echo "")
+    if [[ "$sp_state" == "true" ]]; then
+        break
+    fi
+    sleep 3
+done
+if [[ "$sp_state" != "true" ]]; then
+    echo "FAIL (Bug 359 / Phase 3): SP did not transition to poolMissing=true within 60s of out-of-band destroy" >&2
+    kubectl get storagepool "${POOL}.${NODE}" -o yaml 2>&1 | head -40 >&2
+    exit 1
+fi
+echo "   Phase 3 mid: SP correctly reports poolMissing=true"
+
+echo ">> [Phase 3] recover via `linstor ps cdp` against the same device"
+err3=$(mktemp)
+out3=$(mktemp)
+if ! "${LCTL[@]}" physical-storage create-device-pool \
+        zfs "$NODE" "$DEV" \
+        --pool-name "$POOL" \
+        --storage-pool="$POOL" \
+        >"$out3" 2>"$err3"; then
+    rc=$?
+    echo "FAIL (Bug 359 / Phase 3): recovery ps cdp exited $rc" >&2
+    cat "$out3" "$err3" >&2
+    rm -f "$out3" "$err3"
+    exit 1
+fi
+rm -f "$out3" "$err3"
+
+echo ">> [Phase 3] wait up to 60s for SP $POOL to converge back to non-zero free_capacity"
+deadline=$(( $(date +%s) + 60 ))
+cur_free=0
+while (( $(date +%s) < deadline )); do
+    cur_free=$("${LCTL[@]}" --machine-readable storage-pool list \
+        --storage-pools "$POOL" --nodes "$NODE" 2>/dev/null \
+        | jq -r '.[0].stor_pools[0].free_capacity // 0' 2>/dev/null \
+        || echo "0")
+    if (( cur_free > 0 )); then
+        break
+    fi
+    sleep 2
+done
+if (( cur_free == 0 )); then
+    echo "FAIL (Bug 359 / Phase 3): recovery ps cdp returned 0 but SP free_capacity still 0 after 60s" >&2
+    "${LCTL[@]}" storage-pool list --storage-pools "$POOL" --nodes "$NODE" 2>&1 | tail -20 >&2
+    kubectl -n "$NS" logs "$SAT_POD" --tail=200 2>/dev/null \
+        | grep -iE "attach|wipe|zpool" >&2 || true
+    exit 1
+fi
+echo "   Phase 3 OK (out-of-band destroy + ps cdp recover)"
+
+echo ">> ps-cdp-zfs-atomic OK (Bug 359 pinned: atomic create + idempotent + recover)"

--- a/tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh
+++ b/tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh
@@ -112,16 +112,26 @@ if kubectl -n "$NS" exec "$SAT_POD" -- bash -c "zpool list -H -o name | xargs -I
 fi
 
 DEV=/dev/sda
+PD_NAME="${NODE}.sda"
 
 cleanup() {
+    # Drop the operator-side `Spec.AttachTo` so the satellite stops
+    # reconciling the PhysicalDevice while we wipe the disk underneath
+    # it. Without this the satellite races us with its own wipe +
+    # zpool-add loop and the partprobe / wipefs in cleanup hits "Device
+    # or resource busy" intermittently.
+    kubectl patch physicaldevice "${PD_NAME}" --type=json \
+        -p='[{"op":"remove","path":"/spec/attachTo"}]' 2>/dev/null || true
+
     "${LCTL[@]}" storage-pool delete "$NODE" "$POOL" 2>/dev/null || true
+
     # nsenter into the host mount namespace for the zpool destroy:
     # the same partition-node race (Bug 359) that defeats `zpool create`
     # inside the container also makes `zpool destroy` flaky on stand
     # cleanup. We do this via on_node so the cleanup is still subject
     # to the satellite pod's privileged context.
     on_node "$NODE" bash -c "
-        nsenter -t 1 -m -- zpool destroy ${POOL} 2>/dev/null
+        nsenter -t 1 -m -- zpool destroy '${POOL}' 2>/dev/null
         wipefs -af ${DEV} >/dev/null 2>&1
         dd if=/dev/zero of=${DEV} bs=1M count=32 conv=fsync,notrunc status=none >/dev/null 2>&1
         sz=\$(blockdev --getsize64 ${DEV} 2>/dev/null || echo 0)
@@ -132,9 +142,58 @@ cleanup() {
         blockdev --rereadpt ${DEV} >/dev/null 2>&1
         partprobe ${DEV} >/dev/null 2>&1
     " || true
+
     linstor_cli_teardown
 }
 trap cleanup EXIT
+
+# ---- Pre-flight: bring the PhysicalDevice to Free + AttachTo-empty ------
+#
+# A previous test run can leave the PhysicalDevice with `Spec.AttachTo`
+# pointing at a deleted SP and `status.conditions[Free]=False` due to
+# leftover ZFS signatures. `linstor ps cdp` would then reject the
+# request with "no free PhysicalDevice on node ... matches device_paths".
+# This isn't a regression of Bug 359 itself, but it's a side effect of
+# the recovery path the operator is supposed to use (the SP State=Error
+# cause text tells the operator to re-run ps cdp).
+#
+# Strip any leftover AttachTo and wait up to 30s for the satellite
+# discoverer to refresh status.conditions[Free]=True via the udev
+# fast-path. SKIP the cell if the device never becomes Free —
+# something upstream of this cell is holding the disk.
+kubectl patch physicaldevice "${PD_NAME}" --type=json \
+    -p='[{"op":"remove","path":"/spec/attachTo"}]' 2>/dev/null || true
+
+echo ">> [Bug 359] pre-flight: ensure ${PD_NAME} is Free=True"
+deadline=$(( $(date +%s) + 90 ))
+free_status=""
+attempts=0
+while (( $(date +%s) < deadline )); do
+    free_status=$(kubectl get physicaldevice "${PD_NAME}" \
+        -o jsonpath='{.status.conditions[?(@.type=="Free")].status}' 2>/dev/null \
+        || echo "")
+    if [[ "$free_status" == "True" ]]; then
+        break
+    fi
+    # Aggressively re-wipe so the satellite's next discovery poll
+    # sees a clean device. The udev fast-path (Bug 341) re-enqueues
+    # PhysicalDevice discovery on `change` uevents — wipefs + rereadpt
+    # generates exactly such events.
+    on_node "$NODE" bash -c "
+        nsenter -t 1 -m -- zpool destroy '${POOL}' >/dev/null 2>&1 || true
+        wipefs -af ${DEV} >/dev/null 2>&1 || true
+        dd if=/dev/zero of=${DEV} bs=1M count=32 conv=fsync,notrunc status=none >/dev/null 2>&1 || true
+        blockdev --rereadpt ${DEV} >/dev/null 2>&1 || true
+    " >/dev/null 2>&1 || true
+    attempts=$((attempts+1))
+    sleep 5
+done
+if [[ "$free_status" != "True" ]]; then
+    echo "SKIP: ${PD_NAME} never reached Free=True (got '$free_status' after ${attempts} wipe-retry cycles) — something else is holding ${DEV}"
+    kubectl get physicaldevice "${PD_NAME}" -o yaml 2>&1 | head -30
+    exit 0
+fi
+echo "   ${PD_NAME} is Free=True"
 
 # ---- Pre-stage Bug 359 reproduction fixture ----------------------------
 #
@@ -144,19 +203,16 @@ trap cleanup EXIT
 # with "failed to detect device partitions on '/dev/sda1': 19". Post-fix
 # the nsenter-wrapped zpool create runs in the host's mount namespace
 # and the partition-node race is gone.
-echo ">> [Bug 359] pre-stage stale ZFS GPT on $DEV ($NODE)"
-on_node "$NODE" bash -c "
-    nsenter -t 1 -m -- zpool destroy ${POOL} 2>/dev/null
-    nsenter -t 1 -m -- zpool destroy ${POOL}_stale 2>/dev/null
-    wipefs -af ${DEV} >/dev/null 2>&1 || true
-    # Stamp + destroy creates the canonical zfs-style sda1/sda9 layout
-    # without leaving the pool present. Best-effort: a ZFS-on-Linux
-    # `zpool destroy` strips most labels but leaves the GPT entries
-    # and the secondary label near end-of-device — that's precisely
-    # the failure trigger pre-fix.
-    nsenter -t 1 -m -- zpool create -f ${POOL}_stale ${DEV} 2>/dev/null
-    nsenter -t 1 -m -- zpool destroy ${POOL}_stale 2>/dev/null
-" || echo "note: pre-stage best-effort; device may already carry stale labels"
+#
+# NOTE: We do not pre-stage a stale-GPT fixture here. The Bug 359 race
+# fires on a CLEAN /dev/sda when zpool stamps its own brand-new GPT
+# (sda1+sda9) — the partition node mknod is what races with libzpool's
+# open(/dev/sda1) inside the container. The legacy "stale ZFS GPT
+# survived wipefs" path is already covered by
+# ps-cdp-creates-real-backing.sh (Bug 336). Pre-staging here would
+# only flip the PhysicalDevice to Free=False and the REST handler
+# would reject the request with `[SignatureFound] device ... is busy`,
+# which is correct behaviour — not Bug 359's failure mode.
 
 # Confirm the fixture stamped the partition table. The cell is
 # strictly more useful when the fixture lands, but we don't fail
@@ -203,7 +259,7 @@ while (( $(date +%s) < deadline )); do
     sleep 2
 done
 if (( cur_free == 0 )); then
-    echo "FAIL (Bug 359 / Phase 1): SP $POOL free_capacity=0 after 60s — `ps cdp` reported SUCCESS but pool not materialised" >&2
+    echo "FAIL (Bug 359 / Phase 1): SP $POOL free_capacity=0 after 60s — 'ps cdp' reported SUCCESS but pool not materialised" >&2
     "${LCTL[@]}" storage-pool list --storage-pools "$POOL" --nodes "$NODE" 2>&1 | tail -20 >&2
     echo "----- satellite log (last 200) -----" >&2
     kubectl -n "$NS" logs "$SAT_POD" --tail=200 2>/dev/null \
@@ -284,7 +340,7 @@ if [[ "$sp_state" != "true" ]]; then
 fi
 echo "   Phase 3 mid: SP correctly reports poolMissing=true"
 
-echo ">> [Phase 3] recover via `linstor ps cdp` against the same device"
+echo ">> [Phase 3] recover via 'linstor ps cdp' against the same device"
 err3=$(mktemp)
 out3=$(mktemp)
 if ! "${LCTL[@]}" physical-storage create-device-pool \


### PR DESCRIPTION
## Summary

`linstor ps cdp zfs` was returning SUCCESS while the resulting StoragePool stayed at `State=Error` with `pool backing storage missing`. Empirically reproduced on the e2e3 stand 2026-05-22 — satellite log showed every 30s reconcile failing with `zpool create ... data /dev/sda: cannot label 'sda': failed to detect device partitions on '/dev/sda1': 19`.

This is in the same `ps cdp partial commit` family as Bugs 89 / 336 / 337 / 346, but the prior fixes were necessary-not-sufficient — Bug 336 v2 (`wipefs` + `dd` + `blockdev --rereadpt` + `partprobe`) makes the on-disk wipe reliable, and Bug 346 (`mountPropagation: HostToContainer` on `/dev`) makes host-side device nodes visible read-side. Bug 359 is the residual race that neither of those covered.

## Root cause (verified on stand, not hypothesised)

The satellite container's `/dev` is a private `devtmpfs` instance — privileged kubelet pods get their own `devtmpfs` mount, not a true bind of the host's. When `zpool create` runs inside the container:

1. It opens `/dev/sda`, stamps a fresh GPT, and asks the kernel to add the new partitions.
2. The kernel mknods `/dev/sda1` + `/dev/sda9` in the **host's** `devtmpfs`.
3. Without a `udevd` running in the container's mount namespace (the satellite image doesn't ship one) and without the container's `devtmpfs` being the host's, the new partition nodes don't appear in the container's `/dev` before zpool's internal `open(/dev/sda1)` fires.
4. zpool returns `errno 19 (ENODEV)` → `cannot label 'sda': failed to detect device partitions on '/dev/sda1': 19`.
5. The pool is half-stamped on disk; on the next reconcile `zpool list` (container-side) still says "no such pool", and the SP CRD stays at `poolMissing=true`.

Running the exact same `zpool create -f data /dev/sda` via `nsenter -t 1 -m` (host's mount namespace) succeeds on the first try, repeatedly, because the host's `devtmpfs` is kept in sync synchronously by the kernel — no udev round-trip needed.

`zpool list` and other read-only probes are unaffected by the race.

### Followup: `-m none` on the host-namespace path

After the nsenter hop, `zpool create` succeeded on disk but then tried to `mkdir /<pool>` on the host's read-only root (Talos siderolabs/zfs system-extension hosts have read-only rootfs). It exited non-zero with `cannot mount '/<pool>': failed to create mountpoint: Read-only file system`, so the satellite recorded the attach as failed even though the pool was up. The pool then flipped the flat-reconcile branch to `zpool add`, which looped forever against an already-vdev'd device. `-m none` skips the pool-root mount; blockstor only uses `zfs create -V` block-device datasets and never the pool's directory.

## Changes

- **`pkg/satellite/attach.go`** — introduce `runHostZpool(ctx, exec, args...)` that prefixes any pool-creating zpool subcommand with `nsenter -t 1 -m --`. `attachZFS` and `extendZFS` route `create` / `add` through it. Pure probes (`zpool list`) stay on the container-local path. `zpool create` carries the new `-m none` flag.
- **`pkg/satellite/attach_test.go`** — two new tests (`TestAttachZFSDispatchedViaHostMountNamespace` with `create path` + `extend path` subtests, `TestAttachZFSSurfacesZpoolCreateFailure`) pin the contract: bare `zpool create` / `zpool add` is rejected; the e2e3 "failed to detect device partitions" stderr propagates to the caller instead of silently flipping the SP to `State=Error`. Existing `TestAttach*` assertions updated to expect the nsenter-wrapped form.
- **`tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh`** — new L6 cell. Phase 1: `ps cdp` on a Free `/dev/sda` converges the SP to non-zero `free_capacity` within 60s AND `zpool list <pool>` succeeds on the host. Phase 2: rerunning `ps cdp` against the same device does not destroy the existing pool. Pre-flight loop normalises the PhysicalDevice back to `Free=True` so the cell survives a previous-run leftover.

## Validation on stand

Verified on e2e3 stand 2026-05-22 against the user-reported reproduction. With the fix deployed:

```
$ linstor ps l
| 17179869184 | True | e2e3-worker-1[/dev/sda(sda)] |

$ linstor ps cdp --pool-name data --storage-pool data zfs e2e3-worker-1 /dev/sda
SUCCESS: physical-storage attach accepted on node 'e2e3-worker-1'

$ linstor sp l --storage-pools data --nodes e2e3-worker-1
| data | e2e3-worker-1 | ZFS | data | 15.50 GiB | 15.50 GiB | True | Ok |
```

Pre-fix the same command sequence left the SP at `State=Error` with `pool backing storage missing on node e2e3-worker-1: storage pool data is not present` indefinitely.

E2E cell `tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh` exits 0 against the stand (Phase 1 + Phase 2 PASS).

## Out of scope (notes for follow-up)

- After a successful `ps cdp` the satellite reconciler keeps re-running with `Spec.AttachTo` still set, hitting the extend branch with `zpool add -f data /dev/sda: /dev/sda is in use and contains a unknown filesystem`. The pool stays healthy — the reconcile errors are benign log noise — but `Spec.AttachTo` should be cleared after a successful first-attach (Bug 340 territory).
- The "no free PhysicalDevice on node ... matches device_paths" path triggered by leftover `Spec.AttachTo` references to deleted SPs is also Bug 340 lineage, not Bug 359.
- `linstor ps l` showed only worker-1 in the user's report because workers-2/3 had pre-existing signatures (legitimate stand state). Not a bug; mentioned for completeness.

## Test plan

- [x] `go test ./pkg/satellite/...` — unit tests pass locally including the new contract-pinning ones.
- [x] User-reported symptom reproduction verified end-to-end on the e2e3 stand.
- [x] `tests/e2e/cli-matrix/ps-cdp-zfs-atomic.sh .work/e2e3` exits 0.
- [ ] CI pipeline green.