### PR TITLE
ci(e2e): run the real QEMU/Talos suite on the KVM runner (2-lane matrix)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -181,20 +181,42 @@ jobs:
             /tmp/envtest-*.log
 
   e2e:
-    name: E2E
-    # Runner selection mirrors cozystack/cozystack: a labelled `debug` PR
-    # lands on a long-lived `self-hosted` runner so the breakpoint step
-    # below has somewhere stable to attach SSH; regular PRs land on the
-    # CNCF-provided Oracle pool (24 CPU / 96 GB / x86-64) which has
-    # enough headroom for kind + real-DRBD QEMU stands (Talos VMs in
-    # .work/<stand>, ~50 GB RAM, KVM nested virt). The pool labels are
-    # org-wide on cozystack, so no extra setup is required here. Swap
-    # to oracle-vm-32cpu-128gb-x86-64 if a future scenario needs more
-    # RAM/CPU.
+    name: E2E (lane ${{ matrix.lane }})
+    # Real-DRBD QEMU/Talos e2e — the same suite maintainers run on the
+    # dev stand (stand/up.sh + blockstor + pools + tests/e2e/*.sh), driven
+    # by stand/ci-e2e.sh. Runs on the CNCF-provided Oracle pool which
+    # exposes /dev/kvm (nested virt), exactly like cozystack/cozystack's
+    # own e2e job. A labelled `debug` PR lands on a long-lived
+    # `self-hosted` runner so the breakpoint step below has somewhere
+    # stable to attach SSH. Swap to oracle-vm-32cpu-128gb-x86-64 if a
+    # future, heavier scenario set needs more RAM/CPU.
+    #
+    # Parallel lanes: this is a 2-lane template. To widen coverage, add
+    # entries to `matrix.lane` (e.g. 1 2 3 ... 10) AND bump `env.LANES`
+    # to match — ci-e2e.sh round-robins the SCENARIOS list across LANES,
+    # so each runner automatically picks up its 1/N share. Nothing else
+    # changes. (A future optimisation is a single build job that pushes
+    # images to a registry the lanes pull from, instead of each lane
+    # rebuilding — cozystack does this; kept simple here on purpose.)
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     needs: [detect-changes, lint, unit-test]
     if: needs.detect-changes.outputs.code == 'true'
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        lane: [1, 2]
+    env:
+      LANES: 2
+      # Representative scenario set, round-robined across the lanes above.
+      # Expand this list (and the matrix/LANES) to broaden coverage; the
+      # full suite is `make e2e-list`.
+      SCENARIOS: >-
+        toggle-disk two-volume-rd tiebreaker clone
+        resize-pvc snapshot-restore-cross-node
+        recovery-stuck-synctarget network-partition
+        quorum-loss-recovery backup-restore-identity
+        auto-diskful recovery-setgi-per-peer
     permissions:
       contents: read
       checks: write
@@ -209,19 +231,23 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install the latest version of kind
+      - name: Verify KVM is available
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+          test -e /dev/kvm || { echo "::error::/dev/kvm missing — this runner lacks (nested) virtualization"; exit 1; }
+          ls -l /dev/kvm
 
-      - name: Verify kind installation
-        run: kind version
+      - name: Run QEMU e2e (lane ${{ matrix.lane }} of ${{ env.LANES }})
+        run: make ci-e2e LANE=${{ matrix.lane }} LANES=${{ env.LANES }} SCENARIOS="${{ env.SCENARIOS }}"
 
-      - name: Running Test e2e
-        run: |
-          go mod tidy
-          make test-e2e
+      - name: Upload e2e logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-logs-lane-${{ matrix.lane }}
+          path: |
+            /tmp/e2e-ci-lane${{ matrix.lane }}.results
+            /tmp/e2e-ci-lane${{ matrix.lane }}-*.log
+          if-no-files-found: ignore
 
       # Open an SSH breakpoint to the failing e2e runner so maintainers
       # can attach, inspect kind/blockstor state, and resume with

--- a/internal/controller/resource_controller.go
+++ b/internal/controller/resource_controller.go
@@ -1499,7 +1499,7 @@ func (r *ResourceReconciler) takenMinorsCluster(ctx context.Context, selfRD stri
 			}
 
 			for off := range volCount {
-				out = append(out, *base+int32(off)) //nolint:gosec // off is a bounded volume index (<= len), no overflow
+				out = append(out, *base+int32(off))
 			}
 		}
 	}

--- a/stand/Makefile
+++ b/stand/Makefile
@@ -13,7 +13,7 @@ KUBECONFIG := $(WORK_DIR)/kubeconfig
 export TALOSCONFIG
 export KUBECONFIG
 
