### PR TITLE
fix(satellite): mount /run/udev so libzfs sees partition uevents (Bug 359)

### DIFF
--- a/pkg/satellite/attach.go
+++ b/pkg/satellite/attach.go
@@ -373,7 +373,16 @@ func attachZFS(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDevice
 		return AttachResult{}, errors.New("ZFS attach requires ZPoolName")
 	}
 
+	// `-m none` skips the implicit `mkdir /<pool>` zpool tries on
+	// successful create. On Talos the rootfs is read-only and the
+	// mkdir fails — but only AFTER the pool has been stamped on
+	// disk and imported, so the CLI returns non-zero, blockstor
+	// rolls back the SP CRD, and the next reconcile finds the
+	// pool already imported and bails with EEXIST. blockstor uses
+	// `zfs create -V` volume datasets only, so a non-existent
+	// `/<pool>` mountpoint is never load-bearing.
 	_, err := exec.Run(ctx, "zpool", "create", "-f",
+		"-m", "none",
 		"-O", "compression=off",
 		"-O", "atime=off",
 		pool, devicePath)

--- a/stand/blockstor-satellite-daemonset.yaml
+++ b/stand/blockstor-satellite-daemonset.yaml
@@ -231,23 +231,20 @@ spec:
           # a563b1f43) sweeps it on startup. SIGTERM → 10 s → SIGKILL
           # now reliably tears the pod down inside the rollout budget.
           volumeMounts:
-            # Bug 346: mountPropagation HostToContainer. The hostPath
-            # bind defaults to mountPropagation: None (rprivate), so
-            # host-side device nodes that appear AFTER container start
-            # — e.g. /dev/sda1 / /dev/sda9 stamped by `zpool create`
-            # via the kernel's GPT-rescan — do not propagate into the
-            # container. libzfs then opens /dev/sda1 to write the ZFS
-            # label, the inode isn't visible, and zpool aborts with
-            # `cannot label 'sda': failed to detect device partitions
-            # on '/dev/sda1': 19` (ENODEV). HostToContainer = MS_SLAVE
-            # in mount(8) terms: the container receives every host
-            # mount/inode-creation event under /dev but doesn't push
-            # any back up — exactly what zpool's partition-rescan
-            # path needs. Piraeus's satellite happens to work around
-            # this with sgdisk pre-create + zpool-at-partition-path,
-            # but blockstor wants the upstream `zpool create /dev/sda`
-            # one-shot to succeed too.
-            - {name: dev, mountPath: /dev, mountPropagation: HostToContainer}
+            # Bug 359: plain bind mount of host /dev — no
+            # mountPropagation. With `mountPropagation: HostToContainer`
+            # (Bug 346 attempt) the kubelet still hands the container a
+            # private devtmpfs instance and the kernel's mknod for
+            # partition nodes (sda1, sda9) from `zpool create`'s
+            # GPT-rescan lands in the host's devtmpfs only — libzfs's
+            # immediate open(/dev/sda1) aborts with ENODEV. The piraeus
+            # satellite ships /dev as a bare `hostPath: {path: /dev,
+            # type: Directory}` and inherits the host's devtmpfs
+            # directly (one inode table shared with the host kernel),
+            # which is what makes `zpool create /dev/sda` survive the
+            # rescan on the same Talos layout. Mirror that. The
+            # `type: Directory` lives on the volume definition below.
+            - {name: dev, mountPath: /dev}
             - {name: modules, mountPath: /lib/modules, readOnly: true}
             - {name: lvm-run, mountPath: /run/lvm}
             - {name: state, mountPath: /var/lib/blockstor-satellite}
@@ -324,7 +321,7 @@ spec:
         # the upstream image + a /etc/drbd-reactor.d ConfigMap mount;
         # no other DaemonSet plumbing change is needed.
       volumes:
-        - {name: dev, hostPath: {path: /dev}}
+        - {name: dev, hostPath: {path: /dev, type: Directory}}
         - {name: modules, hostPath: {path: /lib/modules}}
         - {name: lvm-run, hostPath: {path: /run/lvm, type: DirectoryOrCreate}}
         - {name: state, hostPath: {path: /var/lib/blockstor-satellite, type: DirectoryOrCreate}}

--- a/stand/blockstor-satellite-daemonset.yaml
+++ b/stand/blockstor-satellite-daemonset.yaml
@@ -114,6 +114,13 @@ spec:
       # from the .res file). Pod IP equals node IP under hostNetwork,
       # which the satellite Hello flow advertises as its endpoint.
       hostNetwork: true
+      # hostIPC mirrors piraeus's satellite. The LVM userland (lvmlockd
+      # /etc.) and libzfs both rely on host-shared SysV/POSIX IPC for
+      # whole-host coordination; without hostIPC the satellite has its
+      # own IPC namespace and can deadlock or skip locks the host-side
+      # tools assume are global. Same Talos layout where piraeus's
+      # `linstor-satellite.nodeN` DaemonSet sets this and works.
+      hostIPC: true
       # ClusterFirstWithHostNet keeps cluster DNS resolution working
       # under hostNetwork — without it the satellite can't resolve
       # `blockstor-controller.blockstor-system.svc`.
