### PR TITLE
fix(storage): idempotent ps cdp attach + lvextend single --config resize

### DIFF
--- a/pkg/satellite/attach.go
+++ b/pkg/satellite/attach.go
@@ -105,18 +105,30 @@ func attachOrExtend(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalD
 	switch dev.AttachTo.ProviderKind {
 	case ProviderKindLVM:
 		if vgExists(ctx, exec, dev.AttachTo.VGName) {
+			if pvInVG(ctx, exec, dev.AttachTo.VGName, devicePath) {
+				return lvmThickResult(dev), nil
+			}
+
 			return extendLVMThick(ctx, exec, dev, devicePath)
 		}
 
 		return attachLVMThick(ctx, exec, dev, devicePath)
 	case ProviderKindLVMThin:
 		if vgExists(ctx, exec, dev.AttachTo.VGName) {
+			if pvInVG(ctx, exec, dev.AttachTo.VGName, devicePath) {
+				return lvmThinResult(dev), nil
+			}
+
 			return extendLVMThin(ctx, exec, dev, devicePath)
 		}
 
 		return attachLVMThin(ctx, exec, dev, devicePath)
 	case ProviderKindZFS, ProviderKindZFSThin:
 		if zpoolExists(ctx, exec, dev.AttachTo.ZPoolName) {
+			if vdevInZpool(ctx, exec, dev.AttachTo.ZPoolName, devicePath) {
+				return zfsResult(dev), nil
+			}
+
 			return extendZFS(ctx, exec, dev, devicePath)
 		}
 
@@ -150,6 +162,113 @@ func zpoolExists(ctx context.Context, exec storage.Exec, pool string) bool {
 	}
 
 	return strings.Contains(string(out), pool)
+}
+
+// vdevInZpool reports whether `devicePath` is already a top-level
+// vdev of the named zpool. This is the idempotency probe that
+// guards the extend branch: `ps cdp <node> zfs /dev/sda` for a
+// *single* device creates a pool whose sole vdev IS /dev/sda, so a
+// re-reconcile that found the pool already present must NOT run
+// `zpool add -f <pool> /dev/sda` — ZFS rejects re-adding a device
+// that is already part of the active pool ("/dev/sda is in use and
+// contains a unknown filesystem"), which would otherwise wedge the
+// reconciler in a tight failing loop and leave the PhysicalDevice
+// CRD stuck (Phase=Failed, finalizer never cleared).
+//
+// `zpool status -P <pool>` prints the full device paths (`-P`) of
+// every vdev. We compare both the full path and its leaf (`sda`)
+// against each output token, because the device a pool was created
+// with (a by-id symlink such as /dev/disk/by-id/...) can be
+// reported by `zpool status` under a different but
+// same-leaf-resolving name. A failed probe (pool vanished between
+// the exists check and here) is treated as "not a member" so the
+// caller falls through to the existing extend path rather than
+// silently skipping a genuine add. Empty inputs → false.
+func vdevInZpool(ctx context.Context, exec storage.Exec, pool, devicePath string) bool {
+	if pool == "" || devicePath == "" {
+		return false
+	}
+
+	out, err := exec.Run(ctx, "zpool", "status", "-P", pool)
+	if err != nil {
+		return false
+	}
+
+	leaf := deviceLeaf(devicePath)
+
+	for field := range strings.FieldsSeq(string(out)) {
+		if field == devicePath {
+			return true
+		}
+
+		if leaf != "" && deviceLeaf(field) == leaf {
+			return true
+		}
+	}
+
+	return false
+}
+
+// pvInVG reports whether `devicePath` is already a physical volume
+// belonging to the named volume group. Mirrors vdevInZpool for the
+// LVM branch: a single-device `ps cdp ... lvm <node> /dev/sda`
+// makes /dev/sda the VG's sole PV, and a re-reconcile must not
+// re-run pvcreate+vgextend on it. `vgextend` on an already-member
+// PV does emit "Physical volume already belongs to this VG" and
+// exits 0, so LVM is less brittle than ZFS here — but probing keeps
+// the two branches symmetric and avoids the noisy pvcreate retry.
+//
+// `pvs -o pv_name,vg_name --noheadings` lists every PV with its VG;
+// we match a row whose PV name resolves to the same leaf as
+// `devicePath` AND whose VG column equals `vg`. A failed probe →
+// false (fall through to extend). Empty inputs → false.
+func pvInVG(ctx context.Context, exec storage.Exec, vg, devicePath string) bool {
+	if vg == "" || devicePath == "" {
+		return false
+	}
+
+	out, err := exec.Run(ctx, "pvs",
+		lvm.Args("--noheadings", "-o", "pv_name,vg_name")...)
+	if err != nil {
+		return false
+	}
+
+	leaf := deviceLeaf(devicePath)
+
+	for line := range strings.SplitSeq(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		pvName, vgName := fields[0], fields[1]
+		if vgName != vg {
+			continue
+		}
+
+		if pvName == devicePath || (leaf != "" && deviceLeaf(pvName) == leaf) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// deviceLeaf returns the final path component of a device path
+// (`/dev/sda` → `sda`, `/dev/disk/by-id/wwn-X` → `wwn-X`). Used by
+// the membership probes to match a device across the differing
+// names `zpool status` / `pvs` may report it under. Empty input →
+// empty.
+func deviceLeaf(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+
+	return path
 }
 
 // vgExists probes whether the named LVM volume group is already
@@ -318,6 +437,46 @@ func readDeviceSizeMiB(ctx context.Context, exec storage.Exec, devicePath string
 	return sizeBytes / mibBytes, true
 }
 
+// lvmThickResult builds the AttachResult for an LVM (thick) pool.
+// Shared by the create, extend, and already-member-idempotent
+// paths so all three hand the reconciler an identical
+// RegisterProvider contract.
+func lvmThickResult(dev *apiv1.PhysicalDevice) AttachResult {
+	return AttachResult{
+		PoolName:     dev.AttachTo.StoragePoolName,
+		ProviderKind: ProviderKindLVM,
+		Props: map[string]string{
+			propLvmVG: dev.AttachTo.VGName,
+		},
+	}
+}
+
+// lvmThinResult builds the AttachResult for an LVM_THIN pool.
+// Shared across create / extend / already-member paths.
+func lvmThinResult(dev *apiv1.PhysicalDevice) AttachResult {
+	return AttachResult{
+		PoolName:     dev.AttachTo.StoragePoolName,
+		ProviderKind: ProviderKindLVMThin,
+		Props: map[string]string{
+			propLvmVG:    dev.AttachTo.VGName,
+			propThinPool: dev.AttachTo.ThinPoolName,
+		},
+	}
+}
+
+// zfsResult builds the AttachResult for a ZFS / ZFS_THIN pool.
+// ProviderKind echoes the request's kind (ZFS vs ZFS_THIN). Shared
+// across create / extend / already-member paths.
+func zfsResult(dev *apiv1.PhysicalDevice) AttachResult {
+	return AttachResult{
+		PoolName:     dev.AttachTo.StoragePoolName,
+		ProviderKind: dev.AttachTo.ProviderKind,
+		Props: map[string]string{
+			propZPool: dev.AttachTo.ZPoolName,
+		},
+	}
+}
+
 // attachLVMThick: pvcreate + vgcreate. Returns the
 // `LVM` provider kind config the satellite then registers via
 // `RegisterProvider` to make the pool available for
@@ -338,13 +497,7 @@ func attachLVMThick(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalD
 		return AttachResult{}, errors.Wrap(err, "vgcreate")
 	}
 
-	return AttachResult{
-		PoolName:     dev.AttachTo.StoragePoolName,
-		ProviderKind: ProviderKindLVM,
-		Props: map[string]string{
-			propLvmVG: vg,
-		},
-	}, nil
+	return lvmThickResult(dev), nil
 }
 
 // attachLVMThin: pvcreate + vgcreate + lvcreate --thinpool.
@@ -379,14 +532,7 @@ func attachLVMThin(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDe
 		return AttachResult{}, errors.Wrap(err, "lvcreate --thinpool")
 	}
 
-	return AttachResult{
-		PoolName:     dev.AttachTo.StoragePoolName,
-		ProviderKind: ProviderKindLVMThin,
-		Props: map[string]string{
-			propLvmVG:    vg,
-			propThinPool: thin,
-		},
-	}, nil
+	return lvmThinResult(dev), nil
 }
 
 // attachZFS: zpool create. The pool name on disk matches the
@@ -415,13 +561,7 @@ func attachZFS(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDevice
 		return AttachResult{}, errors.Wrap(err, "zpool create")
 	}
 
-	return AttachResult{
-		PoolName:     dev.AttachTo.StoragePoolName,
-		ProviderKind: dev.AttachTo.ProviderKind,
-		Props: map[string]string{
-			propZPool: pool,
-		},
-	}, nil
+	return zfsResult(dev), nil
 }
 
 // extendVG runs `pvcreate` + `vgextend` to fold `devicePath` into
