### PR TITLE
fix(rest): emit per-device size in physical-storage list

### DIFF
--- a/pkg/rest/physical_storage.go
+++ b/pkg/rest/physical_storage.go
@@ -750,6 +750,12 @@ type physicalStorageEntry struct {
 // PhysicalStorageDevice (slimmer than our internal apiv1.PhysicalDevice).
 type physicalStorageDeviceWireRepetition struct {
 	Device string `json:"device,omitempty"`
+	// Size is emitted WITHOUT omitempty: the python-linstor CLI reads
+	// it as a required key (responses.py PhysicalStorageDevice.size ->
+	// self._rest_data["size"]), so a missing key raises KeyError and
+	// crashes `linstor physical-storage list` whenever the list is
+	// non-empty. Upstream LINSTOR always carries size per device.
+	Size   int64  `json:"size"`
 	Model  string `json:"model,omitempty"`
 	Serial string `json:"serial,omitempty"`
 	WWN    string `json:"wwn,omitempty"`
@@ -795,6 +801,7 @@ func (s *Server) handlePhysicalStorageListForNode(w http.ResponseWriter, r *http
 
 		out = append(out, physicalStorageDeviceWireRepetition{
 			Device: devs[i].DevicePath,
+			Size:   devs[i].SizeBytes,
 			Model:  devs[i].Model,
 			Serial: devs[i].Serial,
 			WWN:    devs[i].StableID,
@@ -869,6 +876,7 @@ func groupPhysicalDevices(devs []apiv1.PhysicalDevice) []physicalStorageEntry {
 		entry.Nodes[devs[i].NodeName] = append(entry.Nodes[devs[i].NodeName],
 			physicalStorageDeviceWireRepetition{
 				Device: devs[i].DevicePath,
+				Size:   devs[i].SizeBytes,
 				Model:  devs[i].Model,
 				Serial: devs[i].Serial,
 				WWN:    devs[i].StableID,

--- a/pkg/rest/physical_storage_test.go
+++ b/pkg/rest/physical_storage_test.go
@@ -790,10 +790,10 @@ func TestPhysicalStorageListWireShapeMatchesUpstreamLINSTOR(t *testing.T) {
 		t.Fatalf("nodes.n1[0]: got %T, want map[string]any", devsRaw[0])
 	}
 
-	// Upstream PhysicalStorageDevice shape — four NON_EMPTY keys.
-	// `device` / `model` / `serial` / `wwn` are exact upstream
-	// names; the python CLI's storpool_cmds.py parses them by
-	// literal key lookup.
+	// Upstream PhysicalStorageDevice shape. `device` / `model` /
+	// `serial` / `wwn` are the string-valued upstream names; the
+	// python CLI's physical_storage_cmds.py parses them by literal
+	// key lookup.
 	wantDev := map[string]string{
 		"device": "/dev/disk/by-id/wwn-0x5000c500a1b2c3d4",
 		"model":  "Samsung SSD 980 PRO",
@@ -807,11 +807,28 @@ func TestPhysicalStorageListWireShapeMatchesUpstreamLINSTOR(t *testing.T) {
 		}
 	}
 
+	// `size` is REQUIRED on every device entry — and this is the pin
+	// the earlier version of this test got wrong. The python-linstor
+	// CLI's responses.py PhysicalStorageDevice.size returns
+	// self._rest_data["size"] with a bare dict lookup, so a device
+	// entry without `size` raises `KeyError: 'size'` and crashes
+	// `linstor physical-storage list` the instant the list is
+	// non-empty. The previous assertion declared the device carried
+	// ONLY device/model/serial/wwn and would have REJECTED a correct,
+	// size-bearing entry — it pinned the broken shape. The empty-list
+	// smoke in client-compat.sh (A.7) never dereferenced size, so
+	// neither layer caught the crash. The key is emitted without
+	// omitempty so a zero-size device still ships it rather than
+	// tripping the same KeyError.
+	if size, ok := dev["size"].(float64); !ok || int64(size) != 1_000_204_886_016 {
+		t.Errorf("device.size: got %v (%T), want 1000204886016 (float64) — missing/zero size crashes `linstor ps l` with KeyError: 'size'", dev["size"], dev["size"])
+	}
+
 	for k := range dev {
 		switch k {
-		case "device", "model", "serial", "wwn":
+		case "device", "size", "model", "serial", "wwn":
 		default:
-			t.Errorf("unexpected device key %q (drift from upstream PhysicalStorageDevice shape: only device/model/serial/wwn allowed)", k)
+			t.Errorf("unexpected device key %q (drift from upstream PhysicalStorageDevice shape: only device/size/model/serial/wwn allowed)", k)
 		}
 	}
 }


### PR DESCRIPTION
## What

`linstor physical-storage list` crashed with `KeyError: 'size'` whenever the device list was non-empty. The per-device entry in the `GET /v1/physical-storage` (and per-node) response omitted the `size` field, but the python-linstor CLI reads it as a required key on each device.

## Why

The wire repetition struct mirrored the generated OpenAPI `PhysicalStorageDevice` model, which omits `size` (only the per-node `PhysicalStorageNode` model carries it). The python CLI's `PhysicalStorageDevice.size` does a bare `self._rest_data["size"]` lookup per device, so a missing key raises `KeyError` the instant a device is present. On a stand where pool provisioning has already consumed every disk the list is empty, which hid the crash; it only surfaces when a spare device is available.

## Change

- Emit `size` on every device entry in both the grouped (`/v1/physical-storage`) and per-node (`/v1/nodes/{node}/physical-storage`) serialisation paths, without `omitempty` so a zero-size device still ships the key rather than tripping the same `KeyError`.
- Correct the wire-shape unit test, which had pinned the broken shape: it asserted device entries carry only `device/model/serial/wwn` and would have rejected a correct, size-bearing entry. It now requires `size`, so the regression is caught at the unit layer. The existing real-CLI smoke only exercised the empty-list path, where `size` is never dereferenced.

## Testing

- `go test ./pkg/rest/` — green; the corrected wire-shape test fails against the pre-fix code (`device.size: got 0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Physical storage REST API endpoints now consistently include device size information in all responses, preventing instances where clients could encounter missing fields and ensuring reliable access to complete device metadata across different device listing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->