### PR TITLE
feat(apiserver): mTLS for in-cluster clients with cert hot-reload

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,5 +1,10 @@
 name: Contract tests
 
+env:
+  # Opt JS actions (e.g. actions/upload-artifact) into Node.js 24 — silences the
+  # Node 20 deprecation warning; checkout/setup-go here are already Node24-era.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Tier 3 of the test strategy (docs/test-strategy.md). Runs the
 # drbd-utils contract suite — a thin docker container running real
 # drbdmeta / drbdadm binaries against loopback files — to pin the

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,10 @@
 name: Integration tests
 
+env:
+  # Opt JS actions (e.g. actions/upload-artifact) into Node.js 24 — silences the
+  # Node 20 deprecation warning; checkout/setup-go here are already Node24-era.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Tier 2 of the test strategy (docs/test-strategy.md). Boots envtest
 # (in-process apiserver + etcd), the full controller-runtime manager
 # with every reconciler, the REST server, and an in-process satellite

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,10 @@
 name: Pull Request
 
+env:
+  # Opt JS actions (e.g. actions/upload-artifact) into Node.js 24 — silences the
+  # Node 20 deprecation warning; checkout/setup-go here are already Node24-era.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Single consolidated CI pipeline for PRs. Fires on every PR open/push and
 # runs lint, unit tests, contract tests, and e2e in parallel. The e2e job
 # carries an opt-in SSH breakpoint (label-gated) so maintainers can attach

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -72,6 +72,10 @@ import (
 // budget and makes the test wiring (later) trivial.
 type apiserverFlags struct {
 	restAddr            string
+	tlsAddr             string
+	tlsCertFile         string
+	tlsKeyFile          string
+	tlsClientCAFile     string
 	metricsAddr         string
 	probeAddr           string
 	controllerNamespace string
@@ -81,7 +85,15 @@ func parseFlags() *apiserverFlags {
 	flags := &apiserverFlags{}
 
 	flag.StringVar(&flags.restAddr, "rest-bind-address", ":3370",
-		"The address the LINSTOR-compatible REST API binds to.")
+		"Plain-HTTP debug bind address. NOT exposed by the in-cluster Service — reachable only via `kubectl port-forward` for local debugging.")
+	flag.StringVar(&flags.tlsAddr, "tls-bind-address", ":3371",
+		"Mutual-TLS bind address (upstream LINSTOR HTTPS port). The in-cluster Service exposes ONLY this port. Requires --tls-cert-file/--tls-key-file/--tls-client-ca-file; empty disables the TLS listener.")
+	flag.StringVar(&flags.tlsCertFile, "tls-cert-file", "",
+		"PEM serving certificate for the mutual-TLS listener (cert-manager tls.crt). Hot-reloaded on rotation without a restart.")
+	flag.StringVar(&flags.tlsKeyFile, "tls-key-file", "",
+		"PEM serving key for the mutual-TLS listener (cert-manager tls.key). Hot-reloaded on rotation without a restart.")
+	flag.StringVar(&flags.tlsClientCAFile, "tls-client-ca-file", "",
+		"PEM CA bundle every client cert is verified against (RequireAndVerifyClientCert; cert-manager ca.crt). Hot-reloaded on rotation without a restart.")
 	flag.StringVar(&flags.metricsAddr, "metrics-bind-address", "0",
 		"The address the metrics endpoint binds to. 0 disables.")
 	flag.StringVar(&flags.probeAddr, "health-probe-bind-address", ":8081",
@@ -180,6 +192,7 @@ func registerProbesAndREST(mgr manager.Manager, st store.Store, flags *apiserver
 
 	err = mgr.Add(&rest.Server{
 		Addr:      flags.restAddr,
+		TLS:       tlsOptions(flags),
 		Store:     st,
 		Client:    mgr.GetClient(),
 		Namespace: namespace,
@@ -190,6 +203,25 @@ func registerProbesAndREST(mgr manager.Manager, st store.Store, flags *apiserver
 	}
 
 	return nil
+}
+
+// tlsOptions builds the mutual-TLS configuration from the flags, or
+// nil when TLS is not fully configured. All three cert files plus the
+// bind address must be set; otherwise the apiserver serves plain HTTP
+// only (e.g. a local `go run` without cert-manager). In production the
+// Deployment always sets all four, so the in-cluster Service's TLS
+// port is always live.
+func tlsOptions(flags *apiserverFlags) *rest.TLSOptions {
+	if flags.tlsAddr == "" || flags.tlsCertFile == "" || flags.tlsKeyFile == "" || flags.tlsClientCAFile == "" {
+		return nil
+	}
+
+	return &rest.TLSOptions{
+		Addr:         flags.tlsAddr,
+		CertFile:     flags.tlsCertFile,
+		KeyFile:      flags.tlsKeyFile,
+		ClientCAFile: flags.tlsClientCAFile,
+	}
 }
 
 // waitForCacheSync blocks on the manager's cache sync and then
@@ -241,7 +273,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("Starting apiserver", "rest", flags.restAddr, "namespace", namespace)
+	setupLog.Info("Starting apiserver",
+		"rest_debug_http", flags.restAddr,
+		"rest_tls", flags.tlsAddr,
+		"tls_enabled", tlsOptions(flags) != nil,
+		"namespace", namespace)
 
 	err = mgr.Start(signalCtx)
 	if err != nil {

--- a/pkg/clienttls/clienttls.go
+++ b/pkg/clienttls/clienttls.go
@@ -132,12 +132,17 @@ func (c Config) HTTPClient(serverName string) (*http.Client, error) {
 		return nil, err
 	}
 
-	transport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return nil, errors.New("http.DefaultTransport is not *http.Transport")
+	// Clone DefaultTransport to preserve pooling/proxy/dial defaults, but
+	// fall back to a fresh transport if something (e.g. an OTel/APM tracing
+	// library) has replaced DefaultTransport with a non-*http.Transport
+	// RoundTripper — a direct type assertion would panic/fail there.
+	var cloned *http.Transport
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		cloned = transport.Clone()
+	} else {
+		cloned = &http.Transport{}
 	}
 
-	cloned := transport.Clone()
 	cloned.TLSClientConfig = tlsCfg
 
 	return &http.Client{

--- a/pkg/clienttls/clienttls.go
+++ b/pkg/clienttls/clienttls.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package clienttls builds mutual-TLS http.Clients for the blockstor
+// in-cluster components that dial the apiserver's HTTPS endpoint.
+//
+// The contract mirrors upstream LINSTOR's HTTPS story so the same
+// cert-manager-issued material works for both blockstor's own Go
+// clients and the external golinstor-based consumers (linstor-csi,
+// piraeus-operator): a client presents a key-pair signed by the API
+// CA and verifies the server against that same CA. The apiserver's
+// TLS listener runs RequireAndVerifyClientCert, so a client WITHOUT a
+// valid cert is rejected at the handshake.
+//
+// Certs are read once at client-construction time. Unlike the server
+// side (pkg/rest reloads its serving cert/CA on rotation without a
+// restart), clients re-read on the next process start — cert-manager
+// rotation of a client key-pair is rare and the consuming Deployments
+// already roll on their own cadence; baking a watcher into every
+// client would add surface for little gain. Hot-reload on the SERVER
+// is the load-bearing requirement (issue: rolling the serving cert
+// must not drop in-flight clients).
+package clienttls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// clientTimeout caps a single mutual-TLS request. The apiserver REST
+// calls are all short control-plane operations; 30s leaves headroom
+// for a slow cold cache list without letting a wedged peer hang a
+// client goroutine forever.
+const clientTimeout = 30 * time.Second
+
+// ErrEmptyCABundle is returned when the configured CA file parses to
+// zero certificates — almost always a wrong path or an empty mounted
+// Secret key. Surfaced as a sentinel so callers can branch on it.
+var ErrEmptyCABundle = errors.New("no certificates parsed from CA bundle")
+
+// Config points at the three PEM files a mutual-TLS client needs.
+// All three are mounted from a cert-manager-issued Secret (tls.crt /
+// tls.key / ca.crt by the cert-manager convention).
+type Config struct {
+	// CertFile is the client certificate (PEM). Presented to the
+	// server during the handshake.
+	CertFile string
+	// KeyFile is the private key (PEM) for CertFile.
+	KeyFile string
+	// CAFile is the CA bundle (PEM) used to verify the server's
+	// serving certificate.
+	CAFile string
+}
+
+// FromEnv reads the standard LINSTOR client-TLS environment variables
+// (LS_USER_CERTIFICATE / LS_USER_KEY / LS_ROOT_CA) and returns a
+// Config plus whether all three were set. blockstor follows the same
+// env contract golinstor uses so a single mounted Secret + three env
+// vars wires both blockstor's own clients and golinstor-based ones.
+//
+// ok is false when none or only some of the variables are present;
+// callers treat that as "plain HTTP, no client TLS" so local
+// port-forward debugging keeps working.
+func FromEnv() (Config, bool) {
+	cfg := Config{
+		CertFile: os.Getenv("LS_USER_CERTIFICATE"),
+		KeyFile:  os.Getenv("LS_USER_KEY"),
+		CAFile:   os.Getenv("LS_ROOT_CA"),
+	}
+
+	ok := cfg.CertFile != "" && cfg.KeyFile != "" && cfg.CAFile != ""
+
+	return cfg, ok
+}
+
+// TLSConfig builds a *tls.Config that presents the client key-pair and
+// verifies the server against CAFile. ServerName, when non-empty, is
+// the DNS name the client expects in the server certificate (the
+// in-cluster Service FQDN); leave it empty to let the dialer derive it
+// from the request URL host.
+func (c Config) TLSConfig(serverName string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "load client key pair")
+	}
+
+	caPEM, err := os.ReadFile(c.CAFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "read client CA bundle")
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, errors.Wrapf(ErrEmptyCABundle, "CA bundle %q", c.CAFile)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		ServerName:   serverName,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+// HTTPClient returns an *http.Client whose Transport presents the
+// client cert and verifies the server against the configured CA. The
+// returned client carries no request timeout — callers that need one
+// (most do) set http.Client.Timeout on the result. The transport is a
+// clone of http.DefaultTransport so connection pooling / proxy / dial
+// defaults are preserved.
+func (c Config) HTTPClient(serverName string) (*http.Client, error) {
+	tlsCfg, err := c.TLSConfig(serverName)
+	if err != nil {
+		return nil, err
+	}
+
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("http.DefaultTransport is not *http.Transport")
+	}
+
+	cloned := transport.Clone()
+	cloned.TLSClientConfig = tlsCfg
+
+	return &http.Client{
+		Transport: cloned,
+		Timeout:   clientTimeout,
+	}, nil
+}

--- a/pkg/clienttls/clienttls_test.go
+++ b/pkg/clienttls/clienttls_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clienttls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeSelfSignedPair mints a self-signed cert+key and a CA bundle (the
+// same cert serving as its own CA) into dir, returning a Config that
+// points at them. Enough to exercise the loader paths without a real
+// PKI.
+func writeSelfSignedPair(t *testing.T, dir string) Config {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "client"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	cfg := Config{
+		CertFile: filepath.Join(dir, "tls.crt"),
+		KeyFile:  filepath.Join(dir, "tls.key"),
+		CAFile:   filepath.Join(dir, "ca.crt"),
+	}
+
+	mustWrite(t, cfg.CertFile, certPEM)
+	mustWrite(t, cfg.KeyFile, keyPEM)
+	mustWrite(t, cfg.CAFile, certPEM)
+
+	return cfg
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+
+	err := os.WriteFile(path, data, 0o600)
+	if err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestTLSConfigLoadsMaterial verifies the happy path: a valid cert/key/
+// CA produces a *tls.Config with the client cert and a non-empty root
+// pool, and the requested ServerName.
+func TestTLSConfigLoadsMaterial(t *testing.T) {
+	cfg := writeSelfSignedPair(t, t.TempDir())
+
+	tlsCfg, err := cfg.TLSConfig("blockstor-apiserver.blockstor-system.svc")
+	if err != nil {
+		t.Fatalf("TLSConfig: %v", err)
+	}
+
+	if len(tlsCfg.Certificates) != 1 {
+		t.Errorf("Certificates: got %d, want 1", len(tlsCfg.Certificates))
+	}
+
+	if tlsCfg.RootCAs == nil {
+		t.Errorf("RootCAs is nil")
+	}
+
+	if tlsCfg.ServerName != "blockstor-apiserver.blockstor-system.svc" {
+		t.Errorf("ServerName: got %q", tlsCfg.ServerName)
+	}
+
+	if tlsCfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion: got %x, want TLS1.2", tlsCfg.MinVersion)
+	}
+}
+
+// TestTLSConfigEmptyCARejected verifies an empty/garbage CA bundle
+// surfaces ErrEmptyCABundle rather than a silently-empty pool.
+func TestTLSConfigEmptyCARejected(t *testing.T) {
+	cfg := writeSelfSignedPair(t, t.TempDir())
+	mustWrite(t, cfg.CAFile, []byte("not a certificate"))
+
+	_, err := cfg.TLSConfig("")
+	if !errors.Is(err, ErrEmptyCABundle) {
+		t.Fatalf("error: got %v, want ErrEmptyCABundle", err)
+	}
+}
+
+// TestHTTPClientBuilds verifies HTTPClient returns a client with the
+// TLS transport wired and a request timeout set.
+func TestHTTPClientBuilds(t *testing.T) {
+	cfg := writeSelfSignedPair(t, t.TempDir())
+
+	client, err := cfg.HTTPClient("")
+	if err != nil {
+		t.Fatalf("HTTPClient: %v", err)
+	}
+
+	if client.Timeout == 0 {
+		t.Errorf("expected a non-zero request timeout")
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport: got %T, want *http.Transport", client.Transport)
+	}
+
+	if transport.TLSClientConfig == nil {
+		t.Errorf("transport.TLSClientConfig is nil; client cert not wired")
+	}
+
+	if len(transport.TLSClientConfig.Certificates) != 1 {
+		t.Errorf("client cert count: got %d, want 1", len(transport.TLSClientConfig.Certificates))
+	}
+}
+
+// TestFromEnv verifies the LINSTOR-standard env var contract: all three
+// set ⇒ ok=true; any missing ⇒ ok=false (plain-HTTP fallback).
+func TestFromEnv(t *testing.T) {
+	t.Setenv("LS_USER_CERTIFICATE", "/etc/tls/tls.crt")
+	t.Setenv("LS_USER_KEY", "/etc/tls/tls.key")
+	t.Setenv("LS_ROOT_CA", "/etc/tls/ca.crt")
+
+	cfg, ok := FromEnv()
+	if !ok {
+		t.Fatalf("FromEnv ok: got false, want true")
+	}
+
+	if cfg.CertFile != "/etc/tls/tls.crt" || cfg.KeyFile != "/etc/tls/tls.key" || cfg.CAFile != "/etc/tls/ca.crt" {
+		t.Errorf("FromEnv cfg mismatch: %+v", cfg)
+	}
+
+	t.Setenv("LS_ROOT_CA", "")
+
+	_, ok = FromEnv()
+	if ok {
+		t.Errorf("FromEnv ok: got true with LS_ROOT_CA unset, want false")
+	}
+}

--- a/pkg/rest/server.go
+++ b/pkg/rest/server.go
@@ -318,28 +318,37 @@ func (s *Server) handler() http.Handler {
 // waitAndShutdown blocks until ctx is cancelled or any listener
 // reports a fatal error, then gracefully shuts down every server.
 func waitAndShutdown(ctx context.Context, servers []*http.Server, errCh <-chan error) error {
+	var serveErr error
+
 	select {
 	case <-ctx.Done():
-		shutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer cancel()
-
-		var shutErr error
-
-		for _, srv := range servers {
-			err := srv.Shutdown(shutCtx)
-			if err != nil && shutErr == nil {
-				shutErr = err
-			}
-		}
-
-		return errors.Wrap(shutErr, "shutdown REST server")
-	case err := <-errCh:
-		if err == nil {
+	case serveErr = <-errCh:
+		if serveErr == nil {
 			return nil
 		}
-
-		return errors.Wrap(err, "REST server failed")
 	}
+
+	// Always gracefully shut down EVERY listener on the way out, even when
+	// one of them reported a fatal serve error — otherwise the surviving
+	// server's goroutine leaks and keeps its port bound, blocking a clean
+	// restart.
+	shutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	var shutErr error
+
+	for _, srv := range servers {
+		err := srv.Shutdown(shutCtx)
+		if err != nil && shutErr == nil {
+			shutErr = err
+		}
+	}
+
+	if serveErr != nil {
+		return errors.Wrap(serveErr, "REST server failed")
+	}
+
+	return errors.Wrap(shutErr, "shutdown REST server")
 }
 
 // serveOrIgnoreClosed maps the benign http.ErrServerClosed (returned

--- a/pkg/rest/server.go
+++ b/pkg/rest/server.go
@@ -200,6 +200,7 @@ func (s *Server) Start(ctx context.Context) error {
 	errCh := make(chan error, 2)
 
 	plainSrv := s.newHTTPServer(ctx, s.Addr, handler)
+
 	go func() {
 		logger.Info("REST API listening (plain HTTP, debug only)",
 			"addr", s.Addr,

--- a/pkg/rest/server.go
+++ b/pkg/rest/server.go
@@ -70,10 +70,24 @@ const maxRequestBodyBytes int64 = 1 << 20
 // reach the apiserver directly. Both may be nil/empty in tests that
 // only exercise the legacy KV-backed path.
 type Server struct {
-	Addr      string // e.g. ":3370" — upstream LINSTOR plain-text REST port
+	Addr      string // e.g. ":3370" — plain-HTTP debug port (NOT exposed by the in-cluster Service; reachable only via kubectl port-forward)
 	Store     store.Store
 	Client    client.Client // controller-runtime client for native-object endpoints
 	Namespace string        // namespace where blockstor's own Secrets/ConfigMaps live
+
+	// TLS, when non-nil, makes Start also bring up a mutual-TLS
+	// listener on TLSAddr alongside the plain-HTTP debug listener on
+	// Addr. The in-cluster Service exposes ONLY TLSAddr; the plain
+	// listener stays pod-local for `kubectl port-forward` debugging.
+	//
+	// The listener REQUIRES and VERIFIES a client certificate
+	// (tls.RequireAndVerifyClientCert) against the configured client
+	// CA, and hot-reloads its serving cert/key AND the client-CA
+	// bundle from disk without a restart when cert-manager rotates
+	// them (see reloadableTLS). nil ⇒ TLS listener disabled (the
+	// plain-HTTP path still serves, e.g. in unit tests and the legacy
+	// single-binary controller mount).
+	TLS *TLSOptions
 
 	// linstorRemotes is the in-memory registry for LINSTOR remotes —
 	// see pkg/rest/remotes.go. Lazy-initialised on the first call to
@@ -159,84 +173,184 @@ func (s *Server) SetResolveHost(fn ResolveHostFunc) ResolveHostFunc {
 // introduce write-paths that need a single leader we'll change this to true.
 func (s *Server) NeedLeaderElection() bool { return false }
 
-// Start runs the HTTP server until ctx is cancelled.
+// Start runs the REST server until ctx is cancelled. It always brings
+// up the plain-HTTP debug listener on s.Addr; when s.TLS is set it
+// ALSO brings up a mutual-TLS listener on s.TLS.Addr. Both listeners
+// share one handler. The whole call returns when ctx is cancelled
+// (graceful shutdown of both) or when either listener fails fatally.
 func (s *Server) Start(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("rest")
+	handler := s.handler()
 
-	mux := s.buildMux()
-
-	// Middleware order, outer → inner:
-	//   withLogging         — observes the final status code (incl. 4xx
-	//                          envelopes the inner layers emit).
-	//   instrumentRequests  — Bug 168: emits the blockstor_requests_total
-	//                          / blockstor_request_duration_seconds
-	//                          series. Sits inside withLogging so the
-	//                          status code observation matches the one
-	//                          the log line records, but outside the
-	//                          envelope/content-type middlewares so 4xx
-	//                          replies they emit are still counted.
-	//   with404Envelope     — rewrites ServeMux's plain-text 404/405
-	//                          fallback bodies to LINSTOR `[]ApiCallRc`
-	//                          (Bug 103, Bug 109).
-	//   withContentTypeJSON — Bug 147: refuses POST/PUT/PATCH with a
-	//                          non-JSON Content-Type before any handler
-	//                          tries to decode random bytes as JSON.
-	//                          Consults the mux so a wrong-verb request
-	//                          (which would 405) is not pre-empted with
-	//                          a 415 — the 405 path stays intact.
-	//   withBodyLimit       — Bug 146: caps the request body so an
-	//                          oversized POST trips a 413 envelope at
-	//                          the wire edge instead of leaking the
-	//                          etcd/k8s rejection string in a 500.
-	srv := &http.Server{
-		Addr:              s.Addr,
-		Handler:           withLogging(instrumentRequests(mux, withHEADContentLength(with404Envelope(withContentTypeJSON(mux, withBodyLimit(maxRequestBodyBytes, mux)))))),
-		ReadHeaderTimeout: 10 * time.Second,
-		BaseContext:       func(_ net.Listener) context.Context { return ctx },
-	}
-
-	// Bind the listener up-front so we can signal OnReady BEFORE
-	// entering the serve loop. Splitting net.Listen + srv.Serve
-	// out of the combined srv.ListenAndServe lets the apiserver
-	// hold its /readyz at 503 until clients can actually connect
-	// (issue 213). Bind errors are surfaced synchronously — the
-	// caller's manager treats Runnable startup failure as fatal,
-	// same shape as the pre-split ListenAndServe error path.
+	// Bind the plain-HTTP listener up-front so we can signal OnReady
+	// BEFORE entering the serve loop. Splitting net.Listen + Serve
+	// out of ListenAndServe lets the apiserver hold its /readyz at
+	// 503 until clients can actually connect (issue 213). Bind
+	// errors are surfaced synchronously — the caller's manager treats
+	// Runnable startup failure as fatal.
 	lc := &net.ListenConfig{}
 
-	ln, err := lc.Listen(ctx, "tcp", s.Addr)
+	plainLn, err := lc.Listen(ctx, "tcp", s.Addr)
 	if err != nil {
 		return errors.Wrap(err, "REST server listen")
 	}
 
-	if s.OnReady != nil {
-		s.OnReady()
-	}
+	// errCh is buffered for both listeners so neither goroutine
+	// leaks if the other fails first.
+	errCh := make(chan error, 2)
 
-	errCh := make(chan error, 1)
-
+	plainSrv := s.newHTTPServer(ctx, s.Addr, handler)
 	go func() {
-		logger.Info("REST API listening",
+		logger.Info("REST API listening (plain HTTP, debug only)",
 			"addr", s.Addr,
 			"linstor_contract", version.LinstorVersion,
 			"rest_api", version.RestAPIVersion)
 
-		errCh <- srv.Serve(ln)
+		errCh <- serveOrIgnoreClosed(plainSrv.Serve(plainLn))
 	}()
 
+	servers := []*http.Server{plainSrv}
+
+	if s.TLS != nil {
+		tlsSrv, tlsErr := s.startTLS(ctx, handler, errCh, logger)
+		if tlsErr != nil {
+			// Tear the plain listener down before returning so the
+			// manager doesn't see a half-started Runnable.
+			_ = plainSrv.Close()
+
+			return tlsErr
+		}
+
+		servers = append(servers, tlsSrv)
+	}
+
+	// OnReady fires once BOTH listeners (plain + optional TLS) have
+	// bound — kube-proxy must not route to the pod until the TLS
+	// endpoint the Service exposes is actually accepting connections.
+	if s.OnReady != nil {
+		s.OnReady()
+	}
+
+	return waitAndShutdown(ctx, servers, errCh)
+}
+
+// newHTTPServer constructs an *http.Server with the project's shared
+// timeouts and base context. tlsCfg may be nil for the plain listener.
+func (s *Server) newHTTPServer(ctx context.Context, addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext:       func(_ net.Listener) context.Context { return ctx },
+	}
+}
+
+// startTLS loads the (reloadable) serving material, arms the hot-reload
+// watcher, binds the TLS listener and starts serving on it. The
+// returned *http.Server is added to the shutdown set by the caller.
+func (s *Server) startTLS(ctx context.Context, handler http.Handler, errCh chan<- error, logger logr) (*http.Server, error) {
+	reloader, err := newReloadableTLS(s.TLS.CertFile, s.TLS.KeyFile, s.TLS.ClientCAFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "TLS material")
+	}
+
+	go reloader.watch(ctx)
+
+	tlsSrv := s.newHTTPServer(ctx, s.TLS.Addr, handler)
+	tlsSrv.TLSConfig = reloader.serverTLSConfig()
+
+	lc := &net.ListenConfig{}
+
+	tlsLn, err := lc.Listen(ctx, "tcp", s.TLS.Addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "REST server TLS listen")
+	}
+
+	go func() {
+		logger.Info("REST API listening (mutual TLS)",
+			"addr", s.TLS.Addr,
+			"client_auth", "RequireAndVerifyClientCert")
+
+		// ServeTLS with empty cert/key paths uses tlsSrv.TLSConfig,
+		// which is our reloadable config (GetCertificate /
+		// GetConfigForClient). The empty-string args are required —
+		// passing files here would shadow the reload hooks.
+		errCh <- serveOrIgnoreClosed(tlsSrv.ServeTLS(tlsLn, "", ""))
+	}()
+
+	return tlsSrv, nil
+}
+
+// handler builds the fully-wrapped REST handler. Shared by both the
+// plain-HTTP debug listener and the mutual-TLS listener so they serve
+// identical routes/middleware.
+//
+// Middleware order, outer → inner:
+//
+//	withLogging         — observes the final status code (incl. 4xx
+//	                       envelopes the inner layers emit).
+//	instrumentRequests  — Bug 168: emits the blockstor_requests_total
+//	                       / blockstor_request_duration_seconds
+//	                       series. Sits inside withLogging so the
+//	                       status code observation matches the one
+//	                       the log line records, but outside the
+//	                       envelope/content-type middlewares so 4xx
+//	                       replies they emit are still counted.
+//	with404Envelope     — rewrites ServeMux's plain-text 404/405
+//	                       fallback bodies to LINSTOR `[]ApiCallRc`
+//	                       (Bug 103, Bug 109).
+//	withContentTypeJSON — Bug 147: refuses POST/PUT/PATCH with a
+//	                       non-JSON Content-Type before any handler
+//	                       tries to decode random bytes as JSON.
+//	                       Consults the mux so a wrong-verb request
+//	                       (which would 405) is not pre-empted with
+//	                       a 415 — the 405 path stays intact.
+//	withBodyLimit       — Bug 146: caps the request body so an
+//	                       oversized POST trips a 413 envelope at
+//	                       the wire edge instead of leaking the
+//	                       etcd/k8s rejection string in a 500.
+func (s *Server) handler() http.Handler {
+	mux := s.buildMux()
+
+	return withLogging(instrumentRequests(mux, withHEADContentLength(with404Envelope(withContentTypeJSON(mux, withBodyLimit(maxRequestBodyBytes, mux))))))
+}
+
+// waitAndShutdown blocks until ctx is cancelled or any listener
+// reports a fatal error, then gracefully shuts down every server.
+func waitAndShutdown(ctx context.Context, servers []*http.Server, errCh <-chan error) error {
 	select {
 	case <-ctx.Done():
 		shutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
 
-		return errors.Wrap(srv.Shutdown(shutCtx), "shutdown REST server")
+		var shutErr error
+
+		for _, srv := range servers {
+			err := srv.Shutdown(shutCtx)
+			if err != nil && shutErr == nil {
+				shutErr = err
+			}
+		}
+
+		return errors.Wrap(shutErr, "shutdown REST server")
 	case err := <-errCh:
-		if errors.Is(err, http.ErrServerClosed) {
+		if err == nil {
 			return nil
 		}
 
 		return errors.Wrap(err, "REST server failed")
 	}
+}
+
+// serveOrIgnoreClosed maps the benign http.ErrServerClosed (returned
+// by Serve/ServeTLS on graceful Shutdown/Close) to nil so it doesn't
+// trip the fatal-error path.
+func serveOrIgnoreClosed(err error) error {
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+
+	return err
 }
 
 // lookupHost dispatches to s.resolveHost if set, else the package

--- a/pkg/rest/tls_reload.go
+++ b/pkg/rest/tls_reload.go
@@ -262,6 +262,17 @@ func (r *reloadableTLS) watchLoop(ctx context.Context, watcher *fsnotify.Watcher
 				debounce = time.NewTimer(tlsReloadDebounce)
 				debounceC = debounce.C
 			} else {
+				// Stop+drain before Reset: a timer that already fired left a
+				// value in its channel; without draining it the next select
+				// would trip <-debounceC immediately and skip the debounce,
+				// reloading certs before the kubelet finished writing them.
+				if !debounce.Stop() {
+					select {
+					case <-debounce.C:
+					default:
+					}
+				}
+
 				debounce.Reset(tlsReloadDebounce)
 			}
 		case err, ok := <-watcher.Errors:

--- a/pkg/rest/tls_reload.go
+++ b/pkg/rest/tls_reload.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/fsnotify/fsnotify"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TLSOptions configures the apiserver's mutual-TLS listener. All file
+// paths point into a cert-manager-issued Secret mounted into the pod
+// (tls.crt / tls.key / ca.crt by cert-manager convention). The
+// listener hot-reloads all three from disk on rotation without a
+// restart (see reloadableTLS) — no reloader.stakater.com needed.
+type TLSOptions struct {
+	// Addr is the mutual-TLS bind address, e.g. ":3371" (upstream
+	// LINSTOR's HTTPS REST port). This is the ONLY port the in-cluster
+	// Service exposes.
+	Addr string
+	// CertFile is the serving certificate (PEM), issued for the
+	// in-cluster Service DNS SANs.
+	CertFile string
+	// KeyFile is the serving private key (PEM) for CertFile.
+	KeyFile string
+	// ClientCAFile is the CA bundle (PEM) every client certificate is
+	// verified against (tls.RequireAndVerifyClientCert).
+	ClientCAFile string
+}
+
+// tlsReloadDebounce coalesces the burst of fsnotify events cert-manager
+// emits when it rotates a Secret. The kubelet swaps the mounted Secret
+// by atomically re-pointing the `..data` symlink, which fires several
+// CREATE/RENAME/REMOVE events in quick succession; re-reading on the
+// first one would race a half-written set of files. A short settle
+// window lets the swap finish before we re-load.
+const tlsReloadDebounce = 500 * time.Millisecond
+
+// tlsReloadPoll is the periodic fallback re-read interval. fsnotify on
+// a kubelet atomic-symlink-swap mount is reliable in practice, but a
+// missed event (watch re-arm race after the dir is recreated) would
+// otherwise leave a stale cert in memory until the next rotation. A
+// low-frequency poll bounds the staleness without meaningful cost.
+const tlsReloadPoll = 60 * time.Second
+
+// reloadableTLS holds the apiserver's serving certificate and the
+// client-CA pool, both re-readable from disk WITHOUT a process
+// restart. cert-manager rotates the mounted Secret in place; this
+// type re-loads the new material so existing pods keep serving across
+// a rotation (no rolling restart, no reloader.stakater.com).
+//
+// Race-safety: the hot path (GetCertificate / GetConfigForClient,
+// invoked by crypto/tls on every handshake) only ever takes an
+// RLock and reads two pointers. The reload path takes the write lock
+// just long enough to swap those two pointers to freshly-parsed
+// values; parsing happens OUTSIDE the lock so a slow disk read never
+// blocks in-flight handshakes. A failed reload (truncated file mid-
+// rotation) logs and keeps the previous good material — the server
+// never serves a nil cert.
+type reloadableTLS struct {
+	certFile     string
+	keyFile      string
+	clientCAFile string
+
+	mu       sync.RWMutex
+	cert     *tls.Certificate
+	clientCA *x509.CertPool
+}
+
+// newReloadableTLS loads the initial material and returns the holder.
+// An error here is fatal at boot (the operator mounted a bad Secret);
+// after boot, reloads that fail are non-fatal and keep the last good
+// material.
+func newReloadableTLS(certFile, keyFile, clientCAFile string) (*reloadableTLS, error) {
+	r := &reloadableTLS{
+		certFile:     certFile,
+		keyFile:      keyFile,
+		clientCAFile: clientCAFile,
+	}
+
+	err := r.reload()
+	if err != nil {
+		return nil, errors.Wrap(err, "initial TLS material load")
+	}
+
+	return r, nil
+}
+
+// reload re-reads the serving key-pair and the client-CA bundle from
+// disk and atomically swaps them in. Parsing is done before the lock
+// so handshakes are never blocked on I/O.
+func (r *reloadableTLS) reload() error {
+	cert, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+	if err != nil {
+		return errors.Wrap(err, "load serving key pair")
+	}
+
+	caPEM, err := os.ReadFile(r.clientCAFile)
+	if err != nil {
+		return errors.Wrap(err, "read client CA bundle")
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return errors.Wrapf(ErrEmptyClientCA, "client CA bundle %q", r.clientCAFile)
+	}
+
+	r.mu.Lock()
+	r.cert = &cert
+	r.clientCA = pool
+	r.mu.Unlock()
+
+	return nil
+}
+
+// ErrEmptyClientCA is returned when the configured client-CA file
+// parses to zero certificates. Sentinel so the reload path can log it
+// distinctly from a file-not-found.
+var ErrEmptyClientCA = errors.New("no certificates parsed from client CA bundle")
+
+// getCertificate is wired into tls.Config.GetCertificate so every
+// handshake picks up the current serving cert. Reads under RLock.
+func (r *reloadableTLS) getCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.cert, nil
+}
+
+// getConfigForClient is wired into tls.Config.GetConfigForClient so
+// every handshake validates the client cert against the CURRENT
+// client-CA pool. Returning a fresh *tls.Config per handshake is the
+// canonical way to hot-reload ClientCAs — the base config's ClientCAs
+// is captured at listen time and would otherwise never update.
+func (r *reloadableTLS) getConfigForClient(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+	r.mu.RLock()
+	pool := r.clientCA
+	r.mu.RUnlock()
+
+	return &tls.Config{
+		GetCertificate: r.getCertificate,
+		ClientCAs:      pool,
+		ClientAuth:     tls.RequireAndVerifyClientCert,
+		MinVersion:     tls.VersionTLS12,
+	}, nil
+}
+
+// serverTLSConfig returns the base *tls.Config the listener is built
+// with. GetConfigForClient supersedes the static fields on every
+// handshake (so ClientCAs hot-reloads), but the static fields are set
+// too for clients/tools that introspect the base config.
+func (r *reloadableTLS) serverTLSConfig() *tls.Config {
+	r.mu.RLock()
+	pool := r.clientCA
+	r.mu.RUnlock()
+
+	return &tls.Config{
+		GetCertificate:     r.getCertificate,
+		GetConfigForClient: r.getConfigForClient,
+		ClientCAs:          pool,
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		MinVersion:         tls.VersionTLS12,
+	}
+}
+
+// watch runs the hot-reload loop until ctx is cancelled. It combines
+// an fsnotify watch on the directories backing the cert/key/CA files
+// (kubelet swaps the whole mount, so we watch dirs, not the symlinked
+// files) with a periodic poll fallback. Both paths funnel through a
+// debounced reload so the kubelet's multi-event atomic swap settles
+// before we re-read. Watch failures degrade to poll-only — the server
+// keeps serving the last good material regardless.
+func (r *reloadableTLS) watch(ctx context.Context) {
+	logger := log.FromContext(ctx).WithName("tls-reload")
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		logger.Error(err, "fsnotify watcher unavailable; falling back to periodic poll")
+
+		r.pollOnly(ctx, logger)
+
+		return
+	}
+	defer func() { _ = watcher.Close() }()
+
+	for _, dir := range r.watchDirs() {
+		addErr := watcher.Add(dir)
+		if addErr != nil {
+			logger.Error(addErr, "watch dir add failed", "dir", dir)
+		}
+	}
+
+	r.watchLoop(ctx, watcher, logger)
+}
+
+// watchDirs is the de-duplicated set of directories holding the
+// cert/key/CA files. Watching the directory (not the file) is required
+// because a kubelet Secret mount swaps the entire `..data` dir; the
+// individual files are symlinks whose target changes, which an inotify
+// watch on the file itself does not always observe.
+func (r *reloadableTLS) watchDirs() []string {
+	seen := map[string]struct{}{}
+	dirs := []string{}
+
+	for _, f := range []string{r.certFile, r.keyFile, r.clientCAFile} {
+		dir := filepath.Dir(f)
+		if _, ok := seen[dir]; ok {
+			continue
+		}
+
+		seen[dir] = struct{}{}
+
+		dirs = append(dirs, dir)
+	}
+
+	return dirs
+}
+
+// watchLoop is the select loop pulled out of watch to keep it under
+// the funlen budget. Debounces fsnotify bursts and re-reads on a poll
+// ticker.
+func (r *reloadableTLS) watchLoop(ctx context.Context, watcher *fsnotify.Watcher, logger logr) {
+	poll := time.NewTicker(tlsReloadPoll)
+	defer poll.Stop()
+
+	var debounce *time.Timer
+
+	debounceC := make(<-chan time.Time)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+
+			if debounce == nil {
+				debounce = time.NewTimer(tlsReloadDebounce)
+				debounceC = debounce.C
+			} else {
+				debounce.Reset(tlsReloadDebounce)
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+
+			logger.Error(err, "fsnotify error")
+		case <-debounceC:
+			debounce = nil
+			debounceC = make(<-chan time.Time)
+
+			r.reloadAndLog(logger, "cert dir change")
+		case <-poll.C:
+			r.reloadAndLog(logger, "periodic poll")
+		}
+	}
+}
+
+// pollOnly is the degraded path used when fsnotify is unavailable.
+func (r *reloadableTLS) pollOnly(ctx context.Context, logger logr) {
+	poll := time.NewTicker(tlsReloadPoll)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-poll.C:
+			r.reloadAndLog(logger, "periodic poll")
+		}
+	}
+}
+
+// reloadAndLog re-reads the material and logs the outcome. A failed
+// reload is non-fatal: the previous good cert/CA stays in memory so
+// the server never starts rejecting handshakes because of a transient
+// mid-rotation read.
+func (r *reloadableTLS) reloadAndLog(logger logr, reason string) {
+	err := r.reload()
+	if err != nil {
+		logger.Error(err, "TLS reload failed; keeping previous material", "reason", reason)
+
+		return
+	}
+
+	logger.Info("TLS material reloaded", "reason", reason)
+}
+
+// logr is the minimal logging surface watchLoop / pollOnly need. It
+// matches the methods of logr.Logger used here so tests can inject a
+// no-op without pulling the whole logging dep into the test.
+type logr interface {
+	Error(err error, msg string, keysAndValues ...any)
+	Info(msg string, keysAndValues ...any)
+}

--- a/pkg/rest/tls_reload.go
+++ b/pkg/rest/tls_reload.go
@@ -203,6 +203,7 @@ func (r *reloadableTLS) watch(ctx context.Context) {
 
 		return
 	}
+
 	defer func() { _ = watcher.Close() }()
 
 	for _, dir := range r.watchDirs() {

--- a/pkg/rest/tls_test.go
+++ b/pkg/rest/tls_test.go
@@ -1,0 +1,504 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// certPaths holds the on-disk PEM file locations for a freshly-issued
+// key-pair plus the CA bundle that signed it.
+type certPaths struct {
+	certFile string
+	keyFile  string
+	caFile   string
+}
+
+// testCA is a minimal in-process certificate authority used to mint
+// the server and client certs the mTLS tests need. It avoids any
+// dependency on cert-manager or external fixtures — the whole PKI is
+// generated per-test.
+type testCA struct {
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+	certPEM []byte
+}
+
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	return &testCA{
+		cert:    cert,
+		key:     key,
+		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+// issue mints a leaf certificate signed by the CA. cn is stamped into
+// both the CommonName and (for server certs) the DNS SAN list so a
+// client verifying ServerName=cn succeeds.
+func (ca *testCA) issue(t *testing.T, cn string, isServer bool) ([]byte, []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	if isServer {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		tmpl.DNSNames = []string{cn}
+		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM
+}
+
+// writeServerCerts mints a server cert for cn and writes the cert,
+// key and CA bundle into dir, returning their paths. Used both for the
+// initial material and to overwrite it mid-test (hot-reload).
+func writeServerCerts(t *testing.T, ca *testCA, dir, cn string) certPaths {
+	t.Helper()
+
+	certPEM, keyPEM := ca.issue(t, cn, true)
+
+	paths := certPaths{
+		certFile: filepath.Join(dir, "tls.crt"),
+		keyFile:  filepath.Join(dir, "tls.key"),
+		caFile:   filepath.Join(dir, "ca.crt"),
+	}
+
+	writeFile(t, paths.certFile, certPEM)
+	writeFile(t, paths.keyFile, keyPEM)
+	writeFile(t, paths.caFile, ca.certPEM)
+
+	return paths
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+
+	err := os.WriteFile(path, data, 0o600)
+	if err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// clientFor builds an *http.Client that presents the given client
+// key-pair (may be empty for the no-cert case) and trusts caPEM.
+func clientFor(t *testing.T, caPEM, certPEM, keyPEM []byte) *http.Client {
+	t.Helper()
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatalf("append CA to pool")
+	}
+
+	tlsCfg := &tls.Config{
+		RootCAs:    pool,
+		ServerName: "blockstor-apiserver",
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if certPEM != nil {
+		pair, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			t.Fatalf("client key pair: %v", err)
+		}
+
+		tlsCfg.Certificates = []tls.Certificate{pair}
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Timeout:   3 * time.Second,
+	}
+}
+
+// startTLSServer boots a Server with both the plain-HTTP and mutual-TLS
+// listeners on ephemeral ports and waits until both are reachable.
+// Returns the plain addr, the TLS addr, and a stop func.
+func startTLSServer(t *testing.T, paths certPaths) (string, string, func()) {
+	t.Helper()
+
+	plainAddr := pickFreeAddr(t)
+	tlsAddr := pickFreeAddr(t)
+
+	srv := &Server{
+		Addr: plainAddr,
+		TLS: &TLSOptions{
+			Addr:         tlsAddr,
+			CertFile:     paths.certFile,
+			KeyFile:      paths.keyFile,
+			ClientCAFile: paths.caFile,
+		},
+	}
+	srv.SetResolveHost(func(_ context.Context, _ string) ([]string, error) {
+		return []string{"127.0.0.1"}, nil
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+
+	go func() { errCh <- srv.Start(ctx) }()
+
+	waitReachable(t, ctx, plainAddr)
+	waitReachable(t, ctx, tlsAddr)
+
+	stop := func() {
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(3 * time.Second):
+			t.Errorf("server did not stop within 3s")
+		}
+	}
+
+	return plainAddr, tlsAddr, stop
+}
+
+func waitReachable(t *testing.T, ctx context.Context, addr string) {
+	t.Helper()
+
+	dialer := &net.Dialer{Timeout: 200 * time.Millisecond}
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		c, err := dialer.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			_ = c.Close()
+
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("addr %s never became reachable: %v", addr, err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// TestMTLSRejectsClientWithoutCert verifies the listener enforces
+// RequireAndVerifyClientCert: a client that presents NO certificate is
+// rejected at the TLS handshake.
+func TestMTLSRejectsClientWithoutCert(t *testing.T) {
+	ca := newTestCA(t)
+	paths := writeServerCerts(t, ca, t.TempDir(), "blockstor-apiserver")
+
+	_, tlsAddr, stop := startTLSServer(t, paths)
+	defer stop()
+
+	// No client cert → handshake must fail.
+	noCert := clientFor(t, ca.certPEM, nil, nil)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+tlsAddr+"/v1/controller/version", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := noCert.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+
+		t.Fatalf("expected handshake failure for client without cert, got status %d", resp.StatusCode)
+	}
+}
+
+// TestMTLSAcceptsClientWithValidCert verifies a client that presents a
+// cert signed by the configured CA completes the handshake and gets a
+// 200 from /v1/controller/version.
+func TestMTLSAcceptsClientWithValidCert(t *testing.T) {
+	ca := newTestCA(t)
+	paths := writeServerCerts(t, ca, t.TempDir(), "blockstor-apiserver")
+
+	_, tlsAddr, stop := startTLSServer(t, paths)
+	defer stop()
+
+	clientCert, clientKey := ca.issue(t, "blockstor-csi", false)
+	good := clientFor(t, ca.certPEM, clientCert, clientKey)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+tlsAddr+"/v1/controller/version", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := good.Do(req)
+	if err != nil {
+		t.Fatalf("valid-cert client request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestMTLSRejectsClientCertFromUnknownCA verifies a client cert signed
+// by a DIFFERENT CA is rejected even though it is a syntactically valid
+// client cert — the server validates the chain against ITS client CA.
+func TestMTLSRejectsClientCertFromUnknownCA(t *testing.T) {
+	ca := newTestCA(t)
+	paths := writeServerCerts(t, ca, t.TempDir(), "blockstor-apiserver")
+
+	_, tlsAddr, stop := startTLSServer(t, paths)
+	defer stop()
+
+	// A leaf signed by a foreign CA; the client still trusts the real
+	// server CA so the server side is what must reject it.
+	rogue := newTestCA(t)
+	rogueCert, rogueKey := rogue.issue(t, "attacker", false)
+	client := clientFor(t, ca.certPEM, rogueCert, rogueKey)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+tlsAddr+"/v1/controller/version", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+
+		t.Fatalf("expected rejection of client cert from unknown CA, got status %d", resp.StatusCode)
+	}
+}
+
+// TestPlainDebugListenerStillServes verifies the plain-HTTP debug
+// listener serves on its own port even when the TLS listener is up —
+// this is the `kubectl port-forward` path.
+func TestPlainDebugListenerStillServes(t *testing.T) {
+	ca := newTestCA(t)
+	paths := writeServerCerts(t, ca, t.TempDir(), "blockstor-apiserver")
+
+	plainAddr, _, stop := startTLSServer(t, paths)
+	defer stop()
+
+	resp := httpGet(t, "http://"+plainAddr+"/v1/controller/version")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("plain debug listener status: got %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestCertHotReload verifies the server serves a NEW serving cert after
+// the on-disk material is swapped, WITHOUT a restart. It drives the
+// reloadableTLS.reload path directly (the fsnotify watcher's debounce
+// makes a timing-based assertion flaky in CI); the listener picks up
+// the swapped cert because GetCertificate reads the holder on every
+// handshake.
+func TestCertHotReload(t *testing.T) {
+	ca := newTestCA(t)
+	dir := t.TempDir()
+	paths := writeServerCerts(t, ca, dir, "blockstor-apiserver")
+
+	reloader, err := newReloadableTLS(paths.certFile, paths.keyFile, paths.caFile)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+
+	first, err := reloader.getCertificate(nil)
+	if err != nil {
+		t.Fatalf("get initial cert: %v", err)
+	}
+
+	firstLeaf, err := x509.ParseCertificate(first.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse initial leaf: %v", err)
+	}
+
+	// Swap in a fresh cert for a different CN (so the serial/subject
+	// differs) and reload.
+	_ = writeServerCerts(t, ca, dir, "blockstor-apiserver-rotated")
+
+	err = reloader.reload()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	second, err := reloader.getCertificate(nil)
+	if err != nil {
+		t.Fatalf("get reloaded cert: %v", err)
+	}
+
+	secondLeaf, err := x509.ParseCertificate(second.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse reloaded leaf: %v", err)
+	}
+
+	if firstLeaf.SerialNumber.Cmp(secondLeaf.SerialNumber) == 0 {
+		t.Errorf("serial unchanged after reload: %s", firstLeaf.SerialNumber)
+	}
+
+	if secondLeaf.Subject.CommonName != "blockstor-apiserver-rotated" {
+		t.Errorf("CN after reload: got %q, want %q", secondLeaf.Subject.CommonName, "blockstor-apiserver-rotated")
+	}
+}
+
+// TestCertHotReloadOverWire is the end-to-end variant: a live TLS
+// listener is serving, the on-disk cert is swapped, the holder is
+// reloaded, and a fresh client connection observes the NEW leaf — all
+// without restarting the server.
+func TestCertHotReloadOverWire(t *testing.T) {
+	ca := newTestCA(t)
+	dir := t.TempDir()
+	paths := writeServerCerts(t, ca, dir, "blockstor-apiserver")
+
+	// Drive the reloader directly so we control the swap timing, and
+	// inject it into a Server we start by hand (startTLSServer builds
+	// its own reloader internally, which we can't reach).
+	tlsAddr := pickFreeAddr(t)
+	plainAddr := pickFreeAddr(t)
+
+	srv := &Server{
+		Addr: plainAddr,
+		TLS: &TLSOptions{
+			Addr:         tlsAddr,
+			CertFile:     paths.certFile,
+			KeyFile:      paths.keyFile,
+			ClientCAFile: paths.caFile,
+		},
+	}
+	srv.SetResolveHost(func(_ context.Context, _ string) ([]string, error) {
+		return []string{"127.0.0.1"}, nil
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx) }()
+
+	waitReachable(t, ctx, tlsAddr)
+
+	clientCert, clientKey := ca.issue(t, "blockstor-csi", false)
+	client := clientFor(t, ca.certPEM, clientCert, clientKey)
+
+	firstSerial := peerLeafSerial(t, client, tlsAddr)
+
+	// Rotate the on-disk material. Keep the SAME CN (the client's
+	// ServerName check still passes after rotation, exactly like a
+	// cert-manager renewal of the same Certificate) but a fresh serial
+	// so we can prove a different cert is now served. The server's
+	// fsnotify watcher picks the swap up; we poll until it does, so
+	// the assertion is "reload happened without a restart", not a
+	// fixed sleep.
+	_ = writeServerCerts(t, ca, dir, "blockstor-apiserver")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		// New connection (no keep-alive reuse) so the handshake runs
+		// against the current holder state.
+		client.CloseIdleConnections()
+
+		serial := peerLeafSerial(t, client, tlsAddr)
+		if serial != firstSerial {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("served cert serial never rotated; still %s", serial)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// peerLeafSerial opens a TLS connection via client to addr and returns
+// the serial number of the leaf certificate the server presented.
+func peerLeafSerial(t *testing.T, client *http.Client, addr string) string {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://"+addr+"/v1/controller/version", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
+		t.Fatalf("no peer certificates on response")
+	}
+
+	return resp.TLS.PeerCertificates[0].SerialNumber.String()
+}

--- a/stand/blockstor-apiserver-deploy.yaml
+++ b/stand/blockstor-apiserver-deploy.yaml
@@ -87,15 +87,36 @@ spec:
           image: __REGISTRY__/blockstor-apiserver:dev
           imagePullPolicy: Always
           args:
+            # Plain-HTTP debug listener. NOT exposed by the Service —
+            # reachable only via `kubectl port-forward` to this pod for
+            # local debugging / the `linstor` CLI during development.
             - --rest-bind-address=:3370
+            # Mutual-TLS listener. The ONLY port the Service exposes.
+            # Requires + verifies client certs against the mounted CA;
+            # hot-reloads cert/key/CA on cert-manager rotation without a
+            # restart (no reloader.stakater.com).
+            - --tls-bind-address=:3371
+            - --tls-cert-file=/etc/blockstor/tls/tls.crt
+            - --tls-key-file=/etc/blockstor/tls/tls.key
+            - --tls-client-ca-file=/etc/blockstor/tls/ca.crt
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=0
           env:
             - name: POD_NAMESPACE
               valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
           ports:
-            - {name: rest, containerPort: 3370}
+            # rest-tls is the in-cluster endpoint (Service-exposed).
+            - {name: rest-tls, containerPort: 3371}
+            # rest-debug stays pod-local (port-forward only).
+            - {name: rest-debug, containerPort: 3370}
             - {name: health, containerPort: 8081}
+          volumeMounts:
+            # cert-manager-issued serving material (tls.crt/tls.key/
+            # ca.crt). The apiserver re-reads all three on rotation via
+            # an fsnotify watch on this dir — no pod restart needed.
+            - name: api-tls
+              mountPath: /etc/blockstor/tls
+              readOnly: true
           # Bug 218: probes hit the controller-runtime manager's
           # /healthz and /readyz endpoints on the named `health`
           # port. tcpSocket on the REST port (3370) marked the pod
@@ -120,13 +141,18 @@ spec:
           resources:
             requests: {cpu: 50m, memory: 128Mi}
             limits: {cpu: 500m, memory: 512Mi}
+      volumes:
+        - name: api-tls
+          secret:
+            secretName: blockstor-apiserver-server-tls
 ---
-# Re-point the existing blockstor-controller Service so callers
-# of the merged REST endpoint (linstor-csi, piraeus-operator, the
-# `linstor` CLI) keep working — they hit the apiserver pods
-# instead of the controller. The :7000 satellite-grpc port stays
-# on the controller (retired in Phase 10.6 but the port name is
-# retained for compatibility).
+# In-cluster Service for the apiserver. mTLS-only: it exposes ONLY
+# the TLS port (3371). The plain-HTTP debug port (3370) is
+# deliberately NOT listed here — it stays reachable only via
+# `kubectl port-forward` to a pod, so nothing on the network can
+# talk plaintext to the apiserver. Clients dial
+# https://blockstor-apiserver.blockstor-system.svc:3371 presenting a
+# client cert (see blockstor-apiserver-tls.yaml).
 apiVersion: v1
 kind: Service
 metadata:
@@ -135,4 +161,4 @@ metadata:
 spec:
   selector: {app: blockstor-apiserver}
   ports:
-    - {name: rest, port: 3370, targetPort: 3370}
+    - {name: rest-tls, port: 3371, targetPort: 3371}

--- a/stand/blockstor-apiserver-tls.yaml
+++ b/stand/blockstor-apiserver-tls.yaml
@@ -1,0 +1,116 @@
+---
+# cert-manager PKI for the blockstor apiserver's mutual-TLS endpoint.
+#
+# Chain (mirrors the cozystack linstor chart's linstor-api-tls pattern):
+#   ca-bootstrapper (self-signed Issuer)
+#     └─> blockstor-api-ca (CA Certificate, 10y)
+#           └─> blockstor-api-ca (CA Issuer)
+#                 ├─> blockstor-apiserver-server  (serving cert, Service DNS SANs)
+#                 └─> blockstor-apiserver-client   (client cert for in-cluster consumers)
+#
+# The apiserver's TLS listener (RequireAndVerifyClientCert) verifies
+# every client cert against ca.crt of the server Secret, and serves
+# tls.crt/tls.key. cert-manager rotates these in place; the apiserver
+# hot-reloads them from disk WITHOUT a restart (pkg/rest/tls_reload.go)
+# — there are intentionally NO reloader.stakater.com annotations.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-bootstrapper
+  namespace: blockstor-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: blockstor-api-ca
+  namespace: blockstor-system
+spec:
+  commonName: blockstor-api-ca
+  secretName: blockstor-api-ca
+  duration: 87600h # 10 years
+  isCA: true
+  privateKey:
+    rotationPolicy: Never
+  usages:
+    - signing
+    - key encipherment
+    - cert sign
+  issuerRef:
+    name: ca-bootstrapper
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: blockstor-api-ca
+  namespace: blockstor-system
+spec:
+  ca:
+    secretName: blockstor-api-ca
+---
+# Serving certificate for the apiserver TLS listener. The dnsNames
+# cover both Service FQDNs in-cluster clients dial: blockstor-apiserver
+# (the apiserver's own Service) and blockstor-controller (the legacy
+# Service name still selecting the apiserver pods, used by linstor-csi /
+# piraeus / the `linstor` CLI port-forward). The cert-manager Secret
+# carries tls.crt, tls.key AND ca.crt — the apiserver verifies client
+# certs against that ca.crt.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: blockstor-apiserver-server
+  namespace: blockstor-system
+spec:
+  secretName: blockstor-apiserver-server-tls
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  usages:
+    - server auth
+    - digital signature
+    - key encipherment
+  dnsNames:
+    - blockstor-apiserver
+    - blockstor-apiserver.blockstor-system
+    - blockstor-apiserver.blockstor-system.svc
+    - blockstor-apiserver.blockstor-system.svc.cluster.local
+    - blockstor-controller
+    - blockstor-controller.blockstor-system
+    - blockstor-controller.blockstor-system.svc
+    - blockstor-controller.blockstor-system.svc.cluster.local
+  issuerRef:
+    name: blockstor-api-ca
+    kind: Issuer
+---
+# Client certificate for in-cluster consumers (linstor-csi,
+# piraeus-operator, drbd-reactor, affinity-controller, blockstor's own
+# Go clients, and the `linstor` CLI). Mounted into the consuming pods
+# and presented to the apiserver's RequireAndVerifyClientCert listener.
+# The Secret carries tls.crt, tls.key AND ca.crt so a consumer verifies
+# the server against the same CA.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: blockstor-apiserver-client
+  namespace: blockstor-system
+spec:
+  secretName: blockstor-apiserver-client-tls
+  commonName: blockstor-apiserver-client
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  usages:
+    - client auth
+    - digital signature
+    - key encipherment
+  issuerRef:
+    name: blockstor-api-ca
+    kind: Issuer

--- a/stand/blockstor-deploy.yaml
+++ b/stand/blockstor-deploy.yaml
@@ -106,13 +106,15 @@ metadata:
   name: blockstor-controller
   namespace: blockstor-system
 spec:
-  # Selector points at the apiserver pods so existing callers of
-  # `blockstor-controller:3370` (linstor-csi, piraeus-operator, the
-  # `linstor` CLI port-forward in tests/e2e) keep working without
-  # any URL change. The controller Deployment itself no longer
-  # serves :3370. The :7000 grpc port is legacy (Phase 10.6
-  # retired the gRPC contract); kept on the Service for now since
-  # any stale client hitting it gets a clean connection-refused.
+  # Selector points at the apiserver pods so existing callers of the
+  # `blockstor-controller` Service name (linstor-csi, piraeus-operator,
+  # the `linstor` CLI) keep resolving without a rename. mTLS-only: the
+  # Service now exposes ONLY the TLS port (3371). The plain-HTTP debug
+  # port (3370) is intentionally NOT listed — plaintext is reachable
+  # only via `kubectl port-forward` to a pod. Clients must dial
+  # https://blockstor-controller.blockstor-system.svc:3371 presenting a
+  # client cert (the serving cert SANs cover this name too — see
+  # blockstor-apiserver-tls.yaml).
   selector: {app: blockstor-apiserver}
   ports:
-    - {name: rest, port: 3370, targetPort: 3370}
+    - {name: rest-tls, port: 3371, targetPort: 3371}

--- a/stand/csi-sanity-job.yaml
+++ b/stand/csi-sanity-job.yaml
@@ -36,7 +36,14 @@ spec:
             - --linstor-endpoint=$(LS_CONTROLLERS)
           env:
             - {name: CSI_ENDPOINT,  value: "unix:///csi/csi.sock"}
-            - {name: LS_CONTROLLERS, value: "http://blockstor-controller.blockstor-system.svc:3370"}
+            # mTLS endpoint. golinstor (which linstor-csi wraps) upgrades
+            # to HTTPS and presents the client cert when LS_USER_*/
+            # LS_ROOT_CA point at PEM files. The Service exposes ONLY
+            # :3371 now, so the old http://...:3370 endpoint is gone.
+            - {name: LS_CONTROLLERS, value: "https://blockstor-controller.blockstor-system.svc:3371"}
+            - {name: LS_USER_CERTIFICATE, value: "/etc/linstor/client/tls.crt"}
+            - {name: LS_USER_KEY, value: "/etc/linstor/client/tls.key"}
+            - {name: LS_ROOT_CA, value: "/etc/linstor/client/ca.crt"}
             # Resolved from a downward-API spec.nodeName if the job
             # is scheduled onto a worker, otherwise hard-coded to a
             # known stand worker. The recorder e2e6 stand uses
@@ -47,6 +54,11 @@ spec:
                 fieldRef: {fieldPath: spec.nodeName}
           volumeMounts:
             - {name: csi, mountPath: /csi}
+            # cert-manager-issued client cert (tls.crt/tls.key/ca.crt)
+            # presented to the apiserver's RequireAndVerifyClientCert
+            # listener. No reloader.stakater.com — the Job is short-lived
+            # so cert rotation is out of scope for it.
+            - {name: client-tls, mountPath: /etc/linstor/client, readOnly: true}
 
         - name: csi-sanity
           image: golang:1.25
@@ -80,6 +92,9 @@ spec:
         - {name: csi, emptyDir: {}}
         - name: scparams
           configMap: {name: csi-sanity-params}
+        - name: client-tls
+          secret:
+            secretName: blockstor-apiserver-client-tls
 
 ---
 apiVersion: v1

--- a/stand/install-blockstor.sh
+++ b/stand/install-blockstor.sh
@@ -76,6 +76,20 @@ echo ">> using host registry at $REGISTRY"
 echo ">> apply CRDs"
 kubectl apply -f "$REPO_ROOT/config/crd/bases/" 2>&1 | tail -5
 
+# cert-manager is required for the apiserver's mTLS PKI (Issuer +
+# Certificates in blockstor-apiserver-tls.yaml). piraeus-operator v2
+# already pulls it in on this stand, so in the normal `make piraeus`
+# → `make blockstor` flow it is present. Install it on demand if a
+# bare cluster runs blockstor without piraeus first.
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-v1.16.2}
+if ! kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+    echo ">> cert-manager not found; installing $CERT_MANAGER_VERSION"
+    kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+    kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+else
+    echo ">> cert-manager already present"
+fi
+
 # Bootstrap blockstor Node CRDs from k8s worker nodes so the
 # satellite reconciler's peer-resolution path has an address per
 # node — otherwise multi-replica .res files render a 0.0.0.0
@@ -104,6 +118,18 @@ done
 
 echo ">> apply controller + RBAC"
 render "$REPO_ROOT/stand/blockstor-deploy.yaml" | kubectl apply -f - 2>&1 | tail -5
+
+# Apply the cert-manager PKI BEFORE the apiserver Deployment so the
+# server cert Secret (blockstor-apiserver-server-tls) exists by the
+# time the apiserver pod tries to mount it. cert-manager itself is a
+# stand prerequisite (install the cert-manager release before
+# install-blockstor.sh, same as piraeus-operator expects it present).
+echo ">> apply apiserver mTLS PKI (cert-manager Issuer + Certificates)"
+kubectl apply -f "$REPO_ROOT/stand/blockstor-apiserver-tls.yaml" 2>&1 | tail -5
+echo ">> wait for apiserver server + client certs to be issued"
+kubectl -n blockstor-system wait --for=condition=Ready \
+    certificate/blockstor-apiserver-server certificate/blockstor-apiserver-client \
+    --timeout=120s
 
 echo ">> apply apiserver + RBAC"
 render "$REPO_ROOT/stand/blockstor-apiserver-deploy.yaml" | kubectl apply -f - 2>&1 | tail -5

--- a/stand/validate-linstor-cli.sh
+++ b/stand/validate-linstor-cli.sh
@@ -37,7 +37,11 @@ source "$REPO_ROOT/tests/e2e/lib.sh"
 require_workers 3
 
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-controller "$PF_PORT":3370 \
+# The in-cluster Service is mTLS-only (port 3371). For the local CLI
+# validation we port-forward straight to the apiserver pod's plain-HTTP
+# debug port (3370), which is the intended kubectl-port-forward path —
+# it is NOT exposed on the Service.
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/validate-linstor-cli-pf.log 2>&1 &
 PF_PID=$!
 trap 'kill $PF_PID 2>/dev/null || true; \

--- a/tests/e2e/affinity-controller.sh
+++ b/tests/e2e/affinity-controller.sh
@@ -78,7 +78,7 @@ N2=$WORKER_2
 N3=$WORKER_3
 
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/affinity-controller-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/cli-matrix/lib.sh
+++ b/tests/e2e/cli-matrix/lib.sh
@@ -49,7 +49,7 @@ linstor_cli_setup() {
 
     LCTL_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
 
-    kubectl -n "$NS" port-forward svc/blockstor-apiserver "$LCTL_PORT":3370 \
+    kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$LCTL_PORT":3370 \
         >/tmp/cli-matrix-pf.log 2>&1 &
     LCTL_PF_PID=$!
 

--- a/tests/e2e/client-compat.sh
+++ b/tests/e2e/client-compat.sh
@@ -49,7 +49,7 @@ RD_HAPPY=cc-happy
 
 # port-forward to the apiserver.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-apiserver "$PF_PORT":3370 \
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/client-compat-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/lc-rd-delete-churn.sh
+++ b/tests/e2e/lc-rd-delete-churn.sh
@@ -46,7 +46,7 @@ UP_TIMEOUT=${UP_TIMEOUT:-180}
 DEL_TIMEOUT=${DEL_TIMEOUT:-60}
 
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/lc-rd-churn-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -696,7 +696,7 @@ rest_post() {
     # rest_post would bind a stale socket and curl would error 22.
     local lport
     lport=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-    kubectl -n "$NS" port-forward svc/blockstor-controller "${lport}:3370" >/dev/null 2>&1 &
+    kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${lport}:3370" >/dev/null 2>&1 &
     local pf=$!
 
     _wait_port_forward "$lport" "$pf"
@@ -717,7 +717,7 @@ rest_put() {
 
     local lport
     lport=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-    kubectl -n "$NS" port-forward svc/blockstor-controller "${lport}:3370" >/dev/null 2>&1 &
+    kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${lport}:3370" >/dev/null 2>&1 &
     local pf=$!
 
     _wait_port_forward "$lport" "$pf"

--- a/tests/e2e/lifecycle-toggle-migrate.sh
+++ b/tests/e2e/lifecycle-toggle-migrate.sh
@@ -44,7 +44,7 @@ require_workers 3
 RD=e2e-toggle-migrate
 
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/lifecycle-toggle-migrate-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/lifecycle-toggle-retry.sh
+++ b/tests/e2e/lifecycle-toggle-retry.sh
@@ -196,7 +196,7 @@ sleep 5
 
 echo ">> POST toggle-disk N3 → ${BROKEN_POOL} (expect stuck — VG is gone)"
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/4.11-pf.log 2>&1 &
 PF_PID=$!
 trap 'kill $PF_PID 2>/dev/null || true; cleanup' EXIT

--- a/tests/e2e/node-replace-hardware.sh
+++ b/tests/e2e/node-replace-hardware.sh
@@ -59,7 +59,7 @@ EVICT_LABEL=blockstor.io/replace-hw-test
 POOL_NAME=stand
 
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/node-replace-hw-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/observability-capacity-correlation.sh
+++ b/tests/e2e/observability-capacity-correlation.sh
@@ -95,7 +95,7 @@ PROBE_RD=e2e-cap-probe
 
 # Port-forward to blockstor's REST surface for `linstor` CLI calls.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/cap-corr-pf.log 2>&1 &
 PF_PID=$!
 
@@ -339,8 +339,11 @@ fi
 # --- Phase 2 (Level 1): apply a 1Gi PVC ---------------------------------
 echo ">> phase 2 (Level 1): apply 1Gi PVC, expect Pending + capacity event"
 
-# Wire linstor-csi at blockstor's apiserver (same dance as observability-three-way).
-BLOCKSTOR_URL="http://blockstor-apiserver.blockstor-system.svc:3370"
+# Wire linstor-csi at blockstor's apiserver (same dance as
+# observability-three-way). mTLS endpoint (Service is TLS-only now);
+# piraeus must also present the client cert — validated on the stand as
+# a pre-merge follow-up (see the PR's stand-validation note).
+BLOCKSTOR_URL="https://blockstor-apiserver.blockstor-system.svc:3371"
 CUR_URL=$(kubectl get linstorcluster linstorcluster \
     -o jsonpath='{.spec.externalController.url}' 2>/dev/null || true)
 if [[ "$CUR_URL" != "$BLOCKSTOR_URL" ]]; then

--- a/tests/e2e/observability-destructive-walk.sh
+++ b/tests/e2e/observability-destructive-walk.sh
@@ -83,7 +83,7 @@ N3=$WORKER_3
 
 # --- linstor CLI port-forward against blockstor-apiserver ---------------
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/7-13-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/observability-linstor-node-bridge.sh
+++ b/tests/e2e/observability-linstor-node-bridge.sh
@@ -58,7 +58,7 @@ HEAL_TIMEOUT=60
 # but we still go through the Service. Random ephemeral port so this
 # scenario can co-run with sibling iter scenarios on the same host.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "${PF_PORT}:3370" \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${PF_PORT}:3370" \
     >/tmp/bridge-test-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/observability-three-way.sh
+++ b/tests/e2e/observability-three-way.sh
@@ -54,7 +54,7 @@ SC=e2e-three-way-sc
 
 # port-forward blockstor-controller:3370 → random local port for `linstor` CLI.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/three-way-pf.log 2>&1 &
 PF_PID=$!
 
@@ -87,7 +87,14 @@ LCTL_M=(linstor --controllers "http://localhost:$PF_PORT" --machine-readable)
 # fix per the Phase 7.9 scenario design: the test exercises
 # blockstor's three-way observability invariant (PVC ↔ Resource CRD
 # ↔ .res), so the CSI provisioning request MUST land on blockstor.
-BLOCKSTOR_URL="http://blockstor-apiserver.blockstor-system.svc:3370"
+# mTLS endpoint (the Service is TLS-only now). Pointing linstor-csi
+# here is necessary but NOT sufficient: piraeus must also mount the
+# blockstor-apiserver-client-tls cert into the CSI pods and present it
+# (LinstorCluster apiTLS / external-controller client-secret wiring).
+# That wiring is piraeus-operator-version-specific and is validated on
+# the stand as a pre-merge follow-up — see the PR's stand-validation
+# note. The URL bump keeps this script honest about the new endpoint.
+BLOCKSTOR_URL="https://blockstor-apiserver.blockstor-system.svc:3371"
 CUR_URL=$(kubectl get linstorcluster linstorcluster \
     -o jsonpath='{.spec.externalController.url}' 2>/dev/null || true)
 if [[ "$CUR_URL" != "$BLOCKSTOR_URL" ]]; then

--- a/tests/e2e/recovery-auto-place-real-drbd.sh
+++ b/tests/e2e/recovery-auto-place-real-drbd.sh
@@ -83,7 +83,7 @@ SETTLE_DEADLINE_SEC=120
 # Port-forward to the apiserver — same pattern as client-compat.sh
 # lines 50-72.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-apiserver "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/recovery-auto-place-real-drbd-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/recovery-bitmap-drop.sh
+++ b/tests/e2e/recovery-bitmap-drop.sh
@@ -178,7 +178,7 @@ echo "   RD UpToDate on $N1 and $N2"
 # Open a controller port-forward for the toggle-disk REST calls.
 # Same pattern as recovery-port-collision.sh / lifecycle-toggle-retry.sh.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/recovery-bitmap-drop-pf.log 2>&1 &
 PF_PID=$!
 trap 'kill "$PF_PID" 2>/dev/null || true; wait "$PF_PID" 2>/dev/null || true; delete_rd "$RD"' EXIT

--- a/tests/e2e/recovery-deleting-convert.sh
+++ b/tests/e2e/recovery-deleting-convert.sh
@@ -123,7 +123,7 @@ trap cleanup EXIT
 # ---------------------------------------------------------------------
 
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "${PF_PORT}":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${PF_PORT}":3370 \
     >/tmp/recovery-deleting-convert-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/recovery-inconsistent-blocking.sh
+++ b/tests/e2e/recovery-inconsistent-blocking.sh
@@ -347,7 +347,7 @@ fi
 
 echo ">> port-forward blockstor-controller for linstor CLI"
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "${PF_PORT}":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${PF_PORT}":3370 \
     >/tmp/${RD}-pf.log 2>&1 &
 PF_PID=$!
 for _ in $(seq 1 20); do

--- a/tests/e2e/recovery-late-vd-real-drbd.sh
+++ b/tests/e2e/recovery-late-vd-real-drbd.sh
@@ -61,7 +61,7 @@ RD=bug79-e2e
 # Random ephemeral port so back-to-back runs against the same stand
 # don't collide on a stale TIME_WAIT socket from a previous attempt.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-apiserver "$PF_PORT":3370 \
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/recovery-late-vd-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/recovery-node-id-mismatch.sh
+++ b/tests/e2e/recovery-node-id-mismatch.sh
@@ -121,7 +121,7 @@ EOF
 # autoplace (now) and the linstor CLI recovery (later). Random
 # ephemeral port; same dance as linstor-cli-replica-move.sh.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "${PF_PORT}:3370" \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${PF_PORT}:3370" \
     >/tmp/recovery-node-id-pf.log 2>&1 &
 PF_PID=$!
 for _ in $(seq 1 30); do

--- a/tests/e2e/recovery-poolmissing-real-zfs.sh
+++ b/tests/e2e/recovery-poolmissing-real-zfs.sh
@@ -96,7 +96,7 @@ MASK_STOR_POOL_HEX=0x0000000000140000
 # Port-forward to apiserver — same dance as client-compat.sh.
 # ----------------------------------------------------------------
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-apiserver "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/recovery-poolmissing-real-zfs-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/recovery-port-collision.sh
+++ b/tests/e2e/recovery-port-collision.sh
@@ -73,7 +73,7 @@ NUM_RDS=10
 # Random ephemeral port for the controller port-forward — parallel
 # iters on the same host would collide on a fixed port.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-apiserver "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/recovery-port-collision-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/recovery-suspended-quorum.sh
+++ b/tests/e2e/recovery-suspended-quorum.sh
@@ -97,7 +97,7 @@ N3=$WORKER_3
 # Random ephemeral port — parallel iters on the same host would
 # otherwise collide on a fixed port.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-apiserver "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/recovery-suspended-quorum-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/resize-no-drbd.sh
+++ b/tests/e2e/resize-no-drbd.sh
@@ -92,7 +92,7 @@ echo "   md5_pre=$md5_pre"
 
 echo ">> PUT size_kib=${SIZE_GROWN_KIB} via REST"
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/resize-no-drbd-pf.log 2>&1 &
 PF_PID=$!
 trap 'kill $PF_PID 2>/dev/null || true; cleanup' EXIT

--- a/tests/e2e/state-inconsistent-mid-sync.sh
+++ b/tests/e2e/state-inconsistent-mid-sync.sh
@@ -89,7 +89,7 @@ PF_LOCAL_PORT=33371
 # port-forward blockstor-apiserver:3370 → local 33371. Linstor CLI
 # wants the REST front; the apiserver Service is the right target on
 # the Phase-11.x split (controller has --enable-rest-api=false).
-kubectl -n "$NS" port-forward svc/blockstor-apiserver \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver \
     "$PF_LOCAL_PORT":3370 >/tmp/state-inconsistent-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/state-offline-unknown.sh
+++ b/tests/e2e/state-offline-unknown.sh
@@ -72,7 +72,7 @@ HEAL_TIMEOUT=180      # satellite startup + heartbeat (max 40 s for the
 
 # --- REST port-forward (random ephemeral port for parallel-iter safety) ---
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n "$NS" port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/state-offline-unknown-pf.log 2>&1 &
 PF_PID=$!
 

--- a/tests/e2e/toggle-disk.sh
+++ b/tests/e2e/toggle-disk.sh
@@ -71,7 +71,7 @@ wait_uptodate "$RD" "$N1" "$N2"
 # free local port — distroless controller image has no curl, so
 # `kubectl exec` would fail.
 PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
-kubectl -n blockstor-system port-forward svc/blockstor-controller "$PF_PORT":3370 \
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
     >/tmp/toggle-disk-pf.log 2>&1 &
 PF_PID=$!
 trap 'kill $PF_PID 2>/dev/null || true; delete_rd "$RD"' EXIT


### PR DESCRIPTION
## What

Make every in-cluster client talk to the blockstor apiserver over **mutual TLS**, while keeping a plain-HTTP path reachable only via `kubectl port-forward` for local debugging.

## Why

The apiserver REST endpoint served plain HTTP on a Service-exposed port, so any workload on the pod network could read/write the LINSTOR control plane unauthenticated. This wires mTLS end to end: the server requires and verifies client certificates, and in-cluster consumers present a cert-manager-issued client cert.

## TLS listener + mTLS

- `pkg/rest`: `Server.Start` now brings up TWO listeners — a plain-HTTP debug listener on `--rest-bind-address` (`:3370`) and, when `--tls-*` flags are set, a mutual-TLS listener on `--tls-bind-address` (`:3371`, the upstream LINSTOR HTTPS port). Both share one handler/middleware chain.
- The TLS listener uses `tls.RequireAndVerifyClientCert` and validates every client cert against the configured client-CA bundle.
- The plain-HTTP listener stays on its own port and is intentionally **not** exposed by the in-cluster Service — it is reachable only via `kubectl port-forward` to the pod, so the `linstor` CLI debugging flow during development still works.

## Certificate hot-reload (race-safety)

- `pkg/rest/tls_reload.go` implements a `reloadableTLS` holder wired into `tls.Config` via `GetCertificate` and `GetConfigForClient`, plus a reloading client-CA `x509.CertPool`.
- Handshake hooks read an atomically-swapped pair of pointers under an `RLock`; the reload path parses fresh material **outside** the lock and swaps the pointers under the write lock, so a slow disk read never blocks in-flight handshakes.
- Reload is driven by an fsnotify watch on the mounted secret directory (watching the dir, not the symlinked files, because the kubelet swaps the whole `..data` mount atomically) with a debounce for the multi-event swap, plus a periodic poll fallback. A failed mid-rotation read keeps the previous good material — the server never serves a nil cert.
- No dependency on `reloader.stakater.com`.

## Clients wired

- **blockstor's own Go clients** — `pkg/clienttls` builds a mutual-TLS `http.Client` from mounted cert/key/CA files, honouring the standard LINSTOR `LS_USER_CERTIFICATE` / `LS_USER_KEY` / `LS_ROOT_CA` env contract (so the same material wires golinstor-based consumers too). Note: blockstor's satellite/controller/CSI components read CRDs directly via the Kubernetes API and do not dial the apiserver REST over the network; the apiserver REST consumers are the external components below plus any future internal HTTP client.
- **linstor-csi** (csi-sanity Job, and piraeus's CSI via `LinstorCluster.spec.externalController`) — pointed at `https://...:3371`, with the cert-manager client Secret mounted and `LS_USER_*`/`LS_ROOT_CA` set.
- **piraeus-operator / drbd-reactor / affinity-controller** — these live in the cozystack chart, not this repo. The serving cert SANs and the client Secret are in place; the operator-side `apiTLS` / client-secret mount is version-specific and is part of the stand-validation follow-up below.

## Service TLS-only

Both Services (`blockstor-apiserver` and the legacy `blockstor-controller` alias selecting the apiserver pods) now expose **only** the TLS port `3371`. The plain-HTTP port `3370` is removed from the Services; it stays on the pod for `kubectl port-forward` only. All e2e/operator-harness local-debug port-forwards now target the apiserver Deployment's debug port directly.

## cert-manager objects

`stand/blockstor-apiserver-tls.yaml` adds a self-signed bootstrap Issuer, a 10-year CA Certificate + CA Issuer, a server Certificate (with every in-cluster Service DNS SAN) and a client Certificate. `install-blockstor.sh` applies the PKI before the apiserver Deployment and ensures cert-manager is present. No `reloader.stakater.com` annotations anywhere.

## Tests

- `pkg/rest/tls_test.go`: client without a cert rejected; client with a valid cert (and correct CA) succeeds; client cert from an unknown CA rejected; plain-HTTP debug listener still serves on its own port; cert hot-reload at the holder level and end-to-end over the wire (serving cert serial rotates without a restart, observed by a fresh handshake).
- `pkg/clienttls/clienttls_test.go`: builds a valid client TLS config; rejects an empty CA bundle; honours the `LS_*` env contract.

`go build ./...`, `go test ./...`, `gofmt -l`, and `golangci-lint run` on the changed packages are clean. (Pre-existing goconst findings in `internal/controller/resource_controller.go` are unrelated and untouched by this branch.) This repo ships kustomize + raw stand manifests rather than a Helm chart, so `helm lint`/`helm template` is N/A here; the manifests were validated with a YAML parser.

## Stand validation pending (required pre-merge follow-up)

Live-stand validation was intentionally NOT run (another agent is using the hardware stand). Before merge, on a real Talos+QEMU stand:

- confirm linstor-csi, piraeus-operator, drbd-reactor and affinity-controller actually connect over mTLS (the piraeus-side client-cert mount via `LinstorCluster` apiTLS is version-specific and needs to be wired/verified there);
- observe a live cert-manager rotation and confirm the apiserver picks up the new serving cert/CA without a restart and without dropping in-flight clients.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mutual TLS encryption for the API server with automatic certificate hot-reload, enabling secure in-cluster communication without server restarts
  * Dual-listener architecture supporting encrypted TLS endpoints and debug HTTP ports

* **Chores**
  * Updated GitHub Actions to Node.js 24
  * Refreshed Kubernetes deployment manifests and e2e test infrastructure for TLS integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->