@@ -462,13 +602,7 @@ func extendLVMThick(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalD
 		return AttachResult{}, err
 	}
 
-	return AttachResult{
-		PoolName:     dev.AttachTo.StoragePoolName,
-		ProviderKind: ProviderKindLVM,
-		Props: map[string]string{
-			propLvmVG: vg,
-		},
-	}, nil
+	return lvmThickResult(dev), nil
 }
 
 // extendLVMThin extends an existing thin-pool's backing VG by
@@ -492,24 +626,18 @@ func extendLVMThin(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDe
 		return AttachResult{}, err
 	}
 
-	return AttachResult{
-		PoolName:     dev.AttachTo.StoragePoolName,
-		ProviderKind: ProviderKindLVMThin,
-		Props: map[string]string{
-			propLvmVG:    vg,
-			propThinPool: thin,
-		},
-	}, nil
+	return lvmThinResult(dev), nil
 }
 
 // extendZFS extends an existing zpool by adding `devicePath` as
-// a new top-level vdev. `zpool add -f <pool> <device>` is
-// idempotent on a device already part of the pool: ZFS returns
-// `/dev/sdX is part of active pool '<pool>'` and exits non-zero
-// — caller probes vdev membership before calling on a known-
-// member device, OR the next reconcile observes the already-
-// extended pool and the create branch never re-runs anyway.
-// Bug 337.
+// a new top-level vdev. `zpool add -f <pool> <device>` is NOT
+// idempotent on a device already part of the pool — ZFS exits
+// non-zero with "<dev> is in use and contains a unknown
+// filesystem" (it sees the pool's own on-disk label). The caller
+// (`attachOrExtend`) therefore probes vdev membership via
+// `vdevInZpool` BEFORE reaching this function, so we only ever get
+// here for a genuinely new device. Bug 337 / single-device
+// re-reconcile loop fix.
 //
 // `-f` is required for the same reason `zpool create -f` carries
 // it: a device with stale ZFS labels from a prior attempt would
