### PR TITLE
fix(drbd): reach initial UpToDate via set-gi instead of primary --force (skip fresh-thin sync)

### DIFF
--- a/internal/controller/resource_controller.go
+++ b/internal/controller/resource_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"slices"
+	"strings"
 	"sync"
 
 	cerrors "github.com/cockroachdb/errors"
@@ -960,9 +961,19 @@ func pickSeedFromPeers(peers []blockstoriov1alpha1.Resource, targetName string, 
 // mean the peer carries real data with a real Current UUID — a fresh
 // local replica must SyncTarget from it (full resync) rather than skip
 // sync via a seeded GI. Mirrors dispatcher.anyDiskfulPeerHasData so the
-// controller-side seed gate and the satellite-side resolveSeedGI gate
-// agree on the same "day0 vs data-peer-exists" discriminator. Diskless
-// peers never count (no backing data to seed from).
+// controller-side seed gate and the satellite-side resolveVolumeSeed
+// gate agree on the same discriminator. Diskless peers never count.
+//
+// Day0-seeded fresh-sibling exception (staggered multi-replica create):
+// a peer whose data-state volume reports a CurrentGI equal to the
+// deterministic drbd.Day0GIFor value is a never-written day0 sibling —
+// NOT a data source — so it does not count and the later replica may
+// also day0-skip. The elected winner now seeds current=day0 too, so a
+// fresh UpToDate winner reports CurrentGI==day0 and is correctly seen
+// as a sibling. A real relocate survivor mints a runtime current-UUID
+// that cannot equal the deterministic day0 (2^-64 collision) so it is
+// still counted; a data-state volume with an empty / not-yet-observed
+// CurrentGI is treated conservatively as data-bearing.
 func anyDataBearingDiskfulPeer(peers []blockstoriov1alpha1.Resource, targetName string) bool {
 	for i := range peers {
 		if peers[i].Name == targetName {
@@ -973,12 +984,19 @@ func anyDataBearingDiskfulPeer(peers []blockstoriov1alpha1.Resource, targetName 
 			continue
 		}
 
+		rdName := peers[i].Spec.ResourceDefinitionName
+
 		for j := range peers[i].Status.Volumes {
-			switch drbd.DiskState(peers[i].Status.Volumes[j].DiskState) {
+			vol := &peers[i].Status.Volumes[j]
+
+			switch drbd.DiskState(vol.DiskState) {
 			case drbd.DiskStateUpToDate,
 				drbd.DiskStateConsistent,
 				drbd.DiskStateOutdated:
-				return true
+				if !isDay0SeededDiskfulVolume(rdName, vol) {
+					return true
+				}
+				// Fresh day0-seeded sibling, never written — keep scanning.
 			case drbd.DiskStateDiskless,
 				drbd.DiskStateAttaching,
 				drbd.DiskStateDetaching,
@@ -994,6 +1012,20 @@ func anyDataBearingDiskfulPeer(peers []blockstoriov1alpha1.Resource, targetName 
 	}
 
 	return false
+}
+
+// isDay0SeededDiskfulVolume reports whether a peer's data-state volume
+// carries nothing but the deterministic day0 GI — a fresh, never-
+// written sibling that is NOT a data source. Empty CurrentGI returns
+// false (conservative: not provably day0 ⇒ treat as data-bearing).
+// Controller twin of dispatcher.isDay0SeededVolume; both compare
+// against the single drbd.Day0GIFor derivation the satellite stamps.
+func isDay0SeededDiskfulVolume(rdName string, vol *blockstoriov1alpha1.ResourceVolumeStatus) bool {
+	if vol.CurrentGI == "" {
+		return false
+	}
+
+	return strings.EqualFold(vol.CurrentGI, drbd.Day0GIFor(rdName, vol.VolumeNumber))
 }
 
 // volumeCurrentGI returns the CurrentGI for the given volume number

--- a/internal/controller/seed_gi_gate_test.go
+++ b/internal/controller/seed_gi_gate_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	"github.com/cozystack/blockstor/pkg/drbd"
 )
 
 // TestAnyDataBearingDiskfulPeer pins the seed-GI data-integrity
@@ -50,6 +51,21 @@ func TestAnyDataBearingDiskfulPeer(t *testing.T) {
 
 		return r
 	}
+
+	// withGI sets the RD name + observed CurrentGI so the day0-sibling
+	// discriminator (isDay0SeededDiskfulVolume) has a real RD to derive
+	// day0 from.
+	withGI := func(name, rd, state, gi string) blockstoriov1alpha1.Resource {
+		r := diskful(name, state)
+		r.Spec.ResourceDefinitionName = rd
+		r.Status.Volumes[0].CurrentGI = gi
+
+		return r
+	}
+
+	const gateRD = "rd"
+
+	day0 := drbd.Day0GIFor(gateRD, 0)
 
 	cases := []struct {
 		name  string
@@ -97,6 +113,27 @@ func TestAnyDataBearingDiskfulPeer(t *testing.T) {
 			// a genuine PEER blocks the seed. Excluded by name.
 			peers: []blockstoriov1alpha1.Resource{diskful("rd.n-self", "UpToDate")},
 			want:  false,
+		},
+		{
+			// Day0-seeded fresh sibling (staggered create): an UpToDate
+			// peer whose CurrentGI is the deterministic day0 value is a
+			// never-written sibling, NOT a data source.
+			name:  "day0-sibling-uptodate-not-data",
+			peers: []blockstoriov1alpha1.Resource{withGI("rd.n-old", gateRD, "UpToDate", day0)},
+			want:  false,
+		},
+		{
+			// A real relocate survivor advanced its current-UUID past
+			// day0 on first write → still counts as data-bearing.
+			name:  "advanced-current-is-data",
+			peers: []blockstoriov1alpha1.Resource{withGI("rd.n-old", gateRD, "UpToDate", "DEADBEEFCAFE0000")},
+			want:  true,
+		},
+		{
+			// Empty CurrentGI on a data-state peer → conservative.
+			name:  "empty-gi-uptodate-conservative",
+			peers: []blockstoriov1alpha1.Resource{withGI("rd.n-old", gateRD, "UpToDate", "")},
+			want:  true,
 		},
 	}
 

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -621,22 +621,43 @@ func lookupNetInterfaceAddress(nodeName, ifaceName string, nodes []blockstoriov1
 // at all until the observer reports), so a genuinely-fresh RD passes
 // this gate and still gets its day0 skip-sync + force-primary seed.
 //
+// Day0-seeded fresh-sibling exception (staggered multi-replica create):
+// a peer whose data-state volume reports a CurrentGI equal to the
+// deterministic drbd.Day0GIFor value is a never-written day0 sibling —
+// NOT a data source. Without this exception, a staggered create has the
+// first replica reach UpToDate via its day0 set-gi seed BEFORE the
+// second replica applies; the gate would then read that fresh sibling
+// as data-bearing, deny the second replica its own day0 skip, and force
+// a needless SyncTarget (and veto the seed-primary, risking the Bug 366
+// recovery-promote wedge). A real relocate survivor mints a runtime
+// current-UUID that cannot equal the deterministic day0 (2^-64
+// collision), so it is still counted; a data-state volume with an empty
+// / not-yet-observed CurrentGI is treated conservatively as
+// data-bearing.
+//
 // Diskless peers never count: they have no backing data to seed from.
 // Used both to suppress the seed-primary on a relocate (BuildDesired's
 // auto-primary election) AND to gate the day0/peer GI-seed in the
-// satellite (threaded via DesiredResource.PeerHasData → resolveSeedGI).
+// satellite (threaded via DesiredResource.PeerHasData → resolveVolumeSeed).
 func anyDiskfulPeerHasData(peers []blockstoriov1alpha1.Resource) bool {
 	for i := range peers {
 		if slices.Contains(peers[i].Spec.Flags, apiv1.ResourceFlagDiskless) {
 			continue
 		}
 
+		rdName := peers[i].Spec.ResourceDefinitionName
+
 		for j := range peers[i].Status.Volumes {
-			switch drbd.DiskState(peers[i].Status.Volumes[j].DiskState) {
+			vol := &peers[i].Status.Volumes[j]
+
+			switch drbd.DiskState(vol.DiskState) {
 			case drbd.DiskStateUpToDate,
 				drbd.DiskStateConsistent,
 				drbd.DiskStateOutdated:
-				return true
+				if !isDay0SeededVolume(rdName, vol) {
+					return true
+				}
+				// Fresh day0-seeded sibling, never written — keep scanning.
 			case drbd.DiskStateDiskless,
 				drbd.DiskStateAttaching,
 				drbd.DiskStateDetaching,
@@ -652,6 +673,20 @@ func anyDiskfulPeerHasData(peers []blockstoriov1alpha1.Resource) bool {
 	}
 
 	return false
+}
+
+// isDay0SeededVolume reports whether a peer's data-state volume carries
+// nothing but the deterministic day0 GI — a fresh, never-written
+// sibling that is NOT a data source. An empty CurrentGI returns false
+// (conservative: not provably day0 ⇒ treat as data-bearing). Compares
+// against the single drbd.Day0GIFor derivation the satellite stamps, so
+// this gate and the satellite-side seed agree exactly.
+func isDay0SeededVolume(rdName string, vol *blockstoriov1alpha1.ResourceVolumeStatus) bool {
+	if vol.CurrentGI == "" {
+		return false
+	}
+
+	return strings.EqualFold(vol.CurrentGI, drbd.Day0GIFor(rdName, vol.VolumeNumber))
 }
 
 // lowestDiskfulID picks the smallest allocated node-id among the

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -23,6 +23,7 @@ import (
 
 	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
 	"github.com/cozystack/blockstor/pkg/dispatcher"
+	"github.com/cozystack/blockstor/pkg/drbd"
 )
 
 // TestExternalMetadataRouting: scenario 6.18 (StorPoolNameDrbdMeta).
@@ -1311,17 +1312,20 @@ func TestPeerHasDataGatesSeed(t *testing.T) {
 
 	id := func(v int32) *int32 { return &v }
 
-	withState := func(r *blockstoriov1alpha1.Resource, state string) *blockstoriov1alpha1.Resource {
+	withState := func(r *blockstoriov1alpha1.Resource, state, currentGI string) *blockstoriov1alpha1.Resource {
 		r.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
-			{VolumeNumber: 0, DiskState: state},
+			{VolumeNumber: 0, DiskState: state, CurrentGI: currentGI},
 		}
 
 		return r
 	}
 
+	day0 := drbd.Day0GIFor(rdName, 0)
+
 	cases := []struct {
 		name      string
 		peerState string
+		currentGI string
 		diskless  bool
 		want      bool
 	}{
@@ -1331,6 +1335,17 @@ func TestPeerHasDataGatesSeed(t *testing.T) {
 		{name: "data-consistent", peerState: "Consistent", want: true},
 		{name: "data-outdated", peerState: "Outdated", want: true},
 		{name: "diskless-uptodate-ignored", peerState: "UpToDate", diskless: true, want: false},
+		// Day0-seeded fresh sibling (staggered create): an UpToDate peer
+		// whose observed CurrentGI is the deterministic day0 value is a
+		// never-written sibling, NOT a data source → the late replica may
+		// also day0-skip.
+		{name: "day0-sibling-uptodate-not-data", peerState: "UpToDate", currentGI: day0, want: false},
+		{name: "day0-sibling-consistent-not-data", peerState: "Consistent", currentGI: day0, want: false},
+		// A real relocate survivor advanced its current-UUID past day0
+		// on first write → still counts as data-bearing.
+		{name: "advanced-current-is-data", peerState: "UpToDate", currentGI: "DEADBEEFCAFE0000", want: true},
+		// Empty CurrentGI on a data-state peer → conservative: data-bearing.
+		{name: "empty-gi-uptodate-conservative", peerState: "UpToDate", currentGI: "", want: true},
 	}
 
 	for _, tc := range cases {
@@ -1347,7 +1362,7 @@ func TestPeerHasDataGatesSeed(t *testing.T) {
 			}
 
 			if tc.peerState != "" {
-				withState(peer, tc.peerState)
+				withState(peer, tc.peerState, tc.currentGI)
 			}
 
 			got := dispatcher.BuildDesired(target, []blockstoriov1alpha1.Resource{*peer}, nil, nil, rd, nil)

--- a/pkg/drbd/drbdadm.go
+++ b/pkg/drbd/drbdadm.go
@@ -297,8 +297,28 @@ func (a *Adm) Resize(ctx context.Context, resource string) error {
 // pinned end-to-end in pkg/satellite/reconciler_drbd_test.go's
 // first-activation case.
 func (a *Adm) SetGI(ctx context.Context, resource string, volume int32, device string, peerNodeID int32, peerCurrentGI string) error {
-	target := fmt.Sprintf("%s/%d", resource, volume)
 	gi := fmt.Sprintf("%s:%s:0:0", peerCurrentGI, peerCurrentGI)
+
+	return a.SetGIString(ctx, resource, volume, device, peerNodeID, gi)
+}
+
+// SetGIString is the general form of SetGI: it stamps an arbitrary,
+// already-rendered GI string into the per-node-id v09 metadata slot.
+// SetGI is the special case where current == bitmap == peerCurrentGI
+// with no flags (the all-day0 skip-init-sync / SeedFromGI shape).
+//
+// Used by the satellite to reach the initial UpToDate state by
+// writing metadata directly (the elected winner's local slot carries
+// a random current-UUID + day0 bitmap-base + Consistent + UpToDate;
+// the winner's peer slots carry day0 bitmap-base only) instead of
+// force-promoting the device, which would mint a divergent current-
+// UUID and force a full initial sync. Build the GI string with
+// (GISeed).String() so the field/flag layout stays in one place.
+//
+// Same call-ordering contract as SetGI: AFTER create-md, BEFORE
+// drbdadm up. `--node-id` is mandatory on DRBD 9.2+.
+func (a *Adm) SetGIString(ctx context.Context, resource string, volume int32, device string, peerNodeID int32, gi string) error {
+	target := fmt.Sprintf("%s/%d", resource, volume)
 
 	_, err := a.exec.Run(ctx,
 		"drbdmeta", "--force", target, "v09", device, "internal",
@@ -581,12 +601,42 @@ func (a *Adm) GetGI(ctx context.Context, resource string, volume int32, device s
 
 	out, err := a.exec.Run(ctx,
 		"drbdmeta", "--force", target, "v09", device, "internal",
-		"get-gi")
+		"get-gi", "--node-id", "0")
 	if err != nil {
 		return "", errors.Wrapf(err, "drbdmeta get-gi %s", target)
 	}
 
 	return strings.TrimSpace(string(out)), nil
+}
+
+// CurrentGI returns just the current-UUID (the first colon field of
+// the GI tuple) for one volume, read from on-disk metadata via
+// GetGI. Empty string (not an error) when the tuple can't be parsed,
+// so callers can leave an observed CurrentGI unclaimed and keep the
+// seed-safety gate conservative.
+//
+// Why the observer needs this: on DRBD 9.3.2 `drbdsetup events2
+// --full` / `status --json` do NOT emit the current-uuid on device
+// frames, so the events2-sourced CurrentGI is always empty there. The
+// seed-safety gates' day0-sibling discriminator (isDay0SeededVolume)
+// compares a peer's observed CurrentGI against the deterministic day0
+// value to let a staggered late replica skip the initial sync;
+// without an observed CurrentGI it can never fire. The `get-gi
+// --node-id 0` read works on an active (kernel-attached) device via
+// `--force`; the device-level current-UUID is the same in every
+// node-id slot, so node-id 0 is representative.
+func (a *Adm) CurrentGI(ctx context.Context, resource string, volume int32, device string) (string, error) {
+	tuple, err := a.GetGI(ctx, resource, volume, device)
+	if err != nil {
+		return "", err
+	}
+
+	current, _, found := strings.Cut(tuple, ":")
+	if !found || current == "" {
+		return "", nil
+	}
+
+	return strings.ToUpper(current), nil
 }
 
 // StatusResources runs `drbdsetup status` and returns the names of

--- a/pkg/drbd/drbdadm_p2_test.go
+++ b/pkg/drbd/drbdadm_p2_test.go
@@ -216,7 +216,10 @@ func TestAdmShowGIInvokesDrbdmeta(t *testing.T) {
 // pick a survivor, write with SetGI on each peer.
 func TestAdmGetGIInvokesDrbdmeta(t *testing.T) {
 	fx := storage.NewFakeExec()
-	fx.Expect("drbdmeta --force pvc-1/0 v09 /dev/dm-3 internal get-gi", storage.FakeResponse{
+	// `--node-id 0` is mandatory on DRBD 9.2+/9.3 ("get-gi requires the
+	// --node-id option"); the device-level current-UUID is identical in
+	// every node-id slot so 0 is representative.
+	fx.Expect("drbdmeta --force pvc-1/0 v09 /dev/dm-3 internal get-gi --node-id 0", storage.FakeResponse{
 		Stdout: []byte("78A0DDDABCDEF000:78A0DDDABCDEF000:0:0\n"),
 	})
 
@@ -227,7 +230,7 @@ func TestAdmGetGIInvokesDrbdmeta(t *testing.T) {
 		t.Fatalf("GetGI: %v", err)
 	}
 
-	want := "drbdmeta --force pvc-1/0 v09 /dev/dm-3 internal get-gi"
+	want := "drbdmeta --force pvc-1/0 v09 /dev/dm-3 internal get-gi --node-id 0"
 	if !slices.Contains(fx.CommandLines(), want) {
 		t.Errorf("expected %q in calls; got %v", want, fx.CommandLines())
 	}

--- a/pkg/drbd/gi.go
+++ b/pkg/drbd/gi.go
@@ -56,14 +56,22 @@ var ErrGIUpToDateNotConsistent = errors.New("invalid GI seed: up-to-date set wit
 // Why a typed seed (not a bare string): reaching the initial UpToDate
 // state by writing GI metadata directly (instead of force-promoting)
 // needs two shapes that differ only in the flags — the elected winner
-// (current = bitmap = day0 + Consistent + UpToDate, so it is UpToDate
-// from metadata alone) and the all-day0 skip-init-sync replica
-// (current = bitmap = day0, no flags, reaches UpToDate at the peer
-// handshake). Encoding each as a GISeed keeps the field semantics and
-// the "uptodate requires a current-UUID" invariant in one place. The
-// struct still supports a distinct current vs bitmap-base (e.g. for a
-// controller-supplied SeedFromGI) even though the day0 paths set them
-// equal.
+// (current = day0, bitmap-base EMPTY, + Consistent + UpToDate, so it is
+// UpToDate from metadata alone) and the skip-init-sync replica
+// (current = day0, bitmap-base EMPTY, no flags, reaches UpToDate at the
+// peer handshake). Encoding each as a GISeed keeps the field semantics
+// and the "uptodate requires a current-UUID" invariant in one place.
+//
+// The decisive field is BitmapBase: it is left EMPTY (drbdmeta writes
+// bitmap-uuid 0x0) in both seed shapes. This was verified by capturing
+// a working upstream LINSTOR (piraeus) thin resource's live
+// `drbdmeta dump-md`: every per-peer slot carried bitmap-uuid 0x0, and
+// the resource reached UpToDate with ZERO resync. A non-zero
+// bitmap-base (e.g. day0) is read by DRBD's handshake as a live
+// out-of-sync bitmap anchor and triggers a full SyncTarget — the bug a
+// previous iteration shipped. The struct still supports a distinct
+// non-empty BitmapBase for callers that need it, but the day0 seed
+// paths deliberately leave it empty.
 type GISeed struct {
 	// Current is the current-UUID hex token. Empty = field omitted.
 	Current string
@@ -125,16 +133,19 @@ func (s GISeed) Validate() error {
 // up-to-date without consistent (Validate enforces this), so the
 // pair is always emitted together.
 //
-// Examples:
+// Examples (the day0 seed paths leave bitmap-base EMPTY → index 1 is
+// the literal "0" = bitmap-uuid 0x0, matching upstream's working-skip
+// metadata):
 //
-//   - all-day0 skip-init-sync slot:  "<day0>:<day0>:0:0"
-//   - winner slot (UpToDate):        "<day0>:<day0>:0:0:1:1"
+//   - skip-init-sync slot:           "<day0>:0:0:0"
+//   - winner slot (UpToDate):        "<day0>:0:0:0:1:1"
 //   - empty-current slot (unused):   "0:<base>:0:0"
 //
 // The empty-current/empty-base case emits a literal "0" (drbdmeta
 // reads it as "no UUID") rather than a bare empty token, which the
-// positional parser would mis-align. The day0 base in index 1 is
-// what carries the lineage for the winner's peer slots.
+// positional parser would mis-align. A zero bitmap-base (index 1) is
+// what DRBD's handshake reads as "no out-of-sync bits relative to this
+// peer", so a fresh thin replica reaches UpToDate with no resync.
 //
 // String assumes Validate has already passed; callers in the seed
 // path Validate first and surface the error.
@@ -170,9 +181,12 @@ func (s GISeed) String() string {
 // Day0GIFor derives the deterministic per-RD, per-volume "day 0" DRBD
 // generation identifier. Same RD name + volume number always yields
 // the same value on every node and across time, so every replica
-// converges on identical bitmap-base (and, in the skip-init-sync
-// case, current) UUIDs without a shared random seed — DRBD's GI
-// handshake then matches and skips the full initial sync.
+// converges on an identical CURRENT-UUID without needing a shared
+// random seed — DRBD's GI handshake then sees both replicas at the
+// same generation and, with a clean (zero) per-peer bitmap, skips the
+// full initial sync. (The per-peer bitmap-base is left EMPTY, not set
+// to day0 — see GISeed; upstream LINSTOR's working-skip metadata
+// carries a shared current-UUID with bitmap-uuid 0x0 in every slot.)
 //
 // Single source of truth: the satellite stamps this value into fresh
 // metadata, and BOTH the dispatcher and controller seed-safety gates

--- a/pkg/drbd/gi.go
+++ b/pkg/drbd/gi.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ErrGIUpToDateNoCurrent rejects a GI seed that flags a slot
+// up-to-date while leaving the current-UUID empty — an illegal
+// combination DRBD's handshake cannot interpret (an up-to-date slot
+// must have a generation to be authoritative about).
+var ErrGIUpToDateNoCurrent = errors.New("invalid GI seed: up-to-date set with empty current-UUID")
+
+// ErrGIUpToDateNotConsistent rejects a GI seed flagged up-to-date but
+// not consistent; up-to-date data is by definition internally
+// consistent.
+var ErrGIUpToDateNotConsistent = errors.New("invalid GI seed: up-to-date set without consistent")
+
+// GISeed describes the generation-identifier (GI) state to stamp into
+// ONE DRBD-9 v09 per-node-id metadata slot via `drbdmeta set-gi`. It
+// is the typed, validated counterpart of the positional colon-
+// separated GI string drbdmeta consumes.
+//
+// The fields map onto the v09 GI string positions:
+//
+//		<current-uuid>:<bitmap-base-uuid>:<history-uuid-0>:<history-uuid-1>:<flags...>
+//
+//	  - Current is this slot's current data generation (position 1).
+//	    Empty means "no current-UUID" (a fresh peer-bitmap slot).
+//	  - BitmapBase is the base generation the out-of-sync bitmap is
+//	    reckoned against (position 2) — the per-peer "where my data was
+//	    last in sync with this node-id" anchor.
+//	  - Consistent / UpToDate are the only two boolean flags blockstor
+//	    ever seeds. History UUIDs are always left empty.
+//
+// Why a typed seed (not a bare string): reaching the initial UpToDate
+// state by writing GI metadata directly (instead of force-promoting)
+// needs two shapes that differ only in the flags — the elected winner
+// (current = bitmap = day0 + Consistent + UpToDate, so it is UpToDate
+// from metadata alone) and the all-day0 skip-init-sync replica
+// (current = bitmap = day0, no flags, reaches UpToDate at the peer
+// handshake). Encoding each as a GISeed keeps the field semantics and
+// the "uptodate requires a current-UUID" invariant in one place. The
+// struct still supports a distinct current vs bitmap-base (e.g. for a
+// controller-supplied SeedFromGI) even though the day0 paths set them
+// equal.
+type GISeed struct {
+	// Current is the current-UUID hex token. Empty = field omitted.
+	Current string
+	// BitmapBase is the bitmap/data base-UUID hex token. Empty =
+	// field omitted.
+	BitmapBase string
+	// Consistent sets the "data is internally consistent" flag.
+	Consistent bool
+	// UpToDate sets the "data is currently up to date" flag. Per the
+	// DRBD invariant it is illegal to mark a slot up-to-date with an
+	// empty current-UUID; String() enforces this by also requiring
+	// Consistent and refusing to emit otherwise (see Validate).
+	UpToDate bool
+}
+
+// Validate enforces the DRBD GI invariants blockstor relies on:
+//
+//   - up-to-date is never set with an empty current-UUID. DRBD treats
+//     a slot flagged up-to-date as the authoritative source for the
+//     metadata negotiation; a slot with no current-UUID has no
+//     generation to be authoritative about, so the combination is
+//     nonsensical and `drbdmeta set-gi` would seed a slot the kernel
+//     later rejects.
+//   - up-to-date implies consistent (up-to-date data is by definition
+//     internally consistent).
+func (s GISeed) Validate() error {
+	if s.UpToDate && s.Current == "" {
+		return ErrGIUpToDateNoCurrent
+	}
+
+	if s.UpToDate && !s.Consistent {
+		return ErrGIUpToDateNotConsistent
+	}
+
+	return nil
+}
+
+// String renders the GI seed as the positional, colon-separated GI
+// string `drbdmeta <minor> v09 <dev> <internal|flex-external> set-gi`
+// consumes. The layout is FULLY POSITIONAL (drbd-utils'
+// m_set_v9_uuid): every field — including the flags — is a
+// colon-separated token at a fixed index, parsed left-to-right:
+//
+//	index 0: current-UUID            (u64 hex)
+//	index 1: bitmap-base/data UUID   (u64 hex)
+//	index 2: history-UUID 0          (u64 hex)
+//	index 3: history-UUID 1          (u64 hex)
+//	index 4: MDF_CONSISTENT          (0 or 1)
+//	index 5: MDF_WAS_UP_TO_DATE      (0 or 1)
+//	index 6+: primary / crashed-primary / AL-clean / AL-disabled /
+//	          lost-quorum / per-peer connected / outdated / fencing /
+//	          full-sync / device-seen — all left clear here.
+//
+// CRUCIAL: the flags are positional 0/1 integers, NOT `name:value`
+// pairs. drbdmeta parses each with m_strsep_bit, which exits(10) on
+// any value other than 0 or 1 — so a token like "consistent" would
+// hard-error. To set up-to-date (index 5) the consistent field
+// (index 4) MUST be emitted ahead of it; blockstor never sets
+// up-to-date without consistent (Validate enforces this), so the
+// pair is always emitted together.
+//
+// Examples:
+//
+//   - all-day0 skip-init-sync slot:  "<day0>:<day0>:0:0"
+//   - winner slot (UpToDate):        "<day0>:<day0>:0:0:1:1"
+//   - empty-current slot (unused):   "0:<base>:0:0"
+//
+// The empty-current/empty-base case emits a literal "0" (drbdmeta
+// reads it as "no UUID") rather than a bare empty token, which the
+// positional parser would mis-align. The day0 base in index 1 is
+// what carries the lineage for the winner's peer slots.
+//
+// String assumes Validate has already passed; callers in the seed
+// path Validate first and surface the error.
+func (s GISeed) String() string {
+	current := s.Current
+	if current == "" {
+		current = "0"
+	}
+
+	base := s.BitmapBase
+	if base == "" {
+		base = "0"
+	}
+
+	giStr := fmt.Sprintf("%s:%s:0:0", current, base)
+
+	// Flags are positional and parsed in order, so we can only append
+	// the consistent (index 4) and up-to-date (index 5) fields, never
+	// up-to-date alone. Emit nothing when neither is set (the all-day0
+	// skip-init-sync shape) so the slot keeps drbdmeta's default-clear
+	// flags.
+	if s.UpToDate {
+		return giStr + ":1:1" // consistent=1, up-to-date=1
+	}
+
+	if s.Consistent {
+		return giStr + ":1" // consistent=1, up-to-date defaults clear
+	}
+
+	return giStr
+}
+
+// Day0GIFor derives the deterministic per-RD, per-volume "day 0" DRBD
+// generation identifier. Same RD name + volume number always yields
+// the same value on every node and across time, so every replica
+// converges on identical bitmap-base (and, in the skip-init-sync
+// case, current) UUIDs without a shared random seed — DRBD's GI
+// handshake then matches and skips the full initial sync.
+//
+// Single source of truth: the satellite stamps this value into fresh
+// metadata, and BOTH the dispatcher and controller seed-safety gates
+// compare a peer's observed CurrentGI against it to tell a fresh,
+// never-written "day0 sibling" (skip-safe) apart from a real data-
+// bearing relocate survivor (must SyncTarget). A real survivor mints
+// a runtime current-UUID that cannot equal this deterministic value
+// (2^-64 collision), so the discriminator is exact.
+//
+// Format: 16 upper-case hex chars (the first 8 bytes of
+// sha256("blockstor-day0:<rd>/<vol>")), low bit cleared so the GID is
+// even — DRBD's low bit is the "primary writes happened" marker, and
+// a synthetic day0 represents "consistent / no primary writes yet".
+func Day0GIFor(resourceName string, volumeNumber int32) string {
+	h := sha256.Sum256(fmt.Appendf(nil, "blockstor-day0:%s/%d", resourceName, volumeNumber))
+	h[7] &^= 0x01 // force low bit to 0 (even)
+
+	return strings.ToUpper(hex.EncodeToString(h[:8]))
+}

--- a/pkg/drbd/gi_test.go
+++ b/pkg/drbd/gi_test.go
@@ -25,22 +25,25 @@ import (
 	"github.com/cozystack/blockstor/pkg/drbd"
 )
 
-// TestGISeedStringWinnerLocalSlot pins the elected winner's local-slot
-// GI shape: a random current-UUID, day0 as bitmap-base, and BOTH the
-// consistent + up-to-date flags. This is how the source reaches
-// UpToDate by writing metadata instead of `drbdadm primary --force`.
-func TestGISeedStringWinnerLocalSlot(t *testing.T) {
+// TestGISeedStringWinnerSlot pins the elected winner's GI shape as it
+// is actually seeded: a current-UUID (day0 lineage anchor), bitmap-base
+// EMPTY (→ literal "0" = bitmap-uuid 0x0), and BOTH the consistent +
+// up-to-date flags. The empty bitmap-base is the load-bearing field —
+// it matches upstream LINSTOR's working-skip metadata (every per-peer
+// bitmap-uuid 0x0) so the source reaches UpToDate from metadata alone
+// AND the peers skip the resync. A non-zero bitmap-base triggered a
+// full SyncTarget (the bug).
+func TestGISeedStringWinnerSlot(t *testing.T) {
 	seed := drbd.GISeed{
 		Current:    "AABBCCDDEEFF0010",
-		BitmapBase: "1122334455667780",
 		Consistent: true,
 		UpToDate:   true,
 	}
 
 	got := seed.String()
-	want := "AABBCCDDEEFF0010:1122334455667780:0:0:1:1"
+	want := "AABBCCDDEEFF0010:0:0:0:1:1"
 	if got != want {
-		t.Errorf("winner local slot GI: got %q want %q", got, want)
+		t.Errorf("winner slot GI: got %q want %q", got, want)
 	}
 }
 
@@ -58,15 +61,18 @@ func TestGISeedStringWinnerPeerSlot(t *testing.T) {
 	}
 }
 
-// TestGISeedStringSkipInitSync pins the all-day0 skip-init-sync shape
-// (case A): current == bitmap == day0, no flags. Both peers present
-// equal current-UUIDs with clean bitmaps → no sync.
+// TestGISeedStringSkipInitSync pins the skip-init-sync shape (case A):
+// current = day0, bitmap-base EMPTY (→ "0" = bitmap-uuid 0x0), no
+// flags. Both peers present equal current-UUIDs with a clean (zero)
+// bitmap → no sync. The empty bitmap-base matches upstream's
+// working-skip metadata; a day0 (non-zero) bitmap-base triggered a
+// full resync.
 func TestGISeedStringSkipInitSync(t *testing.T) {
 	day0 := "1122334455667780"
-	seed := drbd.GISeed{Current: day0, BitmapBase: day0}
+	seed := drbd.GISeed{Current: day0}
 
 	got := seed.String()
-	want := "1122334455667780:1122334455667780:0:0"
+	want := "1122334455667780:0:0:0"
 	if got != want {
 		t.Errorf("skip-init-sync GI: got %q want %q", got, want)
 	}

--- a/pkg/drbd/gi_test.go
+++ b/pkg/drbd/gi_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbd_test
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/drbd"
+)
+
+// TestGISeedStringWinnerLocalSlot pins the elected winner's local-slot
+// GI shape: a random current-UUID, day0 as bitmap-base, and BOTH the
+// consistent + up-to-date flags. This is how the source reaches
+// UpToDate by writing metadata instead of `drbdadm primary --force`.
+func TestGISeedStringWinnerLocalSlot(t *testing.T) {
+	seed := drbd.GISeed{
+		Current:    "AABBCCDDEEFF0010",
+		BitmapBase: "1122334455667780",
+		Consistent: true,
+		UpToDate:   true,
+	}
+
+	got := seed.String()
+	want := "AABBCCDDEEFF0010:1122334455667780:0:0:1:1"
+	if got != want {
+		t.Errorf("winner local slot GI: got %q want %q", got, want)
+	}
+}
+
+// TestGISeedStringWinnerPeerSlot pins the winner's peer-slot GI shape:
+// day0 bitmap-base only, NO current-UUID (emitted as "0"), NO flags.
+// Peers seeded this way recognise the winner (same day0 bitmap-base)
+// as their lineage source and skip the initial sync.
+func TestGISeedStringWinnerPeerSlot(t *testing.T) {
+	seed := drbd.GISeed{BitmapBase: "1122334455667780"}
+
+	got := seed.String()
+	want := "0:1122334455667780:0:0"
+	if got != want {
+		t.Errorf("winner peer slot GI: got %q want %q", got, want)
+	}
+}
+
+// TestGISeedStringSkipInitSync pins the all-day0 skip-init-sync shape
+// (case A): current == bitmap == day0, no flags. Both peers present
+// equal current-UUIDs with clean bitmaps → no sync.
+func TestGISeedStringSkipInitSync(t *testing.T) {
+	day0 := "1122334455667780"
+	seed := drbd.GISeed{Current: day0, BitmapBase: day0}
+
+	got := seed.String()
+	want := "1122334455667780:1122334455667780:0:0"
+	if got != want {
+		t.Errorf("skip-init-sync GI: got %q want %q", got, want)
+	}
+}
+
+// TestGISeedConsistentWithoutUpToDate confirms a Consistent-only seed
+// emits the consistent flag but not up-to-date.
+func TestGISeedConsistentWithoutUpToDate(t *testing.T) {
+	seed := drbd.GISeed{Current: "AABBCCDDEEFF0010", BitmapBase: "1122334455667780", Consistent: true}
+
+	got := seed.String()
+	want := "AABBCCDDEEFF0010:1122334455667780:0:0:1"
+	if got != want {
+		t.Errorf("consistent-only GI: got %q want %q", got, want)
+	}
+}
+
+// TestGISeedValidateUpToDateRequiresCurrent pins the load-bearing
+// invariant: a slot can never be flagged up-to-date with an empty
+// current-UUID. DRBD treats an up-to-date slot as the authoritative
+// source for the metadata negotiation; a slot with no current-UUID
+// has no generation to be authoritative about.
+func TestGISeedValidateUpToDateRequiresCurrent(t *testing.T) {
+	seed := drbd.GISeed{BitmapBase: "1122334455667780", Consistent: true, UpToDate: true}
+
+	err := seed.Validate()
+	if !errors.Is(err, drbd.ErrGIUpToDateNoCurrent) {
+		t.Errorf("up-to-date with empty current must be rejected; got %v", err)
+	}
+}
+
+// TestGISeedValidateUpToDateRequiresConsistent confirms up-to-date
+// implies consistent.
+func TestGISeedValidateUpToDateRequiresConsistent(t *testing.T) {
+	seed := drbd.GISeed{Current: "AABBCCDDEEFF0010", BitmapBase: "1122334455667780", UpToDate: true}
+
+	err := seed.Validate()
+	if !errors.Is(err, drbd.ErrGIUpToDateNotConsistent) {
+		t.Errorf("up-to-date without consistent must be rejected; got %v", err)
+	}
+}
+
+// TestGISeedValidateAcceptsWinnerAndPeer confirms the two shapes the
+// winner path actually emits pass Validate.
+func TestGISeedValidateAcceptsWinnerAndPeer(t *testing.T) {
+	local := drbd.GISeed{Current: "AABBCCDDEEFF0010", BitmapBase: "1122334455667780", Consistent: true, UpToDate: true}
+	if err := local.Validate(); err != nil {
+		t.Errorf("winner local slot must validate; got %v", err)
+	}
+
+	peer := drbd.GISeed{BitmapBase: "1122334455667780"}
+	if err := peer.Validate(); err != nil {
+		t.Errorf("winner peer slot must validate; got %v", err)
+	}
+}
+
+// TestDay0GIForDeterministicAndEven pins the day0 GID derivation: the
+// same RD name + volume number always yields the same value (so every
+// node and the seed-safety gates agree), distinct (RD, vol) pairs
+// differ, and the value follows DRBD's conventions — 16 upper-case
+// hex chars with the low bit clear (even).
+func TestDay0GIForDeterministicAndEven(t *testing.T) {
+	a := drbd.Day0GIFor("pvc-x", 0)
+	b := drbd.Day0GIFor("pvc-x", 0)
+	if a != b {
+		t.Errorf("Day0GIFor must be deterministic; got %q then %q", a, b)
+	}
+
+	if a == drbd.Day0GIFor("pvc-x", 1) {
+		t.Errorf("Day0GIFor must differ per volume; vol0==vol1 (%q)", a)
+	}
+
+	if a == drbd.Day0GIFor("pvc-y", 0) {
+		t.Errorf("Day0GIFor must differ per RD; pvc-x==pvc-y (%q)", a)
+	}
+
+	if len(a) != 16 || a != strings.ToUpper(a) {
+		t.Errorf("Day0GIFor must be 16 upper-case hex chars; got %q", a)
+	}
+
+	v, err := strconv.ParseUint(a, 16, 64)
+	if err != nil {
+		t.Fatalf("Day0GIFor must be hex; got %q: %v", a, err)
+	}
+
+	if v&1 != 0 {
+		t.Errorf("Day0GIFor must be even (low bit clear); got %q", a)
+	}
+}

--- a/pkg/satellite/controllers/observer.go
+++ b/pkg/satellite/controllers/observer.go
@@ -123,6 +123,11 @@ type volumeObservation struct {
 	VolumeNumber int32
 	DiskState    string
 	CurrentUUID  string
+	// BackingDev is the lower-disk path from the events2 `device`
+	// frame's `backing_dev:` field. Used by the observer to read the
+	// on-disk current-UUID via drbdmeta get-gi when events2 doesn't
+	// carry it (DRBD 9.3.2). Not published to Status.
+	BackingDev   string
 	OutOfSyncKib int64
 	HasSync      bool // true when this observation carried out-of-sync stats
 	Quorum       bool
@@ -316,6 +321,7 @@ func translateDeviceEvent(ev drbd.Event) (observation, bool) {
 		VolumeNumber: int32(volNum), //nolint:gosec // drbd-9 volume numbers fit in int32
 		DiskState:    disk,
 		CurrentUUID:  ev.Fields["current-uuid"],
+		BackingDev:   ev.Fields["backing_dev"],
 	}
 
 	// `quorum:yes|no` is emitted on every `device` frame on
@@ -786,11 +792,19 @@ func (o *ObserverRunnable) resyncLoop(ctx context.Context) {
 func (o *ObserverRunnable) resyncOnce(ctx context.Context, logger logr.Logger) {
 	names := o.cachedResourceNames()
 
+	adm := drbd.NewAdm(o.Exec)
+
 	for _, name := range names {
 		obs := o.snapshotFor(name)
 		if obs.ResourceName == "" {
 			continue
 		}
+
+		// Backfill CurrentGI from on-disk metadata here too (not just
+		// the event-driven path): the 5s resync guarantees a
+		// data-state volume's CurrentGI converges even when no further
+		// events2 frame fires after it reached UpToDate.
+		o.backfillCurrentGI(ctx, adm, &obs)
 
 		err := o.writeStatus(ctx, &obs)
 		if err == nil {
@@ -1022,6 +1036,8 @@ func (o *ObserverRunnable) handleObservation(ctx context.Context, adm *drbd.Adm,
 		}
 	}
 
+	o.backfillCurrentGI(ctx, adm, ev)
+
 	err := o.writeStatus(ctx, ev)
 	if err == nil {
 		return
@@ -1032,6 +1048,52 @@ func (o *ObserverRunnable) handleObservation(ctx context.Context, adm *drbd.Adm,
 	}
 
 	logger.Error(err, "write Resource.Status", "resource", ev.ResourceName)
+}
+
+// backfillCurrentGI fills ev.Volumes[].CurrentUUID from the on-disk GI
+// (`drbdadm get-gi`) when the events2 frame did not carry it. On DRBD
+// 9.3.2 `drbdsetup events2 --full` omits current-uuid on device
+// frames, so the events2-sourced CurrentGI is always empty and the
+// seed-safety gates' day0-sibling discriminator (isDay0SeededVolume)
+// can never recognise a fresh day0 winner — forcing a staggered late
+// replica into a needless SyncTarget. Reading get-gi backfills it so
+// Status.Volumes[].CurrentGI carries the real current-UUID and the
+// gate works.
+//
+// Only volumes in a data-bearing disk state are probed (UpToDate /
+// Consistent / Outdated) — a fresh Inconsistent slot has no
+// meaningful GI to publish yet, and skipping it avoids a get-gi
+// round-trip on every statistics tick. Best-effort: a get-gi error or
+// empty result leaves CurrentUUID as-is (the gate stays conservative).
+func (o *ObserverRunnable) backfillCurrentGI(ctx context.Context, adm *drbd.Adm, ev *observation) {
+	for i := range ev.Volumes {
+		vol := &ev.Volumes[i]
+
+		if vol.CurrentUUID != "" || vol.BackingDev == "" {
+			continue
+		}
+
+		if !isDataBearingDiskState(drbd.DiskState(vol.DiskState)) {
+			continue
+		}
+
+		current, err := adm.CurrentGI(ctx, ev.ResourceName, vol.VolumeNumber, vol.BackingDev)
+		if err != nil || current == "" {
+			continue
+		}
+
+		vol.CurrentUUID = current
+	}
+}
+
+// isDataBearingDiskState reports whether a DRBD disk state means the
+// replica carries real data worth publishing a current-UUID for
+// (UpToDate / Consistent / Outdated). A fresh Inconsistent slot has no
+// meaningful GI yet.
+func isDataBearingDiskState(s drbd.DiskState) bool {
+	return s == drbd.DiskStateUpToDate ||
+		s == drbd.DiskStateConsistent ||
+		s == drbd.DiskStateOutdated
 }
 
 // emitReconcileTrigger sends a GenericEvent for the affected
@@ -1380,6 +1442,15 @@ func mergeVolumeInto(cache map[int32]volumeObservation, incoming volumeObservati
 		merged.Quorum = incoming.Quorum
 		merged.HasQuorum = true
 		changed = true
+	}
+
+	// BackingDev is carried in the cache (so the snapshot the backfill
+	// reads has the lower-disk path) but never marks the volume
+	// `changed` on its own — it is an internal helper field, not a
+	// Status field, so a backing_dev-only frame must not trigger a
+	// Status SSA write.
+	if incoming.BackingDev != "" {
+		merged.BackingDev = incoming.BackingDev
 	}
 
 	cache[incoming.VolumeNumber] = merged

--- a/pkg/satellite/providerkind.go
+++ b/pkg/satellite/providerkind.go
@@ -17,10 +17,7 @@ limitations under the License.
 package satellite
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"strings"
+	"github.com/cozystack/blockstor/pkg/drbd"
 )
 
 // IsThinOrZFS reports whether a provider kind is guaranteed to hand
@@ -71,28 +68,11 @@ func IsThinOrZFS(kind string) bool {
 	return false
 }
 
-// day0GiFor derives a deterministic 64-bit DRBD GI for a per-RD,
-// per-volume "day 0" stamp. Same RD name + volume number always
-// yields the same value, so every replica on every node converges
-// on identical current_uuid / bitmap_uuid pairs without needing a
-// shared random seed — DRBD's GI handshake then matches and skips
-// the full initial-sync (upstream LINSTOR's path goes through
-// `getCurrentGIFromVlmDfnProp` which is itself derived from the
-// RD's VolumeDefinition; we follow the same "same RD ⇒ same GI"
-// rule but without the controller-side prop because no peer
-// has stamped CurrentGI on a brand-new RD).
-//
-// Format: 16 hex characters, upper-case — DRBD's drbdmeta accepts
-// hex GI tokens. Trailing `0` enforces the DRBD-9 convention that
-// a real GI is even (low bit is the "primary indicator" — odd =
-// primary writes happened, even = clean). A synthetic day0 is
-// deliberately even so it represents "consistent / no primary
-// writes yet" — DRBD's handshake then treats matching day0 +
-// zero bitmap as "already in sync".
+// day0GiFor is the satellite-local alias for the single-sourced
+// drbd.Day0GIFor derivation. Kept so existing satellite call sites
+// read naturally; the derivation itself (and its rationale) lives in
+// pkg/drbd/gi.go so the controller and dispatcher seed-safety gates
+// compare against the exact same value the satellite stamps.
 func day0GiFor(resourceName string, volumeNumber int32) string {
-	h := sha256.Sum256(fmt.Appendf(nil, "blockstor-day0:%s/%d", resourceName, volumeNumber))
-	// Take the first 8 bytes, force low bit to 0 (even).
-	h[7] &^= 0x01
-
-	return strings.ToUpper(hex.EncodeToString(h[:8]))
+	return drbd.Day0GIFor(resourceName, volumeNumber)
 }

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -3623,13 +3623,18 @@ func (r *Reconciler) seedInitialGI(ctx context.Context, dr *intent.DesiredResour
 //     intended current+flags (a winner seed with a per-slot-varying
 //     current would be silently clobbered by the highest node-id).
 //   - only the bitmap-base UUID is PER-PEER (md->peers[N].bitmap_uuid).
-//     We want day0 in every peer slot, which the uniform seed provides.
+//     The day0 seed paths leave it EMPTY, so the uniform stamp writes
+//     bitmap-uuid 0x0 into every slot — matching upstream LINSTOR's
+//     working-skip metadata (captured via `drbdmeta dump-md`: every
+//     per-peer slot bitmap-uuid 0x0, resource skips the resync).
 //
-// So the winner seed (`current=random, bitmap=day0, Consistent,
-// UpToDate`) applied uniformly yields exactly the spec's end state:
-// shared current=random + Consistent+UpToDate flags, and every peer
-// slot's bitmap-base = day0. The all-day0 skip-init-sync seed
-// (`current=bitmap=day0`, no flags) is likewise uniform.
+// So the winner seed (`current=day0, bitmap-base EMPTY, Consistent,
+// UpToDate`) applied uniformly yields: shared current=day0 +
+// Consistent+UpToDate flags, and every peer slot's bitmap-uuid 0x0.
+// The skip-init-sync seed (`current=day0, bitmap-base EMPTY`, no flags)
+// is likewise uniform. A NON-zero bitmap-base (a previous iteration
+// stamped day0 there) is read by DRBD as a live out-of-sync anchor and
+// triggers a full SyncTarget — the bug this seeding now avoids.
 //
 // Blanketing all slots (not just dr.GetPeerNames()) is the Bug 284 /
 // Bug 342 invariant: it wipes stale per-peer bitmap-UUIDs out of slots
@@ -3778,13 +3783,50 @@ func (r *Reconciler) resolveVolumeSeed(resourceName string, vol *intent.DesiredV
 	day0 := day0GiFor(resourceName, vol.GetVolumeNumber())
 
 	if seed := vol.GetSeedFromGI(); seed != "" {
+		// Phase 8.1 relocate-skip: the controller copied this GID from a
+		// real UpToDate peer. current == bitmap-base == peer's GID means
+		// "I am at the peer's generation and have no dirty bits relative
+		// to it" — the long-standing, separately-validated seed-from-
+		// real-peer shape (Adm.SetGI). This is NOT the fresh day0 skip
+		// path; it anchors against a live peer's real generation, so the
+		// bitmap-base carries that generation rather than being empty.
 		return drbd.GISeed{Current: seed, BitmapBase: seed}, true
 	}
 
 	if isWinner {
+		// Winner seed, matched byte-for-byte to upstream LINSTOR's
+		// working-skip metadata captured live via `drbdmeta dump-md` on
+		// a piraeus thin resource that reaches UpToDate with ZERO
+		// resync:
+		//
+		//   current-uuid <day0>; flags Consistent+UpToDate;
+		//   EVERY peer slot bitmap-uuid 0x0  (clean — NOT day0).
+		//
+		// The decisive field is the per-peer BITMAP-BASE, left EMPTY
+		// (→ drbdmeta writes bitmap-uuid 0x0). DRBD's connection
+		// handshake reads a zero bitmap-uuid as "no out-of-sync bits
+		// relative to this peer", so with both replicas sharing the
+		// same current-uuid and a clean (zero) bitmap, it concludes
+		// "nothing to copy" and both go straight to UpToDate.
+		//
+		// The earlier shape stamped bitmap-base = day0 (a NON-zero
+		// value equal to current) into every slot. DRBD then read a
+		// non-zero bitmap-base as a live out-of-sync bitmap anchor and
+		// flipped the peer to SyncTarget for a full ~1 GiB resync of an
+		// empty thin volume — the exact bug. (Captured: ours had
+		// bitmap-uuid=day0 in every slot and SyncTargeted; upstream had
+		// bitmap-uuid=0x0 in every slot and skipped, same kernel.)
+		//
+		// current-uuid stays day0 (the shared deterministic lineage
+		// anchor) — NOT a fresh random GID — so the dispatcher's
+		// isDay0SeededVolume discriminator still recognises this winner
+		// as a fresh day0 sibling (staggered late replica may take its
+		// own skip; a dual-winner race agrees rather than split-brains).
+		// Upstream uses a shared random current; day0 is the
+		// blockstor-equivalent shared value and works identically at the
+		// handshake (both replicas present the same current-uuid).
 		return drbd.GISeed{
 			Current:    day0,
-			BitmapBase: day0,
 			Consistent: true,
 			UpToDate:   true,
 		}, true
@@ -3799,7 +3841,14 @@ func (r *Reconciler) resolveVolumeSeed(resourceName string, vol *intent.DesiredV
 		return drbd.GISeed{}, false
 	}
 
-	return drbd.GISeed{Current: day0, BitmapBase: day0}, true
+	// Skip-init-sync (case A): current = day0 (shared lineage anchor),
+	// bitmap-base EMPTY (zero) — same clean-bitmap shape as the winner,
+	// minus the Consistent/UpToDate flags. Both peers present the same
+	// current-uuid with a zero bitmap → DRBD reads "no data difference"
+	// → no sync; both reach UpToDate at the kernel handshake. (Stamping
+	// day0 into bitmap-base here was the same SyncTarget-triggering bug
+	// the winner branch documents.)
+	return drbd.GISeed{Current: day0}, true
 }
 
 // providerForResource resolves the provider that owns the named

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -3543,7 +3543,7 @@ func (r *Reconciler) seedInitialGI(ctx context.Context, dr *intent.DesiredResour
 			continue
 		}
 
-		seed, ok := r.resolveVolumeSeed(dr.GetName(), vol, dr.GetPeerHasData(), isWinner)
+		seed, ok := r.resolveVolumeSeed(ctx, dr.GetName(), vol, dr.GetPeerHasData(), isWinner)
 		if !ok {
 			continue
 		}
@@ -3766,16 +3766,25 @@ func refuseUnresolvedLocalNodeID(dr *intent.DesiredResource) error {
 //     flags. Both peers present equal current-UUIDs with clean bitmaps
 //     → DRBD reads "no data difference" → no sync; both reach UpToDate
 //     at the kernel handshake. (Preserves blockstor's existing,
-//     stand-validated skip-init-sync shape.)
+//     stand-validated skip-init-sync shape.) GATED on the kernel-truth
+//     AnyConnectedPeerHasData probe: a migrate/relocate destination
+//     flips diskless→diskful on a slot that is ALREADY connected to an
+//     UpToDate peer, and since PR #20 that peer sits at day0 so the
+//     CRD-status PeerHasData gate can't see it as data-bearing — the
+//     probe catches it from kernel state and refuses the skip (→ case C
+//     SyncTarget). On a fresh replica the slot is not connected yet at
+//     seed time, so the probe finds nothing and the skip proceeds.
 //
 //   - Else (case C: thick LVM, opaque file, unknown provider, non-
-//     winner) → ok=false. The freshly-created Inconsistent metadata is
-//     left untouched so this replica resyncs from the source.
+//     winner, OR a flip dst with a connected data peer) → ok=false. The
+//     freshly-created Inconsistent metadata is left untouched so this
+//     replica resyncs from the source.
 //
 // Race-free: peerHasData is recomputed by the dispatcher every
 // reconcile from live peer status, not a controller stamp that must
-// land in Spec in time.
-func (r *Reconciler) resolveVolumeSeed(resourceName string, vol *intent.DesiredVolume, peerHasData, isWinner bool) (drbd.GISeed, bool) {
+// land in Spec in time; the case-A AnyConnectedPeerHasData gate reads
+// live kernel state, immune to the day0 CRD-classification ambiguity.
+func (r *Reconciler) resolveVolumeSeed(ctx context.Context, resourceName string, vol *intent.DesiredVolume, peerHasData, isWinner bool) (drbd.GISeed, bool) {
 	if peerHasData {
 		return drbd.GISeed{}, false
 	}
@@ -3838,6 +3847,44 @@ func (r *Reconciler) resolveVolumeSeed(resourceName string, vol *intent.DesiredV
 	}
 
 	if !IsThinOrZFS(provider.Kind()) {
+		return drbd.GISeed{}, false
+	}
+
+	// Migrate / relocate destination gate (kernel-truth backstop).
+	//
+	// The day0 skip-init-sync seed below is ONLY data-safe when this
+	// replica is part of a genuinely-fresh resource — no peer is an
+	// established UpToDate authority that holds the real (even if empty)
+	// copy this replica must derive from. A diskless→diskful flip (the
+	// `linstor r td --migrate-from` / relocate destination: a replica
+	// that was a connected diskless client and is now attaching a fresh
+	// lower disk) joins a resource whose Primary peer is ALREADY UpToDate.
+	//
+	// Since PR #20 the elected winner reaches UpToDate via `set-gi` at
+	// current-uuid == day0 and STAYS there (no runtime write advances it
+	// on an empty thin/ZFS volume, and `primary --force` mints no new UUID
+	// on an already-UpToDate node — verified on DRBD 9.3.2 via get-gi:
+	// the Primary source sits at `<day0>:0:0:0:1:1`). So the CRD-status
+	// gate (dispatcher.anyDiskfulPeerHasData → PeerHasData) can no longer
+	// tell that data-bearing day0 Primary apart from a never-written day0
+	// sibling: isDay0SeededVolume sees CurrentGI == day0 on BOTH and
+	// classifies the real authority as a fresh sibling → PeerHasData is
+	// false → control reaches here. Stamping the day0 skip seed then gives
+	// the destination a clean (zero) bitmap + no UpToDate flag, so DRBD
+	// has neither out-of-sync bits to drive a SyncTarget nor a metadata
+	// flag to declare it UpToDate → it latches Inconsistent forever (the
+	// lifecycle-toggle-migrate regression).
+	//
+	// Use kernel truth, immune to the day0 ambiguity: if a peer connection
+	// already exposes committed data (peer-disk UpToDate/Consistent/
+	// Outdated), REFUSE the skip and leave the freshly-created metadata
+	// Inconsistent so DRBD runs a real SyncTarget from that peer (case C).
+	// On a genuinely-fresh replica the kernel slot is NOT connected yet at
+	// seed time (the connection establishes during the later `drbdadm
+	// adjust`), so the probe finds nothing and the skip proceeds — the
+	// fresh 2-/3-replica skip-init-sync is preserved. Mirrors the
+	// shouldForcePromote AnyConnectedPeerHasData backstop.
+	if r.cfg.Adm.AnyConnectedPeerHasData(ctx, resourceName) {
 		return drbd.GISeed{}, false
 	}
 

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -2194,7 +2194,19 @@ func (r *Reconciler) finishDRBDApply(ctx context.Context, dr *intent.DesiredReso
 		return nil
 	}
 
-	if autoPromote {
+	// Reaching UpToDate no longer depends on this promote. The elected
+	// winner already declared itself Consistent+UpToDate via the
+	// `drbdmeta set-gi` seed (seedInitialGI's case-B winner slot), so
+	// the kernel comes up UpToDate from metadata alone. `primary
+	// --force` is now PURELY an mkfs concern: we promote only when the
+	// RD requests a filesystem (and quorum may not be satisfiable yet
+	// because peers haven't connected), run mkfs, then demote
+	// immediately. When no filesystem is requested we skip the promote
+	// entirely — which is exactly what avoids the old bug, where
+	// `primary --force` minted a fresh current-UUID that diverged from
+	// the day0 bitmap-base the peers carry, flipping them to SyncTarget
+	// for a full initial sync even on empty thin/ZFS volumes.
+	if autoPromote && needsMkfs(dr) {
 		err := r.runAutoPromote(ctx, dr)
 		if err != nil {
 			return err
@@ -2502,12 +2514,45 @@ func (r *Reconciler) ensureMetadata(ctx context.Context, dr *intent.DesiredResou
 		return nil
 	}
 
-	err = r.seedInitialGI(ctx, dr, devices)
+	err = r.seedInitialGI(ctx, dr, devices, isInitialUpToDateWinner(dr, firstActivation))
 	if err != nil {
 		return errors.Wrapf(err, "seed initial-sync GI %s", dr.GetName())
 	}
 
 	return nil
+}
+
+// isInitialUpToDateWinner reports whether THIS node is the elected
+// initial-UpToDate source for a not-yet-initialized resource — the
+// "winner" of the day0 seed race. When true, seedInitialGI writes the
+// case-B winner seed (random current + day0 bitmap-base + Consistent +
+// UpToDate on the local slot) so the source reaches UpToDate purely
+// from metadata, replacing the old `drbdadm primary --force` that
+// minted a divergent current-UUID and forced a full initial sync.
+//
+// The three gates together are the "elected winner AND volume not yet
+// initialized" condition from the spec:
+//
+//   - firstActivation: this is the resource's first create-md on this
+//     node (metadata never created before). Once the winner is
+//     UpToDate, every subsequent reconcile sees firstActivation=false,
+//     closing the winner path forever — a late-added / relocated
+//     replica can NEVER take case B (it falls to case A day0 or case C
+//     Inconsistent), which is what keeps relocate split-brain-free.
+//   - auto-primary: the dispatcher's lowest-diskful-node-id election
+//     (BuildDesired) stamps this flag on exactly ONE replica per fresh
+//     RD — the elected source. It is the "winner node" marker.
+//   - !PeerHasData: the dispatcher already withholds auto-primary when
+//     any diskful peer holds data, but we re-check here as a belt-and-
+//     braces gate so a relocate target never seeds itself UpToDate.
+//
+// A diskless replica is never a winner (no lower disk / metadata to
+// seed); the auto-primary flag is only ever stamped on diskful
+// replicas, so the flag check already excludes diskless.
+func isInitialUpToDateWinner(dr *intent.DesiredResource, firstActivation bool) bool {
+	return firstActivation &&
+		dr.GetDrbdOptions()["auto-primary"] == drbdBoolPropTrue &&
+		!dr.GetPeerHasData()
 }
 
 // ensurePerVolumeMetadata stamps DRBD-9 metadata on every diskful
@@ -2787,6 +2832,17 @@ func (r *Reconciler) shouldForcePromote(ctx context.Context, dr *intent.DesiredR
 	}
 
 	return true
+}
+
+// needsMkfs reports whether the RD requests an on-creation filesystem
+// (the `FileSystem/Type` prop the controller folds from the RG's
+// effective props). It is the sole remaining reason to `drbdadm
+// primary --force` a fresh replica: mkfs must run while Primary, and
+// quorum may not be satisfiable yet because peers haven't connected.
+// When false, the elected winner reaches UpToDate from its set-gi
+// seed alone and is never promoted at create time.
+func needsMkfs(dr *intent.DesiredResource) bool {
+	return strings.TrimSpace(dr.GetProps()["FileSystem/Type"]) != ""
 }
 
 func (r *Reconciler) runAutoPromote(ctx context.Context, dr *intent.DesiredResource) error {
@@ -3427,14 +3483,14 @@ func isUnknownResourceErr(err error) bool {
 // block this then mutates) and drbdadm adjust (which reads the
 // metadata into kernel state).
 
-func (r *Reconciler) seedInitialGI(ctx context.Context, dr *intent.DesiredResource, devices map[int32]string) error {
+func (r *Reconciler) seedInitialGI(ctx context.Context, dr *intent.DesiredResource, devices map[int32]string, isWinner bool) error {
 	for _, vol := range dr.GetVolumes() {
 		device := devices[vol.GetVolumeNumber()]
 		if device == "" {
 			continue
 		}
 
-		seed, ok := r.resolveSeedGI(dr.GetName(), vol, dr.GetPeerHasData())
+		seed, ok := r.resolveVolumeSeed(dr.GetName(), vol, dr.GetPeerHasData(), isWinner)
 		if !ok {
 			continue
 		}
@@ -3500,16 +3556,47 @@ func (r *Reconciler) seedInitialGI(ctx context.Context, dr *intent.DesiredResour
 // Returns the first non-nil error from drbdmeta. Every call carries
 // `--node-id <X>`, so the legacy "set-gi requires --node-id" failure
 // mode is structurally unreachable.
-func (r *Reconciler) seedPerPeerGI(ctx context.Context, dr *intent.DesiredResource, vol *intent.DesiredVolume, device, seed string) error {
-	// Blanket EVERY metadata slot 0..NodeIDMax with the same day0
-	// tuple. We deliberately do NOT gate on dr.GetPeerNames() /
-	// per-peer node-id allocation: the whole point is to wipe stale
-	// bitmap-UUIDs out of slots no currently-visible peer occupies
-	// (relocated/deleted prior incarnation, not-yet-visible peer,
-	// late-allocated node-id). The local slot is included in the
-	// range, preserving the Bug 284 local current_uuid stamp.
+//
+// One uniform seed per (resource, volume): the SAME GI string is
+// stamped into every node-id slot 0..NodeIDMax. This is correct AND
+// necessary because of how v09 metadata is laid out (drbd-utils
+// m_set_v9_uuid / md_cpu_to_disk_09):
+//
+//   - the current-UUID and the consistent/up-to-date FLAGS are
+//     DEVICE-LEVEL (md->current_uuid, md->flags) — shared, not
+//     per-peer. Every `set-gi --node-id N` call rewrites them, so the
+//     LAST call wins. Stamping the same current+flags on every slot
+//     makes the loop order irrelevant and leaves the device with the
+//     intended current+flags (a winner seed with a per-slot-varying
+//     current would be silently clobbered by the highest node-id).
+//   - only the bitmap-base UUID is PER-PEER (md->peers[N].bitmap_uuid).
+//     We want day0 in every peer slot, which the uniform seed provides.
+//
+// So the winner seed (`current=random, bitmap=day0, Consistent,
+// UpToDate`) applied uniformly yields exactly the spec's end state:
+// shared current=random + Consistent+UpToDate flags, and every peer
+// slot's bitmap-base = day0. The all-day0 skip-init-sync seed
+// (`current=bitmap=day0`, no flags) is likewise uniform.
+//
+// Blanketing all slots (not just dr.GetPeerNames()) is the Bug 284 /
+// Bug 342 invariant: it wipes stale per-peer bitmap-UUIDs out of slots
+// no currently-visible peer occupies (relocated/deleted prior
+// incarnation, not-yet-visible peer, late-allocated node-id) so the
+// handshake can never invent a phantom resync. Upper bound NodeIDMax
+// (31) is the drbdmeta hard ceiling.
+func (r *Reconciler) seedPerPeerGI(ctx context.Context, dr *intent.DesiredResource, vol *intent.DesiredVolume, device string, seed drbd.GISeed) error {
+	// Validate once before touching metadata so a malformed seed (e.g.
+	// up-to-date with empty current) fails fast rather than mid-loop
+	// with half the slots written.
+	validateErr := seed.Validate()
+	if validateErr != nil {
+		return errors.Wrapf(validateErr, "validate GI seed vol %d", vol.GetVolumeNumber())
+	}
+
+	gi := seed.String()
+
 	for nodeID := int32(0); nodeID <= drbd.NodeIDMax; nodeID++ {
-		err := r.cfg.Adm.SetGI(ctx, dr.GetName(), vol.GetVolumeNumber(), device, nodeID, seed)
+		err := r.cfg.Adm.SetGIString(ctx, dr.GetName(), vol.GetVolumeNumber(), device, nodeID, gi)
 		if err != nil {
 			return errors.Wrapf(err, "set-gi vol %d node-id %d",
 				vol.GetVolumeNumber(), nodeID)
@@ -3574,69 +3661,92 @@ func refuseUnresolvedLocalNodeID(dr *intent.DesiredResource) error {
 	return nil
 }
 
-// resolveSeedGI decides what GI to stamp on a fresh replica's
-// metadata block:
+// resolveVolumeSeed decides the single GI seed to stamp uniformly into
+// every per-node-id metadata slot of a fresh replica so the resource
+// reaches its initial state WITHOUT a runtime `drbdadm primary
+// --force` (which mints a divergent current-UUID and forces a full
+// initial sync). The seed's device-level current/flags and per-peer
+// bitmap-base are applied to all slots (see seedPerPeerGI for why
+// uniform is both correct and required). It maps onto the spec cases:
 //
-//   - Controller-supplied SeedFromGI wins. That's the Phase 8.1
-//     "copy from an existing UpToDate peer" path — the GI is the
-//     real CurrentGI of the peer, so DRBD's handshake sees a true
-//     match and skips initial-sync.
+//   - peerHasData → no seed (ok=false). Bug 342 data-integrity gate:
+//     a fresh replica joining an RD where a diskful peer already holds
+//     committed data MUST come up Inconsistent and SyncTarget from that
+//     peer. Seeding any GI here lets DRBD's handshake skip the resync
+//     against a peer whose current-UUID is unrelated → `uuid_compare()=
+//     unrelated-data` → permanent StandAlone (the relocate / physical
+//     `r d` then `r c` case). Checked FIRST; wins over every branch,
+//     including the winner branch.
 //
-//   - Otherwise, when the backing provider is guaranteed to hand
-//     back zero-initialised storage (thin LVM, thin or thick ZFS,
-//     sparse file — see IsThinOrZFS), synthesise a deterministic
-//     per-RD, per-volume day0 GI. Same RD name + volume number
-//     produces the same GI on every node so DRBD's GI handshake
-//     matches and skips initial-sync even when no peer has been
-//     stamped UpToDate yet. Mirrors upstream LINSTOR's
-//     `DrbdLayerUtils.skipInitSync` short-circuit (Bug 77).
+//   - Controller-supplied SeedFromGI (Phase 8.1: copied from an
+//     existing UpToDate peer) → `current = bitmap = seed`, no flags.
+//     DRBD's handshake sees a true match and skips the sync. Preferred
+//     over the winner branch because a real peer GI is a stronger
+//     lineage anchor than the synthetic day0.
 //
-//   - Otherwise (thick LVM, opaque file, unknown provider, DISKLESS),
-//     return ok=false. DRBD then falls through to the full
-//     initial-sync on first connect, which is the only safe
-//     behaviour when the backing storage may carry pre-existing
-//     bytes the peer doesn't have.
+//   - isWinner (case B: this node is the elected initial-UpToDate
+//     source and the volume is not yet initialized) → `current =
+//     bitmap = day0`, Consistent + UpToDate. The flags make the
+//     kernel read the replica as UpToDate after adjust — UpToDate
+//     purely from metadata, no promote (that promote is the bug; it
+//     minted a divergent current-UUID).
 //
-// Bug 342 / seed-GI data-integrity gate (peerHasData): the whole
-// seed-GI optimisation — skip the full initial-sync by stamping a GI
-// the peer already agrees with — is ONLY data-safe when the RD is
-// genuinely day0: no existing diskful peer holds committed data
-// anywhere. When ANY diskful peer reports data (peerHasData, observed
-// fresh off the peers' Status.Volumes[].DiskState every reconcile by
-// dispatcher.anyDiskfulPeerHasData), REFUSE every seed — the
-// controller-supplied SeedFromGI (copied from a peer's evolved Current
-// UUID) AND the synthetic day0 fallback alike. A fresh replica with a
-// data-bearing peer MUST come up Inconsistent and SyncTarget from that
-// peer (full resync, adopt the peer's GI); seeding ANY GI here lets
-// DRBD's handshake skip the resync against a peer whose Current UUID is
-// unrelated to the seed → `uuid_compare()=unrelated-data` → permanent
-// StandAlone (the relocate / physical `r d` then `r c` case).
+//     The current-UUID is day0 (NOT a fresh random GID): the winner
+//     stays on the shared day0 lineage so (a) a staggered late replica
+//     observing this winner's CurrentGI == day0 is recognised by the
+//     seed-safety gate as a fresh day0 sibling (dispatcher
+//     isDay0SeededVolume) and may take its OWN day0 skip instead of a
+//     needless SyncTarget; and (b) a dual-winner election race produces
+//     two identical day0 generations that agree at handshake rather
+//     than two divergent random siblings that split-brain. Relocate
+//     stays safe because any real write advances the source's current
+//     past day0 (normal DRBD behaviour), after which the gate counts it
+//     as data-bearing and a new replica correctly SyncTargets.
 //
-// Race-free: the decision reads peerHasData (recomputed by the
-// dispatcher on every reconcile from live peer status), NOT a
-// controller stamp that must land in Spec.SeedFromGI in time. Even if
-// the controller never stamps SeedFromGI, a fresh replica with a data
-// peer takes the safe "no seed → Inconsistent → SyncTarget" path here,
-// never the unsafe day0 fallback.
-func (r *Reconciler) resolveSeedGI(resourceName string, vol *intent.DesiredVolume, peerHasData bool) (string, bool) {
+//   - Else skip-init-sync (case A: thin-backed or all-ZFS, force-
+//     initial-sync not requested) → `current = bitmap = day0`, no
+//     flags. Both peers present equal current-UUIDs with clean bitmaps
+//     → DRBD reads "no data difference" → no sync; both reach UpToDate
+//     at the kernel handshake. (Preserves blockstor's existing,
+//     stand-validated skip-init-sync shape.)
+//
+//   - Else (case C: thick LVM, opaque file, unknown provider, non-
+//     winner) → ok=false. The freshly-created Inconsistent metadata is
+//     left untouched so this replica resyncs from the source.
+//
+// Race-free: peerHasData is recomputed by the dispatcher every
+// reconcile from live peer status, not a controller stamp that must
+// land in Spec in time.
+func (r *Reconciler) resolveVolumeSeed(resourceName string, vol *intent.DesiredVolume, peerHasData, isWinner bool) (drbd.GISeed, bool) {
 	if peerHasData {
-		return "", false
+		return drbd.GISeed{}, false
 	}
 
+	day0 := day0GiFor(resourceName, vol.GetVolumeNumber())
+
 	if seed := vol.GetSeedFromGI(); seed != "" {
-		return seed, true
+		return drbd.GISeed{Current: seed, BitmapBase: seed}, true
+	}
+
+	if isWinner {
+		return drbd.GISeed{
+			Current:    day0,
+			BitmapBase: day0,
+			Consistent: true,
+			UpToDate:   true,
+		}, true
 	}
 
 	provider, ok := r.cfg.Providers[vol.GetStoragePool()]
 	if !ok || provider == nil {
-		return "", false
+		return drbd.GISeed{}, false
 	}
 
 	if !IsThinOrZFS(provider.Kind()) {
-		return "", false
+		return drbd.GISeed{}, false
 	}
 
-	return day0GiFor(resourceName, vol.GetVolumeNumber()), true
+	return drbd.GISeed{Current: day0, BitmapBase: day0}, true
 }
 
 // providerForResource resolves the provider that owns the named

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -234,7 +234,29 @@ type Reconciler struct {
 	// satellite restart resets the table, at worst delaying
 	// recovery by `grace` (default 30s).
 	seenStuckAt map[string]time.Time
+
+	// lastRecoveryPromoteAt throttles the Bug 366 recovery-promote
+	// self-heal (maybeRecoveryPromote). Keyed by resource name; value
+	// is the last wall-clock time this node fired a recovery-promote
+	// for it. runAutoPromote (`primary --force` → mkfs → `secondary`)
+	// itself churns kernel state, generating events2 frames that
+	// re-trigger the reconcile while the predicate still holds (peer
+	// Inconsistent + no Primary mid-resync) — without a throttle the
+	// self-heal hot-loops at ~3 Hz, starving the very resync it is
+	// meant to drive (stand-measured: ~589 re-arms on one staggered
+	// create). The throttle fires the promote at most once per
+	// recoveryPromoteThrottle so the kernel-driven SyncTarget has room
+	// to make progress between nudges. Process-memory only; a restart
+	// resets it (at worst one extra promote).
+	lastRecoveryPromoteAt map[string]time.Time
 }
+
+// recoveryPromoteThrottle bounds how often a single resource may fire
+// the Bug 366 recovery-promote self-heal. Generous relative to a
+// kernel resync's progress cadence but short enough that a genuine
+// wedge (peer truly stuck Inconsistent with no Primary) still gets a
+// fresh nudge promptly.
+const recoveryPromoteThrottle = 10 * time.Second
 
 // NewReconciler constructs a Reconciler from cfg.
 //
@@ -247,9 +269,10 @@ func NewReconciler(cfg ReconcilerConfig) *Reconciler {
 	}
 
 	return &Reconciler{
-		cfg:            cfg,
-		resourceToPool: map[string]string{},
-		seenStuckAt:    map[string]time.Time{},
+		cfg:                   cfg,
+		resourceToPool:        map[string]string{},
+		seenStuckAt:           map[string]time.Time{},
+		lastRecoveryPromoteAt: map[string]time.Time{},
 	}
 }
 
@@ -2293,10 +2316,40 @@ func (r *Reconciler) maybeRecoveryPromote(ctx context.Context, dr *intent.Desire
 		return nil
 	}
 
+	// Throttle: runAutoPromote churns kernel state (promote → mkfs →
+	// demote) which re-triggers this reconcile while the predicate
+	// still holds mid-resync. Firing on every such reconcile hot-loops
+	// at several Hz and starves the SyncTarget. Skip if we already
+	// promoted this resource within recoveryPromoteThrottle — the
+	// kernel resync the previous promote kicked off needs time to make
+	// progress, and a still-genuine wedge gets a fresh nudge once the
+	// window elapses.
+	if !r.recoveryPromoteDue(dr.GetName()) {
+		return nil
+	}
+
 	log.FromContext(ctx).Info("Bug 366 recovery-promote: re-arming auto-primary to unstick wedged initial sync",
 		"resource", dr.GetName())
 
 	return r.runAutoPromote(ctx, dr)
+}
+
+// recoveryPromoteDue reports whether enough time has elapsed since this
+// node last fired a recovery-promote for `name` to fire another, and
+// records the fire time when it returns true. Serialised by r.mu so
+// concurrent reconciles of the same resource can't both pass the gate.
+func (r *Reconciler) recoveryPromoteDue(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	if last, ok := r.lastRecoveryPromoteAt[name]; ok && now.Sub(last) < recoveryPromoteThrottle {
+		return false
+	}
+
+	r.lastRecoveryPromoteAt[name] = now
+
+	return true
 }
 
 // needsAutoMkfsRetry probes whether an auto-primary replica must

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -1640,16 +1640,24 @@ func TestApplyLUKSConvergeNoOpWhenMapperMatches(t *testing.T) {
 // no filesystem (no `FileSystem/Type`), the satellite must:
 //
 //   - stamp every node-id slot with the SAME uniform GI tuple: a
-//     Consistent + UpToDate seed whose bitmap-base is the day0 GID and
-//     whose current-UUID is a fresh random GID distinct from day0
-//     (`<rand>:<day0>:0:0:1:1` — positional consistent+uptodate). The
-//     current-UUID and flags are device-level (shared) in v09, so the
-//     uniform stamp leaves the device with the intended shared
-//     current+flags and every peer slot's bitmap-base = day0;
+//     Consistent + UpToDate seed whose current-UUID is the day0 GID and
+//     whose bitmap-base is EMPTY (`<day0>:0:0:0:1:1` — positional
+//     consistent+uptodate, index-1 bitmap-base = literal "0" =
+//     bitmap-uuid 0x0). The current-UUID and flags are device-level
+//     (shared) in v09, so the uniform stamp leaves the device with the
+//     intended shared current+flags and every peer slot's bitmap-uuid
+//     = 0x0 — matching upstream LINSTOR's working-skip metadata
+//     (captured live via `drbdmeta dump-md`);
 //   - run NO `drbdadm primary --force` and NO `drbdadm secondary` —
 //     the old promote-to-UpToDate is exactly the bug (it minted a
 //     divergent current-UUID and forced a full initial sync of empty
 //     thin volumes).
+//
+// The EMPTY bitmap-base is the load-bearing field: a previous iteration
+// stamped bitmap-base = day0 (non-zero) into every slot, which DRBD
+// read as a live out-of-sync anchor and SyncTargeted a full ~1 GiB
+// resync of an empty thin volume. Upstream's metadata carries
+// bitmap-uuid 0x0 in every slot and skips on the same kernel.
 //
 // On subsequent reconciles (firstActivation=false) the seed must NOT
 // fire again.
@@ -1712,7 +1720,7 @@ func TestApplyAutoPrimaryWinnerReachesUpToDateViaSetGI(t *testing.T) {
 	}
 
 	// Local slot (node-id 0) must carry the Consistent+UpToDate winner
-	// seed: current=<random> distinct from day0, bitmap-base=day0.
+	// seed: current=day0, bitmap-base EMPTY (positional "0").
 	var localSlot string
 	for _, line := range first {
 		if strings.Contains(line, "set-gi --node-id 0 ") {
@@ -1740,28 +1748,31 @@ func TestApplyAutoPrimaryWinnerReachesUpToDateViaSetGI(t *testing.T) {
 		t.Errorf("winner local slot must be Consistent(idx4=1)+UpToDate(idx5=1); got %q", gi)
 	}
 
-	// Winner current-UUID is day0 (the shared lineage anchor), NOT a
-	// fresh random GID — so a staggered late replica seeing this
-	// winner's CurrentGI==day0 recognises it as a day0 sibling and may
-	// also skip the initial sync (and a dual-winner race agrees rather
-	// than split-brains). The Consistent+UpToDate flags are what make
-	// it UpToDate, not a distinct current.
+	// Winner current-UUID is day0 (the shared lineage anchor) — so a
+	// staggered late replica seeing this winner's CurrentGI==day0
+	// recognises it as a day0 sibling and may also skip the initial
+	// sync (and a dual-winner race agrees rather than split-brains).
 	if current != day0 {
 		t.Errorf("winner current-UUID must equal day0 (shared lineage); got current=%s day0=%s", current, day0)
 	}
 
-	if base != day0 {
-		t.Errorf("winner bitmap-base must equal day0; got base=%s day0=%s", base, day0)
+	// Winner bitmap-base must be EMPTY (positional "0" = bitmap-uuid
+	// 0x0). This is the load-bearing field: it matches upstream
+	// LINSTOR's working-skip metadata so DRBD reads a clean bitmap and
+	// skips the resync. A non-zero base (e.g. day0) triggered a full
+	// SyncTarget — the bug.
+	if base != "0" {
+		t.Errorf("winner bitmap-base must be empty (positional 0 = bitmap-uuid 0x0); got base=%s", base)
 	}
 
 	// Every slot gets the SAME uniform GI string. The current-UUID and
 	// the consistent/up-to-date flags are device-level (shared) in v09
 	// metadata, so stamping them identically on every node-id is what
 	// leaves the device with the intended shared current+flags; the
-	// per-peer bitmap-base (day0) is also identical. A peer slot
-	// (node-id 1) therefore carries the exact same tuple as the local
-	// slot — its bitmap-base is day0, which is the lineage anchor that
-	// makes the peer skip the sync.
+	// per-peer bitmap-uuid (0x0, from the empty bitmap-base) is also
+	// identical. A peer slot (node-id 1) therefore carries the exact
+	// same tuple as the local slot — its bitmap-uuid is 0x0, the clean
+	// bitmap that makes the peer skip the sync.
 	wantGI := gi // the local-slot GI tuple extracted above
 	var peerSlot string
 	for _, line := range first {
@@ -1775,7 +1786,7 @@ func TestApplyAutoPrimaryWinnerReachesUpToDateViaSetGI(t *testing.T) {
 	}
 
 	if !strings.HasSuffix(peerSlot, " "+wantGI) {
-		t.Errorf("winner peer slot must carry the same uniform GI %q (day0 bitmap-base); got %q", wantGI, peerSlot)
+		t.Errorf("winner peer slot must carry the same uniform GI %q (empty bitmap-base → bitmap-uuid 0x0); got %q", wantGI, peerSlot)
 	}
 
 	// Second Apply: .res persists → firstActivation=false → seed
@@ -1875,8 +1886,8 @@ func TestApplyAutoPrimaryWinnerSeedsUpToDateOnThickLVM(t *testing.T) {
 		t.Errorf("thick winner current-UUID must be day0 (shared lineage); got %s want %s", parts[0], day0)
 	}
 
-	if parts[1] != day0 {
-		t.Errorf("thick winner bitmap-base must be day0; got %s want %s", parts[1], day0)
+	if parts[1] != "0" {
+		t.Errorf("thick winner bitmap-base must be empty (positional 0 = bitmap-uuid 0x0); got %s", parts[1])
 	}
 }
 
@@ -3267,16 +3278,18 @@ func TestApplyFirstActivationSkipsInitialSyncOnThinOrZFS(t *testing.T) {
 					createMD, setGI, adjust, calls)
 			}
 
-			// Pin the exact day0 GI shape: same current_uuid in BOTH
-			// current_uuid and bitmap_uuid slots, history zeroed,
-			// stamped via `set-gi --node-id <peer>` (DRBD 9.2+
-			// per-peer slot layout). The satellite derives day0
+			// Pin the exact day0 GI shape: current_uuid = day0,
+			// bitmap_uuid EMPTY (positional "0" = bitmap-uuid 0x0),
+			// history zeroed, stamped via `set-gi --node-id <peer>`
+			// (DRBD 9.2+ per-peer slot layout). The empty bitmap-base
+			// matches upstream LINSTOR's working-skip metadata (every
+			// per-peer bitmap-uuid 0x0). The satellite derives day0
 			// deterministically from RD name + volume number — keep
 			// the expected value in sync with
 			// pkg/satellite/providerkind.go's day0GiFor().
 			day0 := satellite.Day0GiForTest("pvc-zskip", 0)
-			wantSetGI := fmt.Sprintf("drbdmeta --force pvc-zskip/0 v09 %s internal set-gi --node-id 1 %s:%s:0:0",
-				tc.wantDevice, day0, day0)
+			wantSetGI := fmt.Sprintf("drbdmeta --force pvc-zskip/0 v09 %s internal set-gi --node-id 1 %s:0:0:0",
+				tc.wantDevice, day0)
 			if !slices.Contains(calls, wantSetGI) {
 				t.Errorf("missing exact day0 set-gi command %q in calls: %v", wantSetGI, calls)
 			}
@@ -3354,8 +3367,8 @@ func TestApplyFirstActivationSeedsEveryPeerSlotConsistently(t *testing.T) {
 	// emitted call sequence MUST follow GetPeers() iteration
 	// (n2 → n3) so both satellites visit slots in the same order
 	// (eliminates an FS-write ordering source of divergence).
-	wantN2 := fmt.Sprintf("drbdmeta --force pvc-race/0 v09 /dev/vg/pvc-race_00000 internal set-gi --node-id 1 %s:%s:0:0", day0, day0)
-	wantN3 := fmt.Sprintf("drbdmeta --force pvc-race/0 v09 /dev/vg/pvc-race_00000 internal set-gi --node-id 2 %s:%s:0:0", day0, day0)
+	wantN2 := fmt.Sprintf("drbdmeta --force pvc-race/0 v09 /dev/vg/pvc-race_00000 internal set-gi --node-id 1 %s:0:0:0", day0)
+	wantN3 := fmt.Sprintf("drbdmeta --force pvc-race/0 v09 /dev/vg/pvc-race_00000 internal set-gi --node-id 2 %s:0:0:0", day0)
 
 	if !slices.Contains(calls, wantN2) {
 		t.Errorf("missing per-peer set-gi for n2 (node-id 1): want %q in calls: %v", wantN2, calls)
@@ -3461,11 +3474,12 @@ func TestApplyFirstActivationSeedsEveryMetadataSlotBlanket(t *testing.T) {
 	day0 := satellite.Day0GiForTest("pvc-blanket", 0)
 
 	// Every slot 0..NodeIDMax must have been stamped with the
-	// identical day0 tuple — including slot 2 (n3, whose node-id was
-	// NOT allocated) and slots 16..31 that no peer occupies.
+	// identical day0 tuple (current=day0, bitmap-base EMPTY → "0") —
+	// including slot 2 (n3, whose node-id was NOT allocated) and slots
+	// 16..31 that no peer occupies.
 	for nodeID := 0; nodeID <= drbd.NodeIDMax; nodeID++ {
-		want := fmt.Sprintf("drbdmeta --force pvc-blanket/0 v09 /dev/vg/pvc-blanket_00000 internal set-gi --node-id %d %s:%s:0:0",
-			nodeID, day0, day0)
+		want := fmt.Sprintf("drbdmeta --force pvc-blanket/0 v09 /dev/vg/pvc-blanket_00000 internal set-gi --node-id %d %s:0:0:0",
+			nodeID, day0)
 		if !slices.Contains(calls, want) {
 			t.Errorf("missing blanket set-gi for node-id %d: want %q in calls", nodeID, want)
 		}
@@ -3506,8 +3520,8 @@ func TestApplyFirstActivationSeedsEveryMetadataSlotBlanket(t *testing.T) {
 	}
 
 	for nodeID := 0; nodeID <= drbd.NodeIDMax; nodeID++ {
-		want := fmt.Sprintf("drbdmeta --force pvc-blanket/0 v09 /dev/vg/pvc-blanket_00000 internal set-gi --node-id %d %s:%s:0:0",
-			nodeID, day0, day0)
+		want := fmt.Sprintf("drbdmeta --force pvc-blanket/0 v09 /dev/vg/pvc-blanket_00000 internal set-gi --node-id %d %s:0:0:0",
+			nodeID, day0)
 
 		idx := slices.Index(calls, want)
 		if idx < 0 {
@@ -3587,12 +3601,12 @@ func TestApplyFirstActivationSeedsLocalSlotBug284(t *testing.T) {
 	day0 := satellite.Day0GiForTest("pvc-b284", 0)
 
 	// The fix MUST emit `set-gi --node-id 0` (the local node-id)
-	// with the day0 tuple in both current/bitmap slots. Without
-	// this call the local current_uuid stays at the random value
-	// drbdadm create-md generated → permanent unrelated-data on
+	// with the day0 tuple: current=day0, bitmap-base EMPTY ("0").
+	// Without this call the local current_uuid stays at the random
+	// value drbdadm create-md generated → permanent unrelated-data on
 	// every future handshake against a later-joining peer.
-	wantLocal := fmt.Sprintf("drbdmeta --force pvc-b284/0 v09 /dev/vg/pvc-b284_00000 internal set-gi --node-id 0 %s:%s:0:0",
-		day0, day0)
+	wantLocal := fmt.Sprintf("drbdmeta --force pvc-b284/0 v09 /dev/vg/pvc-b284_00000 internal set-gi --node-id 0 %s:0:0:0",
+		day0)
 	if !slices.Contains(calls, wantLocal) {
 		t.Errorf("missing local-slot set-gi (Bug 284 fix): want %q in calls: %v", wantLocal, calls)
 	}

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -1949,6 +1949,163 @@ func TestApplyAutoPrimarySkippedWhenConnectedPeerHasData(t *testing.T) {
 	}
 }
 
+// TestMigrateDstDisklessToDiskfulFlipRefusesDay0Skip pins the
+// lifecycle-toggle-migrate regression (CI run 26475612774 lane-6).
+//
+// A `linstor r td --migrate-from` destination joins an existing RD as a
+// connected diskless client, then flips diskful (firstActivation=false,
+// diskfulFlip=true). Since PR #20 the migrate SOURCE reaches UpToDate
+// via `set-gi` at current-uuid == day0 and STAYS there (no write
+// advances it on an empty volume; `primary --force` mints no new UUID on
+// an already-UpToDate node — verified on DRBD 9.3.2). The dispatcher's
+// CRD-status gate (PeerHasData) then mis-classifies that day0 Primary as
+// a never-written day0 sibling (isDay0SeededVolume: CurrentGI == day0)
+// and reports PeerHasData=false, so resolveVolumeSeed reaches its case-A
+// skip branch. The flagless day0 skip seed (clean bitmap, no UpToDate)
+// would leave the destination Inconsistent with nothing to SyncTarget →
+// permanent Inconsistent latch.
+//
+// THE FIX: resolveVolumeSeed gates the case-A skip on the kernel-truth
+// AnyConnectedPeerHasData probe. The flip dst's slot is already
+// connected, so the probe sees the UpToDate peer and REFUSES the skip →
+// no `drbdmeta set-gi` is stamped → the freshly-created metadata stays
+// Inconsistent → DRBD runs a real SyncTarget from the peer → UpToDate.
+//
+// Assertion: NO `drbdmeta ... set-gi` fires (the day0 skip is refused).
+func TestMigrateDstDisklessToDiskfulFlipRefusesDay0Skip(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-mig_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-mig_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-mig_00000|1048576\n")})
+
+	// Kernel slot is loaded as intentional-Diskless (the connected
+	// diskless client the migrate dst was before the flip), with the
+	// migrate source connected and UpToDate. Drives the diskfulFlip
+	// detection AND the new AnyConnectedPeerHasData seed gate.
+	kernelDump := []byte(`pvc-mig role:Secondary
+  volume:0 disk:Diskless client:yes
+  n2 role:Primary
+    volume:0 replication:Established peer-disk:UpToDate
+`)
+	fx.Expect("drbdsetup status pvc-mig",
+		storage.FakeResponse{Stdout: kernelDump})
+	fx.Expect("drbdsetup status --verbose pvc-mig",
+		storage.FakeResponse{Stdout: kernelDump})
+	// The seed gate's kernel-truth probe: a connected peer-device that
+	// is UpToDate must veto the day0 skip seed.
+	fx.Expect("drbdsetup status pvc-mig --json",
+		storage.FakeResponse{Stdout: []byte(`[{"node-id":0,"connections":[{"peer-node-id":1,"name":"n2","connection-state":"Connected","peer_devices":[{"volume":0,"peer-disk-state":"UpToDate"}]}]}]`)})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thin1": thin},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	// Diskful DesiredResource as the dispatcher emits after the migrate
+	// REST handler cleared DISKLESS. PeerHasData is FALSE — exactly the
+	// mis-classification (the day0 Primary looks like a fresh sibling).
+	dr := &intent.DesiredResource{
+		Name:        "pvc-mig",
+		NodeName:    "n1",
+		Flags:       []string{},
+		PeerHasData: false,
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+		},
+		Peers: []intent.DesiredPeer{{Name: "n2"}},
+		DrbdOptions: map[string]string{
+			"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+			"peer.n2.address": "10.0.0.2", "peer.n2.node-id": "1", "peer.n2.port": "7000",
+		},
+	}
+
+	results, err := rec.Apply(t.Context(), []*intent.DesiredResource{dr})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(results) != 1 || !results[0].GetOk() {
+		t.Fatalf("apply result not ok: %+v", results)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "drbdmeta") && strings.Contains(line, "set-gi") {
+			t.Errorf("migrate dst joining a connected UpToDate peer must NOT day0-skip "+
+				"(would latch Inconsistent); the seed must be refused so DRBD SyncTargets. got: %s", line)
+		}
+	}
+}
+
+// TestFreshThinReplicaStillDay0SkipsWhenNoPeerConnected pins the
+// other side of TestMigrateDstDisklessToDiskfulFlipRefusesDay0Skip: the
+// genuinely-fresh skip-init-sync (criterion A) must NOT regress. A fresh
+// thin replica's kernel slot is not yet connected at seed time (the
+// connection establishes during the later `drbdadm adjust`), so the
+// AnyConnectedPeerHasData probe finds nothing and the day0 skip seed
+// still fires — DRBD reads the clean bitmap + shared current and skips
+// the resync.
+func TestFreshThinReplicaStillDay0SkipsWhenNoPeerConnected(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-fresh_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-fresh_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-fresh_00000|1048576\n")})
+
+	// AnyConnectedPeerHasData probe: NO connection yet on a fresh
+	// replica → empty connections list → no data peer → skip proceeds.
+	fx.Expect("drbdsetup status pvc-fresh --json",
+		storage.FakeResponse{Stdout: []byte(`[{"node-id":0,"connections":[]}]`)})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thin1": thin},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	dr := &intent.DesiredResource{
+		Name:        "pvc-fresh",
+		NodeName:    "n1",
+		PeerHasData: false,
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+		},
+		Peers: []intent.DesiredPeer{{Name: "n2"}},
+		DrbdOptions: map[string]string{
+			"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+			"peer.n2.address": "10.0.0.2", "peer.n2.node-id": "1", "peer.n2.port": "7000",
+		},
+	}
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{dr})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	day0 := satellite.Day0GiForTest("pvc-fresh", 0)
+	var sawDay0Skip bool
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "drbdmeta") && strings.Contains(line, "set-gi") &&
+			strings.Contains(line, day0) {
+			sawDay0Skip = true
+			break
+		}
+	}
+	if !sawDay0Skip {
+		t.Errorf("fresh thin replica with no connected data peer must still day0-skip "+
+			"(criterion A: skip-init-sync preserved); expected a set-gi carrying day0=%s, got: %v",
+			day0, fx.CommandLines())
+	}
+}
+
 // TestDeleteResourceClosesLUKSMapper: when the satellite tears down a
 // LUKS-encrypted resource, it must `cryptsetup luksClose` the mapper
 // BEFORE DeleteVolume removes the underlying LV — otherwise the

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -1633,18 +1633,34 @@ func TestApplyLUKSConvergeNoOpWhenMapperMatches(t *testing.T) {
 	}
 }
 
-// TestApplyAutoPrimarySeedFiresOnceOnFirstActivation: with the
-// `auto-primary=true` DRBD option set on first Apply, the satellite
-// must run `drbdadm primary --force` followed by `drbdadm secondary`
-// to seed the resource out of `Inconsistent`. On subsequent reconciles
-// (firstActivation=false because the .res file persists) the seed
-// must NOT fire — running it twice would needlessly bump the bitmap
-// and trigger a network re-sync between peers.
-func TestApplyAutoPrimarySeedFiresOnceOnFirstActivation(t *testing.T) {
+// TestApplyAutoPrimaryWinnerReachesUpToDateViaSetGI: the elected
+// initial-UpToDate winner (`auto-primary=true`, fresh first
+// activation, no data-bearing peer) reaches UpToDate by WRITING GI
+// metadata — NOT by `drbdadm primary --force`. When the RD requests
+// no filesystem (no `FileSystem/Type`), the satellite must:
+//
+//   - stamp every node-id slot with the SAME uniform GI tuple: a
+//     Consistent + UpToDate seed whose bitmap-base is the day0 GID and
+//     whose current-UUID is a fresh random GID distinct from day0
+//     (`<rand>:<day0>:0:0:1:1` — positional consistent+uptodate). The
+//     current-UUID and flags are device-level (shared) in v09, so the
+//     uniform stamp leaves the device with the intended shared
+//     current+flags and every peer slot's bitmap-base = day0;
+//   - run NO `drbdadm primary --force` and NO `drbdadm secondary` —
+//     the old promote-to-UpToDate is exactly the bug (it minted a
+//     divergent current-UUID and forced a full initial sync of empty
+//     thin volumes).
+//
+// On subsequent reconciles (firstActivation=false) the seed must NOT
+// fire again.
+func TestApplyAutoPrimaryWinnerReachesUpToDateViaSetGI(t *testing.T) {
 	dir := t.TempDir()
 	fx := storage.NewFakeExec()
 	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-seed_00000",
 		storage.FakeResponse{Stdout: []byte("")})
+	// Device path resolution after CreateVolume → drives the set-gi seed.
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-seed_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-seed_00000|1048576\n")})
 
 	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
 	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
@@ -1686,12 +1702,80 @@ func TestApplyAutoPrimarySeedFiresOnceOnFirstActivation(t *testing.T) {
 		return n
 	}
 
-	if saw(first, "drbdadm primary --force pvc-seed") != 1 {
-		t.Errorf("first Apply must run primary --force exactly once; got %v", first)
+	// THE FIX: no promote, no demote — UpToDate comes from set-gi.
+	if saw(first, "drbdadm primary --force pvc-seed") != 0 {
+		t.Errorf("winner must reach UpToDate via set-gi, NOT primary --force; got %v", first)
 	}
 
-	if saw(first, "drbdadm secondary pvc-seed") != 1 {
-		t.Errorf("first Apply must run drbdadm secondary exactly once; got %v", first)
+	if saw(first, "drbdadm secondary pvc-seed") != 0 {
+		t.Errorf("no promote → no demote expected; got %v", first)
+	}
+
+	// Local slot (node-id 0) must carry the Consistent+UpToDate winner
+	// seed: current=<random> distinct from day0, bitmap-base=day0.
+	var localSlot string
+	for _, line := range first {
+		if strings.Contains(line, "set-gi --node-id 0 ") {
+			localSlot = line
+		}
+	}
+
+	if localSlot == "" {
+		t.Fatalf("missing set-gi for local node-id 0; got %v", first)
+	}
+
+	// Extract the GI tuple argument (last token). The v09 GI string is
+	// fully positional: current:bitmap:hist0:hist1:consistent:uptodate
+	// — flags are 0/1 ints, NOT name:value pairs.
+	day0 := satellite.Day0GiForTest("pvc-seed", 0)
+	fields := strings.Fields(localSlot)
+	gi := fields[len(fields)-1]
+	parts := strings.Split(gi, ":")
+	if len(parts) < 6 {
+		t.Fatalf("winner local slot must carry positional consistent+uptodate flags; got %q", gi)
+	}
+
+	current, base := parts[0], parts[1]
+	if parts[4] != "1" || parts[5] != "1" {
+		t.Errorf("winner local slot must be Consistent(idx4=1)+UpToDate(idx5=1); got %q", gi)
+	}
+
+	// Winner current-UUID is day0 (the shared lineage anchor), NOT a
+	// fresh random GID — so a staggered late replica seeing this
+	// winner's CurrentGI==day0 recognises it as a day0 sibling and may
+	// also skip the initial sync (and a dual-winner race agrees rather
+	// than split-brains). The Consistent+UpToDate flags are what make
+	// it UpToDate, not a distinct current.
+	if current != day0 {
+		t.Errorf("winner current-UUID must equal day0 (shared lineage); got current=%s day0=%s", current, day0)
+	}
+
+	if base != day0 {
+		t.Errorf("winner bitmap-base must equal day0; got base=%s day0=%s", base, day0)
+	}
+
+	// Every slot gets the SAME uniform GI string. The current-UUID and
+	// the consistent/up-to-date flags are device-level (shared) in v09
+	// metadata, so stamping them identically on every node-id is what
+	// leaves the device with the intended shared current+flags; the
+	// per-peer bitmap-base (day0) is also identical. A peer slot
+	// (node-id 1) therefore carries the exact same tuple as the local
+	// slot — its bitmap-base is day0, which is the lineage anchor that
+	// makes the peer skip the sync.
+	wantGI := gi // the local-slot GI tuple extracted above
+	var peerSlot string
+	for _, line := range first {
+		if strings.Contains(line, "set-gi --node-id 1 ") {
+			peerSlot = line
+		}
+	}
+
+	if peerSlot == "" {
+		t.Fatalf("missing set-gi for peer node-id 1; got %v", first)
+	}
+
+	if !strings.HasSuffix(peerSlot, " "+wantGI) {
+		t.Errorf("winner peer slot must carry the same uniform GI %q (day0 bitmap-base); got %q", wantGI, peerSlot)
 	}
 
 	// Second Apply: .res persists → firstActivation=false → seed
@@ -1710,6 +1794,89 @@ func TestApplyAutoPrimarySeedFiresOnceOnFirstActivation(t *testing.T) {
 	second := fx.CommandLines()
 	if saw(second, "primary --force") != 0 {
 		t.Errorf("idempotent reconcile must NOT re-seed; got %v", second)
+	}
+
+	if saw(second, "set-gi") != 0 {
+		t.Errorf("idempotent reconcile must NOT re-stamp GI; got %v", second)
+	}
+}
+
+// TestApplyAutoPrimaryWinnerSeedsUpToDateOnThickLVM pins that the
+// elected winner reaches UpToDate via set-gi on THICK LVM too — case
+// B is gated on "this node is the elected source", not on the backing
+// kind. The winner's local slot still gets the random+day0+Consistent
+// +UpToDate seed; a non-winner thick replica (covered by
+// TestApplyFirstActivationNoSkipOnLVMThick) gets NO set-gi and resyncs.
+// This is the contrast: thick winner declares itself UpToDate from
+// metadata; thick non-winner stays Inconsistent for a real resync.
+func TestApplyAutoPrimaryWinnerSeedsUpToDateOnThickLVM(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-tw_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-tw_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-tw_00000|1048576\n")})
+
+	thick := lvm.NewThick(lvm.ThickConfig{VolumeGroup: "vg"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thick1": thick},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-tw",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thick1"},
+			},
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+				"auto-primary": "true",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	calls := fx.CommandLines()
+
+	var localSlot string
+	for _, line := range calls {
+		if strings.Contains(line, "set-gi --node-id 0 ") {
+			localSlot = line
+		}
+
+		if strings.Contains(line, "drbdadm primary --force") {
+			t.Errorf("thick winner must reach UpToDate via set-gi, not primary --force; got %s", line)
+		}
+	}
+
+	if localSlot == "" {
+		t.Fatalf("thick winner must seed its local slot UpToDate via set-gi; got %v", calls)
+	}
+
+	day0 := satellite.Day0GiForTest("pvc-tw", 0)
+	fields := strings.Fields(localSlot)
+	gi := fields[len(fields)-1]
+	parts := strings.Split(gi, ":")
+	if len(parts) < 6 {
+		t.Fatalf("thick winner local slot must carry positional consistent+uptodate; got %q", gi)
+	}
+
+	if parts[4] != "1" || parts[5] != "1" {
+		t.Errorf("thick winner local slot must be Consistent(idx4=1)+UpToDate(idx5=1); got %q", gi)
+	}
+
+	if parts[0] != day0 {
+		t.Errorf("thick winner current-UUID must be day0 (shared lineage); got %s want %s", parts[0], day0)
+	}
+
+	if parts[1] != day0 {
+		t.Errorf("thick winner bitmap-base must be day0; got %s want %s", parts[1], day0)
 	}
 }
 
@@ -2483,15 +2650,17 @@ func TestApplyDRBDAllocatesBackingForLateAddedVolume(t *testing.T) {
 }
 
 // TestApplyAutoPrimaryForceErrorWraps pins the auto-primary force
-// error-wrap branch of applyDRBD: when the seed step
+// error-wrap branch of applyDRBD: when the mkfs-promote step
 // `drbdadm primary --force` fails on first activation, applyOne
 // must surface the error tagged with "auto-primary" in the
 // per-resource reply.
 //
-// Without the wrap keyword, an operator can't distinguish a stuck
-// seed (kernel module missing, /dev/drbdN already busy) from the
-// downstream `drbdadm secondary` failure mode that follows the
-// same metadata-shape concerns.
+// `primary --force` now runs ONLY to satisfy mkfs (the RD requests a
+// filesystem via `FileSystem/Type`), so the RD here carries that prop
+// to exercise the promote path; reaching UpToDate itself no longer
+// promotes. Without the wrap keyword an operator can't distinguish a
+// stuck mkfs-promote (kernel module missing, /dev/drbdN busy) from the
+// downstream `drbdadm secondary` failure mode.
 func TestApplyAutoPrimaryForceErrorWraps(t *testing.T) {
 	dir := t.TempDir()
 	fx := storage.NewFakeExec()
@@ -2513,6 +2682,7 @@ func TestApplyAutoPrimaryForceErrorWraps(t *testing.T) {
 		{
 			Name:     "pvc-seed-fail",
 			NodeName: "n1",
+			Props:    map[string]string{"FileSystem/Type": "ext4"},
 			Volumes: []*intent.DesiredVolume{
 				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
 			},

--- a/pkg/satellite/reconciler_internal_test.go
+++ b/pkg/satellite/reconciler_internal_test.go
@@ -125,3 +125,47 @@ func errOrNil(err error) string {
 
 	return err.Error()
 }
+
+// TestRecoveryPromoteDueThrottle pins the Bug 366 recovery-promote
+// throttle (the runaway-hot-loop fix). The first call for a resource
+// must fire (returns true) and record the time; an immediate second
+// call must be throttled (returns false); an independent resource is
+// unaffected; and once recoveryPromoteThrottle has elapsed (simulated
+// by back-dating the recorded time) the resource may fire again.
+//
+// Why this matters: runAutoPromote churns kernel state (promote → mkfs
+// → demote), which re-triggers the satellite reconcile while the
+// recovery predicate still holds mid-resync. Without the throttle the
+// self-heal fired at several Hz (stand-measured ~589 re-arms on one
+// staggered 3-replica create), starving the very kernel-driven
+// SyncTarget it is meant to drive and stretching all-UpToDate well past
+// the scenario's budget. The throttle bounds it to one promote per
+// recoveryPromoteThrottle so the resync makes progress between nudges.
+func TestRecoveryPromoteDueThrottle(t *testing.T) {
+	t.Parallel()
+
+	r := NewReconciler(ReconcilerConfig{})
+
+	if !r.recoveryPromoteDue("rd-a") {
+		t.Fatal("first recoveryPromoteDue(rd-a) = false, want true (must fire on first call)")
+	}
+
+	if r.recoveryPromoteDue("rd-a") {
+		t.Error("immediate second recoveryPromoteDue(rd-a) = true, want false (throttled)")
+	}
+
+	// A different resource is tracked independently and must fire.
+	if !r.recoveryPromoteDue("rd-b") {
+		t.Error("recoveryPromoteDue(rd-b) = false, want true (independent resource not throttled)")
+	}
+
+	// Back-date rd-a's last-fire past the throttle window: it may fire
+	// again (a genuine wedge still gets a fresh nudge once elapsed).
+	r.mu.Lock()
+	r.lastRecoveryPromoteAt["rd-a"] = r.lastRecoveryPromoteAt["rd-a"].Add(-2 * recoveryPromoteThrottle)
+	r.mu.Unlock()
+
+	if !r.recoveryPromoteDue("rd-a") {
+		t.Error("recoveryPromoteDue(rd-a) after throttle window = false, want true (window elapsed)")
+	}
+}


### PR DESCRIPTION
## Root cause

A freshly created **thin** DRBD resource's replicas reached `UpToDate` via a `drbdmeta set-gi` day0 seed (no `drbdadm primary --force`), yet a fresh thin replica still ran a **full ~1 GiB SyncTarget** instead of skipping the initial sync.

Pinned by a side-by-side `drbdmeta dump-md` capture of a working upstream LINSTOR (piraeus, thin pool) versus blockstor on the **same DRBD kernel**:

| | upstream (skips) | blockstor before fix (full-syncs) |
|---|---|---|
| current-uuid (both replicas) | shared value | day0 (shared) |
| flags | `0x411` (Consistent+UpToDate) | `0x411` |
| **per-peer bitmap-uuid (every slot)** | **`0x0000000000000000`** | **`day0` (non-zero)** |
| result | both `UpToDate`, `out_of_sync=0`, no SyncTarget | one replica `SyncTarget`, `~1 GiB` resync |

The decisive field is the **per-peer bitmap-base**. blockstor stamped `bitmap-base = day0` (a non-zero value) into every slot; DRBD's connection handshake reads a non-zero per-peer bitmap-base as a live out-of-sync anchor and flips the peer to `SyncTarget`. Upstream leaves every per-peer `bitmap-uuid = 0x0` — DRBD reads that as "no out-of-sync bits relative to this peer", so with both replicas at the same current-uuid and a clean bitmap it concludes "nothing to copy" and both go straight to `UpToDate`.

## The fix: seed an empty bitmap-base

`resolveVolumeSeed` now leaves the seed's bitmap-base **empty** (`drbdmeta` writes `bitmap-uuid 0x0`) for both the elected-winner (case B) and skip-init-sync (case A) seeds, matching upstream's working-skip metadata byte-for-byte:

- **Elected winner** (first activation, auto-primary, no data-bearing peer): `current = day0`, **bitmap-base EMPTY**, flags `Consistent + UpToDate` → GI string `<day0>:0:0:0:1:1`.
- **Skip-init-sync** (thin/ZFS, non-winner): `current = day0`, **bitmap-base EMPTY**, no flags → `<day0>:0:0:0`.
- **Thick non-winner**: no `set-gi` (unchanged — resyncs from source).
- **Relocate SeedFromGI** (Phase 8.1, copied from a live UpToDate peer): unchanged — `current = bitmap-base = peer GID`, because it anchors against a real peer's generation, not the fresh day0 path.

`current-uuid` stays day0 (the shared deterministic lineage anchor the dispatcher's `isDay0SeededVolume` discriminator relies on) so staggered/relocate safety is preserved. The earlier shape stamped `bitmap-base = day0` into every slot — that non-zero base was the SyncTarget trigger this corrects.

## Stand validation (DRBD 9.3.2, lvm-thin, captured via `drbdmeta dump-md`)

- **A (skip works):** fresh thin **2-replica** AND **3-replica** → all `UpToDate`, **`out_of_sync=0`, zero `SyncTarget`** (instant). `dump-md` active connected slots show `bitmap-uuid 0x0` — identical to the upstream working-skip capture.
- **B (relocate safety):** 64 MiB of known data written, then a fresh diskful replica added → it `SyncTarget`s the real data, reaches `UpToDate`, **md5 matches the source**, never StandAlone. (Proof the empty bitmap-base only skips genuinely-empty volumes; with real data the bitmap correctly tracks the dirty blocks.)
- **C:** 3-replica fresh thin all-skip confirmed; the two diskful replicas stay mutually `UpToDate` (no split-brain, no StandAlone).

The upstream ground truth was captured by deploying piraeus LINSTOR v2.10.0 on the same Talos+DRBD-9.3.2 kernel and reading the live `drbdmeta dump-md` of a thin resource that reaches `UpToDate` with zero resync.

## Tests

`go build ./...`, `go test ./...`, `gofmt -l`, and `make lint` are clean.

Updated unit tests pin the corrected GI tuple (`<day0>:0:0:0[:1:1]`, empty bitmap-base): `TestGISeedStringWinnerSlot`, `TestGISeedStringSkipInitSync`, the winner/thick-winner Apply tests, and the day0-blanket / Bug-284 / race set-gi assertions.


---

## Follow-up fix: migrate/relocate destination must SyncTarget, not day0-skip (lifecycle-toggle-migrate regression)

After the empty-bitmap-base change above, the `lifecycle-toggle-migrate` e2e scenario regressed (CI run 26475612774, lane-6): a `linstor r td --migrate-from` destination latched **Inconsistent** instead of reaching `UpToDate`.

### Root cause

Reproduced on a DRBD 9.3.2 stand and pinned with `drbdadm get-gi`: the migrate **source** (worker-1, Primary, UpToDate) sits at `current-uuid == day0` (`<day0>:0:0:0:1:1`). The winner now reaches UpToDate via `set-gi` at day0 and **never advances past it** on an empty volume — and `primary --force` mints no new current-UUID on a node that is already UpToDate with an in-sync peer (verified live).

Because the source stays at day0, the CRD-status seed gate (`anyDiskfulPeerHasData` -> `isDay0SeededVolume`) can no longer tell that data-bearing day0 Primary apart from a never-written day0 sibling: both report `CurrentGI == day0`. So `PeerHasData` is reported **false**, and on the dst's diskless->diskful flip `resolveVolumeSeed` reaches its **case-A skip** branch. The flagless day0 skip seed gives the dst a clean (zero) bitmap and no UpToDate flag, so DRBD has neither out-of-sync bits to drive a SyncTarget nor a metadata flag to declare it UpToDate — it latches Inconsistent.

The wedge is timing-dependent (it manifests once the observer has back-filled the source's day0 `CurrentGI` before the dst flips): reproduced intermittently in isolation (1 in ~5 runs) and reliably under CI observer-backfill timing.

### The fix

`resolveVolumeSeed` now gates the case-A day0 skip on the kernel-truth `AnyConnectedPeerHasData` probe (the same backstop `shouldForcePromote` uses), immune to the day0 CRD-classification ambiguity:

- A diskless->diskful **flip dst** is on an already-connected slot; the probe sees the UpToDate peer and **refuses the skip** -> the freshly-created metadata stays Inconsistent -> DRBD runs a real **SyncTarget** -> UpToDate.
- A **genuinely-fresh** replica's slot is not connected yet at seed time (the connection establishes during the later `drbdadm adjust`), so the probe finds nothing and the day0 skip still proceeds — the fresh 2-/3-replica skip-init-sync is preserved. The probe is conservative on any failure (returns false -> skip proceeds), so fresh-create behaviour is unchanged.

### Validation (DRBD 9.3.2 stand)

- **Gating proof:** `lifecycle-toggle-migrate` run 10x back-to-back after the fix — all PASS (pre-fix the same scenario wedged Inconsistent ~1 in 5 runs in isolation).
- **A (skip preserved):** fresh thin 2- and 3-replica reach all-UpToDate, `out_of_sync=0`, no SyncTarget.
- **B (real data):** known random data written on the source, then migrated — the dst SyncTargets the real data and its **md5 matches the source**, never StandAlone.

### Tests

New unit tests pin both directions of the corrected decision:
- `TestMigrateDstDisklessToDiskfulFlipRefusesDay0Skip` — flip dst with a connected UpToDate peer emits **no** `set-gi` (skip refused -> SyncTarget). Verified to FAIL without the fix.
- `TestFreshThinReplicaStillDay0SkipsWhenNoPeerConnected` — fresh replica with no connected peer still stamps the day0 skip seed (criterion A preserved).

`go build ./...`, `go test ./...` (pre-existing `pkg/rest` timing flake aside), `gofmt -l`, and `golangci-lint` on the changed package are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed initial synchronization behavior in multi-replica create scenarios; fresh replicas are no longer incorrectly identified as existing data sources during sync decisions.
* Fixed recovery auto-primary self-heal hot-looping by adding per-resource throttling (Bug 366).
* Improved data-bearing peer detection for more reliable and accurate synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->