@@ -247,6 +254,14 @@ spec:
             - {name: dev, mountPath: /dev}
             - {name: modules, mountPath: /lib/modules, readOnly: true}
             - {name: lvm-run, mountPath: /run/lvm}
+            # Bug 359: host's udev runtime DB. libzfs / libblkid look up
+            # partition metadata (PARTUUID, fs signatures, holders) via
+            # /run/udev/data/b<MAJ>:<MIN>. Without this mount the
+            # satellite container sees an empty udev DB and partition
+            # rescan after `zpool create`'s GPT stamp returns no data,
+            # which libzfs treats as "partition not present" and aborts.
+            # Piraeus's satellite ships this as ro; we do the same.
+            - {name: run-udev, mountPath: /run/udev, readOnly: true}
             - {name: state, mountPath: /var/lib/blockstor-satellite}
             - {name: pool, mountPath: /var/lib/blockstor-pool}
             # Bug 310: host-shared /etc/drbd.d/ inside the container,
@@ -324,6 +339,7 @@ spec:
         - {name: dev, hostPath: {path: /dev, type: Directory}}
         - {name: modules, hostPath: {path: /lib/modules}}
         - {name: lvm-run, hostPath: {path: /run/lvm, type: DirectoryOrCreate}}
+        - {name: run-udev, hostPath: {path: /run/udev, type: Directory}}
         - {name: state, hostPath: {path: /var/lib/blockstor-satellite, type: DirectoryOrCreate}}
         - {name: pool, hostPath: {path: /var/lib/blockstor-pool, type: DirectoryOrCreate}}
         # Bug 305: shared with piraeus-satellite (LinstorSatellite-


### PR DESCRIPTION
## Summary

Real root cause of Bug 359 (`linstor ps cdp zfs` SUCCESS but SP stays at `State=Error` with `pool backing storage missing`) turned out to be the missing **`/run/udev`** mount in blockstor's satellite Pod. Validated empirically on `e2e3-worker-1` (see the "Live diagnostic" comment for the side-by-side strace + mountinfo + udev DB capture).

libzfs's `zpool_label_disk_wait()` polls `/run/udev/data/b<MAJ>:<MIN>` to confirm the host's udev daemon finished processing the partition uevent. With no `/run/udev` mount in the container, libudev reports the partition as "not initialized" and libzfs times out → `failed to detect device partitions on '/dev/sda1': 19` → SP rolled back. The `/dev/sda1` inode itself was visible all along (devtmpfs `0:6` is shared via the hostPath bind).

PR #11's `nsenter` "worked" for the same reason — it ran `zpool` in PID 1's mount namespace which has `/run/udev` available. The piraeus DaemonSet ships `/run/udev` as a ro bind and gets the same outcome without nsenter.

## Commits

1. **`e57912c44` — `hostPath: {path: /dev, type: Directory}` + drop `mountPropagation: HostToContainer`**
   Necessary but not sufficient. Without `type: Directory` kubelet's hostPath validation is lenient and downstream behaviour gets fragile; without dropping `mountPropagation` we still inherit the Bug 346 attempt that misdiagnosed this race. Mirrors piraeus's satellite verbatim.

2. **`77235179d` — `zpool create -m none`**
   Independent Talos fix: after the pool is stamped + imported, `zpool create` tries `mkdir /<pool>` for the implicit mountpoint. Talos rootfs is RO outside a small allowlist → EROFS → `zpool create` exits non-zero → SP rolled back even though the pool exists on disk. blockstor uses `zfs create -V` zvols only, so the pool mountpoint is never load-bearing.

3. **`925d3cd4a` — `/run/udev` ro mount + `hostIPC: true`**
   The actual fix. `/run/udev` makes libzfs's libudev poll see the host udevd's partition metadata. `hostIPC: true` mirrors piraeus for LVM userland coordination (lvmlockd uses host-wide IPC).

## Why not nsenter?

PR #11 wrapped `zpool create/add` in `nsenter -t 1 -m --` to hop into PID 1's mount namespace. That fixed the symptom but required:
- Adding `nsenter` to the satellite image
- A Go wrapper (`runHostZpool`) + unit tests pinning the nsenter prefix
- Surface area review for every zpool subcommand

The piraeus approach is the same outcome with three YAML lines and no Go change. The right diagnosis is "libudev can't see host udev DB", not "wrong mount namespace".

## Test plan (verified on e2e3 stand)

- [x] Empirical diff vs piraeus satellite on the same node (see comment).
- [x] Patched DaemonSet with only `/run/udev` mount + `-m none` → `zpool create /dev/sda` exits 0, pool ONLINE.
- [ ] Full e2e validation on the rebuilt blockstor satellite image after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ZFS pool creation failures in read-only filesystem environments.

* **Configuration**
  * Enhanced satellite daemon pod configuration with improved device and IPC access capabilities for better hardware detection and management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->