@@ -525,13 +653,7 @@ func extendZFS(ctx context.Context, exec storage.Exec, dev *apiv1.PhysicalDevice
 		return AttachResult{}, errors.Wrap(err, "zpool add")
 	}
 
-	return AttachResult{
-		PoolName:     dev.AttachTo.StoragePoolName,
-		ProviderKind: dev.AttachTo.ProviderKind,
-		Props: map[string]string{
-			propZPool: pool,
-		},
-	}, nil
+	return zfsResult(dev), nil
 }
 
 // attachFile: directory-backed pool — no on-disk format runs

--- a/pkg/satellite/attach_test.go
+++ b/pkg/satellite/attach_test.go
@@ -586,6 +586,140 @@ func TestWipeDeviceContinuesOnWipefsFailure(t *testing.T) {
 	}
 }
 
+// TestAttachZpoolMemberDeviceIsIdempotent pins the single-device
+// re-reconcile fix: `ps cdp <node> zfs /dev/sda` creates a pool
+// whose SOLE vdev is /dev/sda. On a re-reconcile, the pool already
+// exists (zpool list exits 0) AND /dev/sda is already its member —
+// so the satellite MUST treat the attach as idempotently complete
+// and return success WITHOUT running `zpool add -f data /dev/sda`.
+// Before the fix the extend branch ran `zpool add`, which ZFS
+// rejects ("/dev/sda is in use and contains a unknown filesystem"),
+// wedging the reconciler in a tight failing loop with the
+// PhysicalDevice CRD stuck Phase=Failed and the attach finalizer
+// never cleared.
+func TestAttachZpoolMemberDeviceIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	fx := storage.NewFakeExec()
+	// Pool exists.
+	fx.Expect("zpool list -H -o name data", storage.FakeResponse{Stdout: []byte("data\n")})
+	// /dev/sda is already the pool's sole vdev (real `zpool status -P`
+	// shape: header rows then the pool row, then the vdev row with the
+	// full device path under `-P`).
+	fx.Expect("zpool status -P data", storage.FakeResponse{Stdout: []byte(
+		"  pool: data\n" +
+			" state: ONLINE\n" +
+			"config:\n\n" +
+			"\tNAME        STATE     READ WRITE CKSUM\n" +
+			"\tdata        ONLINE       0     0     0\n" +
+			"\t  /dev/sda  ONLINE       0     0     0\n\n" +
+			"errors: No known data errors\n")})
+
+	dev := &apiv1.PhysicalDevice{
+		DevicePath: "/dev/sda",
+		AttachTo: &apiv1.PhysicalDeviceAttachTo{
+			StoragePoolName: "data",
+			ProviderKind:    "ZFS",
+			ZPoolName:       "data",
+		},
+	}
+
+	res, err := satellite.Attach(t.Context(), fx, dev)
+	if err != nil {
+		t.Fatalf("Attach on already-member device must succeed idempotently: %v", err)
+	}
+
+	// Result must be the normal terminal-success shape so the
+	// reconciler reaches its delete-as-completion / finalizer-strip
+	// path.
+	if res.PoolName != "data" || res.ProviderKind != "ZFS" || res.Props["StorDriver/ZPool"] != "data" {
+		t.Errorf("idempotent attach result: got %+v, want data/ZFS with ZPool data", res)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "zpool add") {
+			t.Fatalf("`zpool add` MUST NOT run when device is already a pool member; calls=%v", fx.CommandLines())
+		}
+	}
+}
+
+// TestAttachZpoolNonMemberDeviceStillExtends guards the other side
+// of the fix: a genuinely NEW device (pool exists, but this device
+// is NOT yet one of its vdevs) MUST still run `zpool add -f` so
+// real multi-device `ps cdp` expansion keeps working. Without this
+// guard a too-aggressive membership probe would silently swallow
+// legitimate extends.
+func TestAttachZpoolNonMemberDeviceStillExtends(t *testing.T) {
+	t.Parallel()
+
+	fx := storage.NewFakeExec()
+	fx.Expect("zpool list -H -o name data", storage.FakeResponse{Stdout: []byte("data\n")})
+	// Pool's existing vdev is /dev/sda; the request is for /dev/sdb,
+	// which is NOT a member yet.
+	fx.Expect("zpool status -P data", storage.FakeResponse{Stdout: []byte(
+		"\tNAME        STATE\n\tdata        ONLINE\n\t  /dev/sda  ONLINE\n")})
+
+	dev := &apiv1.PhysicalDevice{
+		DevicePath: "/dev/sdb",
+		AttachTo: &apiv1.PhysicalDeviceAttachTo{
+			StoragePoolName: "data",
+			ProviderKind:    "ZFS",
+			ZPoolName:       "data",
+		},
+	}
+
+	_, err := satellite.Attach(t.Context(), fx, dev)
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	if !slices.Contains(fx.CommandLines(), "zpool add -f data /dev/sdb") {
+		t.Errorf("new device must still extend via `zpool add -f data /dev/sdb`; calls=%v", fx.CommandLines())
+	}
+}
+
+// TestAttachPVMemberDeviceIsIdempotent pins the LVM analog of the
+// single-device re-reconcile fix: when the VG exists AND the device
+// is already one of its PVs, the satellite returns success WITHOUT
+// re-running pvcreate/vgextend.
+func TestAttachPVMemberDeviceIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	fx := storage.NewFakeExec()
+	probe := "vgs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o vg_name vg"
+	fx.Expect(probe, storage.FakeResponse{Stdout: []byte("  vg\n")})
+	pvsProbe := "pvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o pv_name,vg_name"
+	fx.Expect(pvsProbe, storage.FakeResponse{Stdout: []byte("  /dev/sda vg\n")})
+
+	dev := &apiv1.PhysicalDevice{
+		DevicePath: "/dev/sda",
+		AttachTo: &apiv1.PhysicalDeviceAttachTo{
+			StoragePoolName: "thick",
+			ProviderKind:    "LVM",
+			VGName:          "vg",
+		},
+	}
+
+	res, err := satellite.Attach(t.Context(), fx, dev)
+	if err != nil {
+		t.Fatalf("Attach on already-member PV must succeed idempotently: %v", err)
+	}
+
+	if res.PoolName != "thick" || res.ProviderKind != "LVM" || res.Props["StorDriver/LvmVg"] != "vg" {
+		t.Errorf("idempotent attach result: got %+v, want thick/LVM with VG vg", res)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "vgextend ") {
+			t.Fatalf("`vgextend` MUST NOT run when PV is already a VG member; calls=%v", fx.CommandLines())
+		}
+
+		if strings.HasPrefix(line, "pvcreate ") {
+			t.Fatalf("`pvcreate` MUST NOT run when PV is already a VG member; calls=%v", fx.CommandLines())
+		}
+	}
+}
+
 // TestAttachCreatesWhenPoolAbsent pins the negative of the
 // extend branch: when the probe (`zpool list <pool>`) exits
 // non-zero (pool absent), the satellite falls through to

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -398,8 +398,11 @@ func TestApplyTriggersResizeOnGrow(t *testing.T) {
 		t.Fatalf("Apply: %v", err)
 	}
 