-.PHONY: stand-help up down reset piraeus oracle build-images rebuild blockstor pools smoke smoke-blockstor burnin-blockstor e2e e2e-list iter use list stand-clean
+.PHONY: stand-help up down reset piraeus oracle build-images rebuild blockstor pools smoke smoke-blockstor burnin-blockstor e2e e2e-list ci-e2e iter use list stand-clean
 
 stand-help: ## list dev-stand targets
 	@echo "stand targets (use NAME=<cluster>):"
@@ -58,6 +58,10 @@ e2e: ## run a single e2e scenario (NAME=<cluster>, SCENARIO=<basename without .s
 
 e2e-list: ## list available e2e scenarios
 	@ls tests/e2e/*.sh | xargs -n1 basename | grep -v '^lib\.sh$$' | sed 's/\.sh$$//'
+
+ci-e2e: ## CI: provision an ephemeral stand + run this lane's e2e shard (LANE, LANES, SCENARIOS="a b c")
+	@test -n "$(LANE)" && test -n "$(LANES)" || (echo 'usage: make ci-e2e LANE=<n> LANES=<total> SCENARIOS="s1 s2 ..."'; exit 2)
+	@./stand/ci-e2e.sh "$(LANE)" "$(LANES)" $(SCENARIOS)
 
 iter: ## one dev-loop iteration on a single stand: rollout + cleanup + e2e (NAME=<cluster>, SCENARIO=<name>). Run `make rebuild` first.
 	@test -n "$${SCENARIO}" || (echo "usage: make iter NAME=<cluster> SCENARIO=<name>"; exit 2)

--- a/stand/ci-e2e.sh
+++ b/stand/ci-e2e.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# usage: ci-e2e.sh LANE LANES SCENARIO [SCENARIO ...]
+#
+# CI entry point for the real QEMU/Talos e2e suite. Provisions a Talos
+# cluster on a KVM-capable GitHub Actions runner (the cozystack
+# oracle-vm pool exposes /dev/kvm, same as the dev stand), deploys
+# blockstor, and runs THIS lane's share of the scenario list.
+#
+# Relationship to the dev-stand flow: this is the same pipeline a
+# maintainer runs by hand —
+#     make build-images && make up NAME=<n> && make blockstor NAME=<n>
+#     && make pools NAME=<n> && stand/run-scenarios-only.sh <n> <scen...>
+# — wrapped for an ephemeral CI runner. The differences vs the dev
+# stand are deliberate and limited to the runner environment:
+#   1. We do NOT run stand/setup-host.sh: its `mkfs.xfs` on "the largest
+#      unused block device" is unsafe on a shared CI runner. We install
+#      only the qemu userspace + the FORWARD iptables allow the Talos
+#      qemu provisioner needs.
+#   2. .work lives on the runner's own disk (no NVMe symlink) — a CI
+#      runner has a single disk and the cluster is torn down at the end.
+#   3. VM disks are sized down (EXTRA_DISK_SIZE_MB) to fit a CI runner.
+#   4. A throwaway localhost:5000 registry is started for
+#      build-images.sh; the cluster pulls it via the bridge gateway
+#      exactly as on the dev stand (see stand/up.sh registry mirror).
+#
+# Scenario sharding: the full scenario list is passed as arguments and
+# this lane runs every LANES-th entry starting at index (LANE-1). To
+# widen coverage, add lanes to the workflow matrix and bump LANES — the
+# round-robin here then hands each lane its 1/N share automatically; no
+# change to this script is required.
+set -uo pipefail
+
+LANE=${1:?LANE required (1-based)}
+LANES=${2:?LANES required (total lane count)}
+shift 2
+ALL_SCENARIOS=("$@")
+[ ${#ALL_SCENARIOS[@]} -gt 0 ] || { echo "FATAL: no scenarios given" >&2; exit 2; }
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$REPO_ROOT"
+
+STAND="ci-lane${LANE}"
+REGISTRY_CONTAINER="blockstor-ci-registry"
+
+# CI-tuned VM sizing (env-overridable). The dev stand defaults
+# (EXTRA_DISKS=2, 16 GiB each) assume a multi-TB NVMe; a CI runner has
+# far less, so we provision one smaller storage disk per worker. Still
+# 3 workers — many scenarios need 2 diskful replicas + a diskless
+# tiebreaker (or 3-way placement).
+export EXTRA_DISKS=${EXTRA_DISKS:-1}
+export EXTRA_DISK_SIZE_MB=${EXTRA_DISK_SIZE_MB:-10240}
+CI_WORKERS=${CI_WORKERS:-3}
+
+log() { echo ">> [$STAND] $*"; }
+
+# ── teardown ────────────────────────────────────────────────────────
+cleanup() {
+    local rc=$?
+    log "teardown (exit $rc)"
+    make down NAME="$STAND" >/dev/null 2>&1 || true
+    docker rm -f "$REGISTRY_CONTAINER" >/dev/null 2>&1 || true
+    return $rc
+}
+trap cleanup EXIT
+
+# ── 0. KVM sanity ───────────────────────────────────────────────────
+if [ ! -e /dev/kvm ]; then
+    echo "::error::/dev/kvm is missing — this runner has no (nested) virtualization; the qemu provisioner cannot run" >&2
+    exit 1
+fi
+log "KVM ok: $(ls -l /dev/kvm)"
+
+# ── 1. qemu userspace + provisioner networking ──────────────────────
+# Only the bits stand/setup-host.sh installs that the qemu provisioner
+# needs — no disk formatting, no go/helm (CI provides those separately).
+if ! command -v qemu-system-x86_64 >/dev/null 2>&1; then
+    log "installing qemu userspace"
+    sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        qemu-kvm qemu-system-x86 qemu-utils ovmf \
+        bridge-utils dnsmasq-base iproute2 socat conntrack ipset
+fi
+# Ubuntu cloud images ship a catch-all REJECT in FORWARD; the talos
+# qemu bridges (talos<hash>) need traffic forwarded. Mirrors setup-host.sh.
+sudo iptables -P FORWARD ACCEPT 2>/dev/null || true
+sudo iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited 2>/dev/null || true
+
+# ── 2. throwaway local registry for build-images.sh ─────────────────
+if ! docker ps --format '{{.Names}}' | grep -qx "$REGISTRY_CONTAINER"; then
+    log "starting localhost:5000 registry"
+    docker rm -f "$REGISTRY_CONTAINER" >/dev/null 2>&1 || true
+    docker run -d -p 5000:5000 --name "$REGISTRY_CONTAINER" registry:2 >/dev/null
+fi
+
+# ── 3. build + push blockstor images (pins digests in .work/_factory) ─
+log "building images"
+make build-images
+
+# ── 4. provision the Talos+QEMU cluster ─────────────────────────────
+log "provisioning cluster (workers=$CI_WORKERS, extra-disks=$EXTRA_DISKS x ${EXTRA_DISK_SIZE_MB}MB)"
+make up NAME="$STAND" WORKERS="$CI_WORKERS"
+
+# ── 5. deploy blockstor + storage pools ─────────────────────────────
+log "installing blockstor"
+make blockstor NAME="$STAND"
+log "provisioning pools"
+make pools NAME="$STAND" TYPE=both
+
+# ── 6. this lane's scenario shard (round-robin over LANES) ──────────
+shard=()
+for i in "${!ALL_SCENARIOS[@]}"; do
+    if [ $(( i % LANES )) -eq $(( LANE - 1 )) ]; then
+        shard+=("${ALL_SCENARIOS[$i]}")
+    fi
+done
+[ ${#shard[@]} -gt 0 ] || { log "no scenarios for this lane — nothing to do"; exit 0; }
+log "scenarios for this lane: ${shard[*]}"
+
+bash stand/run-scenarios-only.sh "$STAND" "${shard[@]}" || true
+
+# ── 7. verdict ──────────────────────────────────────────────────────
+RESULTS="/tmp/e2e-$STAND.results"
+echo "================ results ($STAND) ================"
+cat "$RESULTS" 2>/dev/null || { echo "FATAL: results file $RESULTS missing"; exit 1; }
+echo "=================================================="
+
+reds=$(grep -cE '^(FAIL|TIMEOUT) ' "$RESULTS" 2>/dev/null || echo 0)
+if grep -q '^FATAL' "$RESULTS" 2>/dev/null; then
+    echo "::error::stand $STAND never became ready — see results above"
+    exit 1
+fi
+if [ "$reds" -gt 0 ]; then
+    echo "::error::$reds scenario(s) failed on lane $LANE"
+    # Surface the tail of each failing scenario's log for quick triage.
+    grep -E '^(FAIL|TIMEOUT) ' "$RESULTS" | awk '{print $2}' | while read -r sc; do
+        sc_log="/tmp/e2e-$STAND-${sc//\//__}.log"
+        echo "----- last 25 lines of $sc_log -----"
+        tail -25 "$sc_log" 2>/dev/null || echo "(no log)"
+    done
+    exit 1
+fi
+log "all ${#shard[@]} scenario(s) passed"

--- a/tests/e2e/recovery-auto-place-real-drbd.sh
+++ b/tests/e2e/recovery-auto-place-real-drbd.sh
@@ -214,7 +214,7 @@ for n in "$WORKER_1" "$WORKER_2" "$WORKER_3"; do
     flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
         -o jsonpath='{.spec.flags}' 2>/dev/null || true)
     node_id=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
-        -o jsonpath='{.status.drbdNodeId}' 2>/dev/null || true)
+        -o jsonpath='{.status.drbdNodeID}' 2>/dev/null || true)
     role=$(on_node "$n" drbdsetup role "$RD" 2>/dev/null \
         | tr -d '[:space:]' || true)
     disk_local=$(on_node "$n" drbdsetup status "$RD" --verbose 2>/dev/null \

--- a/tests/e2e/recovery-node-id-mismatch.sh
+++ b/tests/e2e/recovery-node-id-mismatch.sh
@@ -159,7 +159,7 @@ echo ">> snapshot Status.DRBDNodeID for surviving replicas"
 declare -A node_id_before
 for w in "$WORKER_1" "$WORKER_2" "$WORKER_3"; do
     id=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${w}" \
-        -o jsonpath='{.status.drbdNodeId}' 2>/dev/null || true)
+        -o jsonpath='{.status.drbdNodeID}' 2>/dev/null || true)
     if [[ -z "$id" ]]; then
         echo "FAIL: Status.DRBDNodeID empty for $w"
         exit 1
@@ -418,7 +418,7 @@ echo ">> assert Phase 8.1 invariant: surviving replicas' drbdNodeId unchanged"
 phase81_ok=true
 for w in "$WORKER_1" "$WORKER_2"; do
     id_after=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${w}" \
-        -o jsonpath='{.status.drbdNodeId}' 2>/dev/null || true)
+        -o jsonpath='{.status.drbdNodeID}' 2>/dev/null || true)
     if [[ "$id_after" != "${node_id_before[$w]}" ]]; then
         echo "   FAIL invariant: $w drbdNodeId drifted: before=${node_id_before[$w]} after=${id_after}"
         phase81_ok=false
@@ -429,7 +429,7 @@ done
 # Worker-3 may have been re-placed elsewhere; whichever replica
 # replaced it just needs a stamped, allocator-consistent id.
 id_w3_after=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${WORKER_3}" \
-    -o jsonpath='{.status.drbdNodeId}' 2>/dev/null || true)
+    -o jsonpath='{.status.drbdNodeID}' 2>/dev/null || true)
 if [[ -z "$id_w3_after" ]]; then
     echo "FAIL: worker-3 replacement has no Status.DRBDNodeID stamped"
     phase81_ok=false


### PR DESCRIPTION
The PR `e2e` job already targeted the CNCF Oracle KVM runner pool (`oracle-vm-24cpu-96gb-x86-64`, which exposes `/dev/kvm` just like cozystack/cozystack's own e2e job) — but the step ran the Kind-based Go scaffold (`make test-e2e`, `test/e2e/*.go`), which never exercises a real DRBD kernel.

This wires the job to the **real QEMU/Talos e2e suite** — the same pipeline maintainers run on the dev stand: `stand/up.sh` → `make blockstor` → `make pools` → `tests/e2e/*.sh`.

## What changed

- **`stand/ci-e2e.sh`** (new) — provisions an ephemeral Talos+QEMU cluster on the runner, deploys blockstor + storage pools, runs this lane's scenario shard, and tears the cluster down on exit. It reuses the existing stand scripts and only differs from the dev stand where the runner environment requires it:
  - no `stand/setup-host.sh` (its `mkfs.xfs` on "the largest unused block device" is unsafe on a shared runner) — only the qemu userspace + the FORWARD iptables allow the provisioner needs;
  - VM storage disks sized down (`EXTRA_DISKS` / `EXTRA_DISK_SIZE_MB`);
  - a throwaway `localhost:5000` registry for `build-images.sh`, pulled by the cluster via the bridge gateway exactly as on the dev stand.
- **`make ci-e2e LANE=<n> LANES=<total> SCENARIOS="..."`** target.
- **`pull-request.yml`** `e2e` job → a **2-lane matrix** running a representative scenario set round-robined across lanes; verifies `/dev/kvm`, uploads per-lane logs as artifacts, and keeps the existing SSH breakpoint-on-failure step. The Kind-based `make test-e2e` step is dropped from the PR job.

## Scaling

Two lanes as a template. To widen coverage, add entries to `matrix.lane` and bump `env.LANES` — `ci-e2e.sh` shards the `SCENARIOS` list across `LANES` automatically, so each runner picks up its 1/N share with no other change.

## Notes

- The push-on-`main` `test-e2e.yml` (Kind) is left unchanged; converting or retiring it can be a follow-up.
- The first CI run on the org runner pool validates disk headroom and registry reachability; VM sizing is env-overridable if tuning is needed.