+	// Bug 305: the udev-less activation section shares the single
+	// `--config` that carries the device filter — a repeated `--config`
+	// is rejected by the LVM CLI, which had blocked the resize.
 	want := []string{
-		"lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --size 2048MiB --config activation{udev_sync=0 udev_rules=0} vg/pvc-grow_00000",
+		"lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } activation { udev_sync=0 udev_rules=0 } --size 2048MiB vg/pvc-grow_00000",
 		"drbdadm resize --assume-clean pvc-grow",
 	}
 

--- a/pkg/storage/lvm/lvm_common.go
+++ b/pkg/storage/lvm/lvm_common.go
@@ -81,6 +81,23 @@ const (
 // `Args(...)` helper enforces this.
 const ConfigFilter = `devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] }`
 
+// activationUdevless is the udev-less activation section appended to
+// the SAME `--config` string the device filter lives in, for write
+// commands that materialise a `/dev/<vg>/<lv>` node (lvcreate,
+// lvextend). The satellite container has no udev daemon; without
+// `udev_sync=0 udev_rules=0` an lvcreate/lvextend blocks waiting for a
+// udev cookie that never arrives, then races the node symlink the next
+// reconcile dereferences (Bug 269, P1, @drbd_ru #17589/#13568).
+//
+// Bug 305 (P1, this fix): the LVM CLI rejects a repeated `--config`
+// ("Option --config may not be repeated."). Passing the device filter
+// via Args(...) AND a second `--config activation{…}` at the call site
+// produced TWO `--config` flags, so lvextend never ran — every resize
+// hot-looped and the LV / DRBD device stayed at the old size while the
+// API/CRD already reported the new one. A single `--config` accepts
+// multiple top-level sections, so we merge both into one string.
+const activationUdevless = `activation { udev_sync=0 udev_rules=0 }`
+
 // Args prepends the inline config filter onto the caller's
 // argument list. Use this as the variadic args sent to
 // `Exec.Run("lvs", lvm.Args(extra...)...)`. Centralising the
@@ -89,6 +106,20 @@ const ConfigFilter = `devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] }`
 func Args(extra ...string) []string {
 	out := make([]string, 0, 2+len(extra))
 	out = append(out, "--config", ConfigFilter)
+	out = append(out, extra...)
+
+	return out
+}
+
+// ArgsUdevless is Args for write commands (lvcreate, lvextend) that
+// must run with the udev-less activation workaround. It emits exactly
+// ONE `--config` whose value carries BOTH the device filter and the
+// `activation { udev_sync=0 udev_rules=0 }` section. The LVM CLI
+// forbids a repeated `--config`, so callers MUST NOT add their own
+// second `--config activation{…}` on top of this (Bug 305).
+func ArgsUdevless(extra ...string) []string {
+	out := make([]string, 0, 2+len(extra))
+	out = append(out, "--config", ConfigFilter+" "+activationUdevless)
 	out = append(out, extra...)
 
 	return out

--- a/pkg/storage/lvm/lvm_thick.go
+++ b/pkg/storage/lvm/lvm_thick.go
@@ -58,13 +58,16 @@ func (t *Thick) CreateVolume(ctx context.Context, vol storage.Volume) error {
 
 	sizeMiB := max(vol.SizeKib/mibPerKib, 1)
 
+	// Skip the optional zero-on-create step (-Wn -Zn) — the satellite
+	// container has no udev daemon, and the wipe trips on the missing
+	// /dev/<vg>/<lv> symlink. Same trick as install-pools.sh. Bug 305:
+	// the udev-less activation section rides in the SAME single
+	// `--config` as the device filter (ArgsUdevless) — a separate
+	// `--config activation{…}` would be a repeated `--config`, which
+	// the LVM CLI rejects.
 	_, err := t.exec.Run(ctx, "lvcreate",
-		Args("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
+		ArgsUdevless("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
 			"--name", volumeLVName(vol),
-			// Skip the optional zero-on-create step — the satellite
-			// container has no udev daemon, and the wipe trips on the
-			// missing /dev/<vg>/<lv> symlink. Same trick as install-pools.sh.
-			"--config", "activation{udev_sync=0 udev_rules=0}",
 			"-Wn", "-Zn",
 			t.cfg.VolumeGroup)...)
 	if err != nil {
@@ -79,12 +82,17 @@ func (t *Thick) CreateVolume(ctx context.Context, vol storage.Volume) error {
 // has no udev daemon so `activation{udev_sync=0 udev_rules=0}` keeps
 // `lvextend` from blocking on a sync that never completes (see
 // Thin.ResizeVolume doc for the @drbd_ru repro chain).
+//
+// Bug 305 (P1): the udev-less activation section MUST share the same
+// single `--config` as the device filter — ArgsUdevless merges both.
+// A separate `--config activation{…}` produced a repeated `--config`,
+// which the LVM CLI rejects ("Option --config may not be repeated."),
+// so lvextend never ran and the resize hot-looped forever.
 func (t *Thick) ResizeVolume(ctx context.Context, vol storage.Volume) error {
 	sizeMiB := max(vol.SizeKib/mibPerKib, 1)
 
 	_, err := t.exec.Run(ctx, "lvextend",
-		Args("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
-			"--config", "activation{udev_sync=0 udev_rules=0}",
+		ArgsUdevless("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
 			t.cfg.VolumeGroup+"/"+volumeLVName(vol))...)
 	if err != nil {
 		return errors.Wrapf(err, "lvextend %s", volumeLVName(vol))
@@ -287,12 +295,12 @@ func (t *Thick) RestoreVolumeFromSnapshot(ctx context.Context, target storage.Vo
 	// in the same LVM transaction that allocates the LV, so a crash
 	// BEFORE dd cannot leave an un-tagged LV that would be mis-trusted
 	// on the next reconcile.
+	// Same udev-less satellite workaround as CreateVolume; Bug 305:
+	// ArgsUdevless folds it into the single device-filter `--config`.
 	_, err = t.exec.Run(ctx, "lvcreate",
-		Args("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
+		ArgsUdevless("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
 			"--name", tgtName,
 			"--addtag", RestoreIncompleteTag,
-			// Same udev-less satellite workaround as CreateVolume.
-			"--config", "activation{udev_sync=0 udev_rules=0}",
 			"-Wn", "-Zn",
 			t.cfg.VolumeGroup)...)
 	if err != nil {

--- a/pkg/storage/lvm/lvm_thick_test.go
+++ b/pkg/storage/lvm/lvm_thick_test.go
@@ -55,7 +55,9 @@ func TestThickCreateVolumeIssuesLvcreate(t *testing.T) {
 		t.Fatalf("CreateVolume: %v", err)
 	}
 
-	want := "lvcreate --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --size 1024MiB --name pvc-1_00000 --config activation{udev_sync=0 udev_rules=0} -Wn -Zn vg"
+	// Bug 305: device filter + udev-less activation ride in ONE
+	// `--config` string (LVM rejects a repeated `--config`).
+	want := "lvcreate --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } activation { udev_sync=0 udev_rules=0 } --size 1024MiB --name pvc-1_00000 -Wn -Zn vg"
 	if !slices.Contains(fx.CommandLines(), want) {
 		t.Errorf("expected %q in calls; got %v", want, fx.CommandLines())
 	}
@@ -99,7 +101,9 @@ func TestThickResizeVolumeIssuesLvextend(t *testing.T) {
 		t.Fatalf("ResizeVolume: %v", err)
 	}
 
-	want := "lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --size 2048MiB --config activation{udev_sync=0 udev_rules=0} vg/pvc-1_00000"
+	// Bug 305: single `--config` carrying both the device filter and
+	// the udev-less activation section.
+	want := "lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } activation { udev_sync=0 udev_rules=0 } --size 2048MiB vg/pvc-1_00000"
 	if !slices.Contains(fx.CommandLines(), want) {
 		t.Errorf("expected %q; got %v", want, fx.CommandLines())
 	}

--- a/pkg/storage/lvm/lvm_thin.go
+++ b/pkg/storage/lvm/lvm_thin.go
@@ -102,12 +102,17 @@ func (t *Thin) CreateVolume(ctx context.Context, vol storage.Volume) error {
 // post-resize `/dev/<vg>/<lv>` symlink races the next reconcile's
 // `blockdev --getsize64`, leaving the volume stuck in `Resizing`
 // state until the operator runs `vgmknodes` + restarts satellite.
+//
+// Bug 305 (P1): the udev-less activation section MUST share the same
+// single `--config` as the device filter — ArgsUdevless merges both.
+// A separate `--config activation{…}` produced a repeated `--config`,
+// which the LVM CLI rejects ("Option --config may not be repeated."),
+// so lvextend never ran and the resize hot-looped forever.
 func (t *Thin) ResizeVolume(ctx context.Context, vol storage.Volume) error {
 	sizeMiB := max(vol.SizeKib/mibPerKib, 1)
 
 	_, err := t.exec.Run(ctx, "lvextend",
-		Args("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
-			"--config", "activation{udev_sync=0 udev_rules=0}",
+		ArgsUdevless("--size", strconv.FormatInt(sizeMiB, 10)+"MiB",
 			t.cfg.VolumeGroup+"/"+volumeLVName(vol))...)
 	if err != nil {
 		return errors.Wrapf(err, "lvextend %s", volumeLVName(vol))

--- a/pkg/storage/lvm/lvm_thin_test.go
+++ b/pkg/storage/lvm/lvm_thin_test.go
@@ -274,7 +274,10 @@ func TestThinResizeVolumeIssuesLvextend(t *testing.T) {
 		t.Fatalf("ResizeVolume: %v", err)
 	}
 
-	want := "lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --size 2048MiB --config activation{udev_sync=0 udev_rules=0} vg/pvc-1_00000"
+	// Bug 305: the udev-less activation section shares the SINGLE
+	// `--config` that also carries the device filter — a repeated
+	// `--config` is rejected by the LVM CLI.
+	want := "lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } activation { udev_sync=0 udev_rules=0 } --size 2048MiB vg/pvc-1_00000"
 	if !slices.Contains(fx.CommandLines(), want) {
 		t.Errorf("expected %q; got %v", want, fx.CommandLines())
 	}

--- a/pkg/storage/lvm/resize_single_config_test.go
+++ b/pkg/storage/lvm/resize_single_config_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lvm_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/storage"
+	"github.com/cozystack/blockstor/pkg/storage/lvm"
+)
+
+// resizer is the slice of storage.Provider both LVM backends implement
+// that this regression test exercises.
+type resizer interface {
+	ResizeVolume(ctx context.Context, vol storage.Volume) error
+}
+
+// TestResizeVolumeSingleConfig is the regression guard for the
+// duplicate-`--config` resize bug: `lvextend` was invoked with TWO
+// `--config` flags — one device
+// filter injected by Args(...) and a second `--config
+// activation{udev_sync=0 udev_rules=0}` added at the call site. The LVM
+// CLI rejects a repeated `--config` ("Option --config may not be
+// repeated."), so lvextend errored at command-line parse, never ran,
+// and the resize hot-looped while the LV (and the DRBD device on top)
+// stayed at the old size.
+//
+// The fix must produce EXACTLY ONE `--config` whose single value
+// carries BOTH the device filter (the /dev/drbd and /dev/zd reject
+// rules) AND the udev-less `activation{udev_sync=0 udev_rules=0}`
+// section (Bug 269 — dropping either is a regression).
+//
+// This test FAILS against the pre-fix double-`--config` code and PASSES
+// after it; it covers Thin AND Thick.
+func TestResizeVolumeSingleConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider func(ex storage.Exec) resizer
+	}{
+		{
+			name: "thin",
+			provider: func(ex storage.Exec) resizer {
+				return lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "thinpool"}, ex)
+			},
+		},
+		{
+			name: "thick",
+			provider: func(ex storage.Exec) resizer {
+				return lvm.NewThick(lvm.ThickConfig{VolumeGroup: "vg"}, ex)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := storage.NewFakeExec()
+			p := tc.provider(fx)
+
+			err := p.ResizeVolume(t.Context(), storage.Volume{
+				ResourceName: "pvc-1",
+				VolumeNumber: 0,
+				SizeKib:      2048 * 1024, // 2 GiB
+			})
+			if err != nil {
+				t.Fatalf("ResizeVolume: %v", err)
+			}
+
+			call := findCall(t, fx, "lvextend")
+
+			// Exactly one --config flag — a repeated --config is what the
+			// LVM CLI rejected.
+			cfgIdx, count := configFlag(call.Args)
+			if count != 1 {
+				t.Fatalf("lvextend argv must carry exactly one --config; got %d in %v",
+					count, call.Args)
+			}
+
+			// The single --config value must carry BOTH sections.
+			cfg := call.Args[cfgIdx+1]
+
+			if !strings.Contains(cfg, "/dev/drbd") || !strings.Contains(cfg, "/dev/zd") {
+				t.Errorf("--config value must keep the device filter (/dev/drbd, /dev/zd); got %q", cfg)
+			}
+
+			if !strings.Contains(cfg, "udev_sync=0") || !strings.Contains(cfg, "udev_rules=0") {
+				t.Errorf("--config value must keep the udev-less activation settings "+
+					"(udev_sync=0 udev_rules=0); got %q", cfg)
+			}
+		})
+	}
+}
+
+// findCall returns the first recorded FakeExec call for the named
+// command, failing the test if none was issued.
+func findCall(t *testing.T, fx *storage.FakeExec, name string) storage.FakeCall {
+	t.Helper()
+
+	for _, c := range fx.Calls {
+		if c.Name == name {
+			return c
+		}
+	}
+
+	t.Fatalf("expected a %q call; recorded %v", name, fx.CommandLines())
+
+	return storage.FakeCall{}
+}
+
+// configFlag returns the index of the first `--config` token in args
+// and the total number of `--config` tokens present.
+func configFlag(args []string) (int, int) {
+	first := -1
+	count := 0
+
+	for i, a := range args {
+		if a == "--config" {
+			count++
+			if first == -1 {
+				first = i
+			}
+		}
+	}
+
+	return first, count
+}


### PR DESCRIPTION
## Summary

Two independent satellite-side storage fixes, each diagnosed live on a dev stand and covered by a unit test.

### 1. `ps cdp` single-device attach is now idempotent

`linstor physical-storage create-device-pool ... zfs <node> /dev/sda` wedged the satellite in an infinite reconcile loop after the pool was already created. For a single device the device becomes the pool's sole vdev at create time; on any re-reconcile the pool exists, so the attach took the "extend" branch and ran `zpool add -f <pool> <dev>` — which ZFS rejects because the device is already part of the active pool. The PhysicalDevice CRD stayed `Phase=Failed` with its finalizer set and was never cleaned up.

The attach now probes vdev/PV membership first: if the device is already a member of the target pool, the attach is treated as idempotently complete and follows the normal success path (register provider, strip finalizer, delete the CRD). A genuinely new device still extends the pool, so multi-device device-pool creation is unchanged.

### 2. `vd set-size` now resizes LVM backends

`linstor vd set-size <rd> 0 2G` updated the API and resized ZFS zvols, but the LVM backend (thin and thick) never grew — the LV and the DRBD device stayed at the old size. `lvextend` was invoked with two `--config` flags (the device filter injected by the shared LVM wrapper plus an `activation{udev_sync=0 udev_rules=0}` section added at the call site); the LVM CLI rejects a repeated `--config`, so the command failed at parse time and the resize hot-looped.

The device filter and the udev-less activation section are now merged into a single `--config`. The same latent double-`--config` in the thick-provider create / restore-from-snapshot paths is fixed too.

## Testing

- `go build ./...`, `go test ./...` (whole module), `gofmt`, `golangci-lint` — all clean.
- New regression tests fail against the pre-fix code and pass after: `TestAttachZpoolMemberDeviceIsIdempotent` / `TestAttachPVMemberDeviceIsIdempotent` (plus a non-member extend guard), and `TestResizeVolumeSingleConfig` (thin + thick).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage pool extension operations (LVM VGs and ZFS zpools) are now idempotent: when a storage device is already a member of an existing pool, attachment operations complete successfully without re-extending.
  * Fixed LVM resize operations that were failing due to incorrect CLI argument handling, which previously caused resize failures and performance issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->