### PR TITLE
ci(release): publish container images on tag + user install/usage docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release Images
+
+env:
+  # Opt JS actions (e.g. actions/checkout, docker actions) into Node.js 24 —
+  # silences the Node 20 deprecation warning, matching the rest of the CI.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+# Build and publish the three blockstor container images on a version tag.
+#
+# Images (Dockerfile multi-stage targets → canonical ghcr.io paths):
+#   - controller → ghcr.io/cozystack/blockstor
+#   - apiserver  → ghcr.io/cozystack/blockstor-apiserver
+#   - satellite  → ghcr.io/cozystack/blockstor-satellite
+#
+# The repository's dev stand (stand/build-images.sh) builds the exact same
+# three targets into a throwaway localhost:5000 registry with a floating
+# `:dev` tag. This release flow instead pushes to the canonical public
+# registry (ghcr.io, derived from the Go module path
+# github.com/cozystack/blockstor and the short image names used by the stand
+# manifests: blockstor / blockstor-apiserver / blockstor-satellite).
+#
+# Tagging is handled by docker/metadata-action's `type=semver` rules:
+#   tag v1.33.2 → images tagged `1.33.2`, `1.33`, and `latest`.
+#   Pre-release tags (v1.33.0-rc.1) get `1.33.0-rc.1` only — no `latest`.
+# This matches the repo's `vMAJOR.MINOR.PATCH[-rc.N]` tag convention
+# (see `git tag -l`).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Manual trigger for re-publishing a tag (e.g. after a registry outage).
+  # The chosen ref must be a tag for the version stamping to be meaningful.
+  workflow_dispatch:
+
+# GITHUB_TOKEN needs packages:write to push to ghcr.io; contents:read to
+# check out the tagged tree.
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    name: Build and push ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # `target` is the Dockerfile stage; `image` is the ghcr.io repo
+          # suffix under ghcr.io/${{ github.repository_owner }}/.
+          - target: controller
+            image: blockstor
+          - target: apiserver
+            image: blockstor-apiserver
+          - target: satellite
+            image: blockstor-satellite
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # Full history so the in-image git SHA stamp (Bug 171) is the real
+          # commit, not a shallow placeholder. The GIT_HASH build-arg below
+          # is resolved on the runner where the .git tree exists.
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        # Enables cross-arch emulation so the satellite's debian apt install
+        # resolves arm64 packages during the linux/arm64 build leg.
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+          # Tag `latest` only on a stable (non-pre-release) semver tag.
+          flavor: |
+            latest=auto
+
+      - name: Resolve build stamps
+        id: stamp
+        # Mirrors stand/build-images.sh + the top-level Makefile: the
+        # Dockerfile excludes .git via .dockerignore, so the SHA/time are
+        # resolved on the runner and passed in as --build-arg.
+        run: |
+          echo "git_hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%FT%TZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          file: ./Dockerfile
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_HASH=${{ steps.stamp.outputs.git_hash }}
+            BUILD_TIME=${{ steps.stamp.outputs.build_time }}
+          provenance: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ blockstor is a Kubernetes control plane for LVM and ZFS storage with [DRBD](http
 - **First-class CRDs.** `Resource`, `ResourceDefinition`, `ResourceGroup`, `StoragePool`, `Snapshot`, `Node`, `PhysicalDevice`, `ControllerConfig` are designed to be read and (where appropriate) written by other operators: cozystack tenant operators, GitOps tooling, custom monitoring/alerting, admission webhooks. Schemas carry kubebuilder enum/min/max validation; multi-writer Status uses Server-Side Apply field managers.
 - **Per-node satellite as a controller.** Each satellite is a controller-runtime manager that watches its own slice of CRDs (filtered by `Spec.NodeName`) and writes observed state back via Status SSA directly. No gRPC dispatch from a central controller.
 
-See [`docs/architecture.md`](docs/architecture.md) for the load-bearing design notes.
+See [`docs/architecture.md`](docs/architecture.md) for the load-bearing design notes, and [`docs/usage.md`](docs/usage.md) for installing blockstor onto a cluster and driving it with the `linstor` client.
 
 ### Ecosystem fit
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -173,6 +173,118 @@ linstor volume list               # per-volume size and device path
 
 A healthy 3-way replicated volume shows two `UpToDate` diskful replicas plus one `TieBreaker` (diskless) row in `linstor resource list`, all sharing the same DRBD port.
 
+## Dynamic provisioning: piraeus components + the `linstor-csi` driver
+
+So far you have driven blockstor by hand with the `linstor` client. To let Kubernetes provision DRBD-replicated PVs on demand, point the LINBIT CSI driver (`linstor-csi`) at the blockstor apiserver and create a `StorageClass`. The CSI driver speaks the same LINSTOR REST API the `linstor` client does, so blockstor is a drop-in controller backend for it.
+
+### What blockstor replaces — deploy the client side only
+
+blockstor **is** the LINSTOR controller plus the satellites: the controller binary hosts the reconcilers, the apiserver serves the REST API, and the satellite DaemonSet drives DRBD on each node. piraeus is normally a full LINSTOR distribution (operator + `linstor-controller` + `linstor-satellite` + the CSI driver). When running against blockstor you take only the **client-side** pieces from piraeus and skip everything blockstor already provides:
+
+| piraeus component | Against blockstor |
+|-------------------|-------------------|
+| `linstor-controller` | **Skip** — blockstor's controller + apiserver already are the controller. |
+| `linstor-satellite` | **Skip** — blockstor ships its own satellite DaemonSet (`stand/blockstor-satellite-daemonset.yaml`). |
+| `linstor-csi` (csi-controller + csi-node) | **Deploy** — this is what provisions PVs. Point it at the blockstor apiserver. |
+| HA / affinity controller, `drbd-reactor` | Optional — deploy if you want failover/affinity. Point them at the apiserver the same way as the CSI driver (mTLS :3371 + client cert). |
+
+> The dev stand's `make piraeus` (`stand/install-piraeus.sh`) installs piraeus as a **separate, parallel** LINSTOR stack for coexistence testing — it brings up piraeus's own controller and satellites and does **not** point them at blockstor. Do not copy that path for a blockstor-backed cluster; use the wiring below instead.
+
+### Point `linstor-csi` at the blockstor apiserver
+
+The CSI driver's controller endpoint is the apiserver's mTLS Service on port **3371** — the same `blockstor-controller` Service the `linstor` client resolves (the plain-HTTP debug port 3370 is pod-local and is not an option here). `linstor-csi` wraps `golinstor`, which upgrades the endpoint to HTTPS and presents a client certificate when the `LS_USER_*` / `LS_ROOT_CA` variables point at PEM files. The exact wiring (verbatim from `stand/csi-sanity-job.yaml`, the in-repo reference for a CSI client against blockstor):
+
+```yaml
+image: quay.io/piraeusdatastore/piraeus-csi:v1.10.1
+args:
+  - --csi-endpoint=$(CSI_ENDPOINT)
+  - --node=$(KUBE_NODE_NAME)            # downward-API spec.nodeName; must match a blockstor Node name
+  - --linstor-endpoint=$(LS_CONTROLLERS)
+env:
+  - {name: CSI_ENDPOINT,        value: "unix:///csi/csi.sock"}
+  - name: KUBE_NODE_NAME
+    valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
+  # mTLS endpoint — the only port the Service exposes.
+  - {name: LS_CONTROLLERS,      value: "https://blockstor-controller.blockstor-system.svc:3371"}
+  - {name: LS_USER_CERTIFICATE, value: "/etc/linstor/client/tls.crt"}
+  - {name: LS_USER_KEY,         value: "/etc/linstor/client/tls.key"}
+  - {name: LS_ROOT_CA,          value: "/etc/linstor/client/ca.crt"}
+volumeMounts:
+  - {name: client-tls, mountPath: /etc/linstor/client, readOnly: true}
+volumes:
+  - name: client-tls
+    secret:
+      secretName: blockstor-apiserver-client-tls
+```
+
+Apply the same `LS_CONTROLLERS` / `LS_USER_*` / `LS_ROOT_CA` env and the same `client-tls` mount to **both** the csi-controller Deployment and the csi-node DaemonSet. If you deploy `linstor-csi` through the piraeus operator instead of plain manifests, set the cluster's external controller URL to the same `https://blockstor-controller.blockstor-system.svc:3371` and mount the same client Secret — verify the exact field name for your piraeus-operator version.
+
+### mTLS client certificate via cert-manager
+
+The apiserver runs a `RequireAndVerifyClientCert` TLS listener and verifies every client cert against the CA it was issued from, so the CSI driver needs a client cert from that same CA. `stand/blockstor-apiserver-tls.yaml` provisions the whole chain with cert-manager:
+
+```
+ca-bootstrapper (self-signed Issuer)
+  └─> blockstor-api-ca (CA Certificate, 10y)
+        └─> blockstor-api-ca (CA Issuer)
+              ├─> blockstor-apiserver-server  (serving cert; Service DNS SANs) → Secret blockstor-apiserver-server-tls
+              └─> blockstor-apiserver-client   (client cert for in-cluster consumers) → Secret blockstor-apiserver-client-tls
+```
+
+The `blockstor-apiserver-client` Certificate emits Secret `blockstor-apiserver-client-tls` carrying `tls.crt`, `tls.key` **and** `ca.crt`. Mount that Secret into the CSI pods (as above): `tls.crt`/`tls.key` authenticate the client to the apiserver, and `ca.crt` lets the client verify the apiserver's serving cert. cert-manager rotates these in place and the apiserver hot-reloads them without a restart, so no reloader annotations are needed. The serving cert's SANs already cover the `blockstor-controller` Service name, so dialing `https://blockstor-controller.blockstor-system.svc:3371` validates cleanly.
+
+If the CSI driver runs in a different namespace from the apiserver, replicate the client Secret there (e.g. issue a second `Certificate` from the same `blockstor-api-ca` Issuer into that namespace) — a Secret is namespace-scoped and the Issuer must be reachable.
+
+### Create a StorageClass and a PVC
+
+Use the `linstor.csi.linbit.com` provisioner. The parameter keys are the standard `linstor.csi.linbit.com/*`-prefixed CSI keys; the values map onto blockstor's resource-group / storage-pool / placement semantics. The shape below mirrors `tests/smoke.sh`:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: blockstor-replicated
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: "data"     # the blockstor storage pool to place diskful replicas in
+  linstor.csi.linbit.com/placementCount: "2"      # number of diskful replicas (autoplacer adds a tiebreaker)
+  # Optional — pin volumes to a resource group you pre-created with `linstor resource-group create`.
+  # The default RG is the canonical "DfltRscGrp".
+  # linstor.csi.linbit.com/resourceGroup: "mygroup"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: blockstor-test
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: blockstor-replicated
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+`storagePool` and `placementCount` are the keys exercised by blockstor's own smoke and csi-sanity tests, and `resourceGroup` is honored verbatim (the default RG is `DfltRscGrp`). Other `linstor.csi.linbit.com/*` keys that upstream `linstor-csi` supports — e.g. `layerList`, `disklessStoragePool`, `allowRemoteVolumeAccess` — are passed straight through to the LINSTOR REST API; verify the ones you rely on against your deployment before depending on them.
+
+### Verify
+
+```sh
+kubectl get pvc blockstor-test                 # PVC should bind once a consumer schedules it
+kubectl get pv                                  # the bound PV's name is the LINSTOR resource name (pvc-<uuid>)
+```
+
+Then confirm the resource shows up through the `linstor` client (port-forward or in-cluster, as above):
+
+```sh
+linstor resource-definition list   # a pvc-<uuid> RD appears
+linstor resource list              # placementCount diskful replicas (UpToDate) + a TieBreaker, sharing one DRBD port
+linstor volume list                # the backing volume and its device path
+```
+
+A bound PVC plus an `UpToDate` resource in `linstor resource list` confirms the CSI driver is provisioning against blockstor end to end.
+
 ## Cleanup
 
 Deleting the resource-definition removes every replica, frees the DRBD port, and tears down the backing volumes:
@@ -180,3 +292,5 @@ Deleting the resource-definition removes every replica, frees the DRBD port, and
 ```sh
 linstor resource-definition delete myvolume
 ```
+
+For CSI-provisioned volumes, delete the PVC instead (`kubectl delete pvc blockstor-test`) — the CSI driver issues the resource-definition delete for you.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,182 @@
+# Installing and using blockstor
+
+This guide covers deploying blockstor onto a Kubernetes cluster and driving it with the upstream `linstor` command-line client. blockstor exposes a LINSTOR-compatible REST API, so the stock `linstor` client (`python-linstor` / `linstor-client`) works unchanged.
+
+If you only want a throwaway local dev environment, use the Talos+QEMU stand instead (`make up && make blockstor`, see the [README](../README.md) Quick start). This page is for installing onto a real cluster.
+
+## Components
+
+blockstor ships three container images, published by CI on every version tag (see [`.github/workflows/release.yml`](../.github/workflows/release.yml)):
+
+| Image | Dockerfile target | Role |
+|-------|-------------------|------|
+| `ghcr.io/cozystack/blockstor` | `controller` | controller-runtime manager hosting the RD / RG / RP / Snapshot / Resource / Node reconcilers. Runs as a Deployment. |
+| `ghcr.io/cozystack/blockstor-apiserver` | `apiserver` | Stateless LINSTOR-compatible REST front end backed by the CRD store. Runs as a multi-replica Deployment behind a Service. This is what the `linstor` client, linstor-csi and piraeus-operator talk to. |
+| `ghcr.io/cozystack/blockstor-satellite` | `satellite` | Per-node manager that reconciles the DRBD / LUKS / STORAGE layers and shells out to `drbdadm` / `lvs` / `zfs` / `cryptsetup`. Runs as a DaemonSet on storage nodes. |
+
+Each tag publishes `MAJOR.MINOR.PATCH`, `MAJOR.MINOR`, and (for stable, non pre-release tags) `latest`.
+
+## Host requirements
+
+Storage nodes that run the satellite need:
+
+- The DRBD 9 kernel module loaded (`modprobe drbd`).
+- `drbd-utils`, `lvm2`, `cryptsetup`, and (for ZFS pools) the ZFS kernel module plus `zfsutils-linux`. The satellite image ships the userspace tools; the kernel modules come from the host (for Talos, via the `siderolabs/drbd` and `siderolabs/zfs` extensions).
+- At least one spare block device or a pre-created LVM volume group / ZFS pool to back the storage pools.
+
+## Deploy
+
+The reference manifests live under `config/crd/bases/` (CRDs) and `stand/` (the controller / apiserver / satellite workloads). Apply in this order:
+
+1. **CRDs** — `Resource`, `ResourceDefinition`, `ResourceGroup`, `StoragePool`, `Snapshot`, `Node`, `PhysicalDevice`, `ControllerConfig`:
+
+   ```sh
+   kubectl apply -f config/crd/bases/
+   ```
+
+2. **Node CRs** — one cluster-scoped `Node` per storage node, with `metadata.name` equal to the Kubernetes node name. These can be created up front (the satellites also reconcile against them) or registered later through the `linstor` client (see below). A minimal Node CR:
+
+   ```yaml
+   apiVersion: blockstor.cozystack.io/v1alpha1
+   kind: Node
+   metadata:
+     name: worker-1
+   spec:
+     type: SATELLITE
+     netInterfaces:
+       - name: default
+         address: 10.0.0.11   # the node's InternalIP, used for DRBD replication
+   ```
+
+3. **Workloads** — the controller, apiserver, and satellite DaemonSet. The manifests in `stand/` carry an `__REGISTRY__/<image>:dev` placeholder for the dev stand; for a real cluster set the `image:` fields to the published tags, e.g. `ghcr.io/cozystack/blockstor:<TAG>`, `ghcr.io/cozystack/blockstor-apiserver:<TAG>`, `ghcr.io/cozystack/blockstor-satellite:<TAG>`:
+
+   - `stand/blockstor-deploy.yaml` — controller + RBAC + the `blockstor-system` namespace.
+   - `stand/blockstor-apiserver-deploy.yaml` — apiserver Deployment + Service.
+   - `stand/blockstor-satellite-daemonset.yaml` — satellite DaemonSet.
+
+All workloads run in the `blockstor-system` namespace. Wait for them to come up:
+
+```sh
+kubectl -n blockstor-system rollout status deploy/blockstor-controller
+kubectl -n blockstor-system rollout status deploy/blockstor-apiserver
+kubectl -n blockstor-system rollout status daemonset/blockstor-satellite
+```
+
+## Point the `linstor` client at the apiserver
+
+Install the client (`apt install linstor-client`, or `pip install python-linstor`). The apiserver Service exposes a mutual-TLS listener on port **3371**; a plain-HTTP debug port **3370** is bound pod-local only. The simplest way to reach it from a workstation is a port-forward to the plain-HTTP port:
+
+```sh
+kubectl -n blockstor-system port-forward deploy/blockstor-apiserver 3370:3370
+```
+
+Then point the client at it (set this once per shell):
+
+```sh
+export LS_CONTROLLERS=http://localhost:3370
+# or pass --controllers on every call:
+linstor --controllers http://localhost:3370 node list
+```
+
+For in-cluster clients (linstor-csi, piraeus-operator) use the mTLS Service endpoint on 3371 with the issued client certificate instead of the port-forward.
+
+A quick connectivity check:
+
+```sh
+linstor controller version
+linstor node list
+```
+
+> Note: `linstor controller version` reports the blockstor version with a `git=blockstor` build stamp (e.g. `1.33.2+ git=blockstor`) rather than a hex commit hash — this is intentional. See [`docs/cli-parity-known-deltas.md`](cli-parity-known-deltas.md) for the full list of user-visible divergences from upstream LINSTOR (notably `advise`, `backup`, and `schedule` subcommands are not implemented).
+
+## Basic setup, end to end
+
+The commands below assume `LS_CONTROLLERS` is exported (otherwise add `--controllers …`). Replace node names, devices, and pool names with your own.
+
+### 1. Register nodes
+
+If you did not pre-create the `Node` CRs, register each satellite node:
+
+```sh
+linstor node create worker-1 10.0.0.11
+linstor node create worker-2 10.0.0.12
+linstor node create worker-3 10.0.0.13
+linstor node list
+```
+
+The IP is the address used for DRBD replication traffic between nodes. Each node automatically gets a `DfltDisklessStorPool` (diskless) pool so it can host diskless replicas and tiebreakers.
+
+### 2. Create a storage pool from a physical device
+
+The one-shot way is `physical-storage create-device-pool` (short: `ps cdp`), which prepares the device and registers the pool in a single call. For a ZFS pool on `/dev/sdb`:
+
+```sh
+linstor physical-storage create-device-pool \
+    --pool-name data --storage-pool data zfs worker-1 /dev/sdb
+```
+
+`zfs` selects the provider (also `lvm`, `lvmthin`, `zfsthin`). Repeat per node, or pass multiple devices to build a multi-device pool. If you already have a volume group or ZFS pool, register it directly instead:
+
+```sh
+linstor storage-pool create lvmthin worker-1 data my_vg/my_thinpool
+```
+
+Check the pools (and their free capacity) once the satellite has reported back:
+
+```sh
+linstor storage-pool list
+```
+
+### 3. Define a resource group (recommended)
+
+A resource group captures replication and placement policy once, so each volume spawned from it inherits the settings:
+
+```sh
+linstor resource-group create mygroup --place-count 3 --storage-pool data
+linstor volume-group create mygroup
+linstor resource-group list
+```
+
+### 4. Create a replicated volume
+
+There are two equivalent paths.
+
+**One-shot via the resource group** — creates the resource-definition, volume-definition, replicas, and tiebreaker in a single call:
+
+```sh
+linstor resource-group spawn mygroup myvolume 10G
+```
+
+**Explicit, step by step** — useful when you are not using a resource group:
+
+```sh
+linstor resource-definition create myvolume
+linstor volume-definition create myvolume 10G
+linstor resource create myvolume --auto-place 3 --storage-pool data
+```
+
+`--auto-place N` lets the autoplacer pick N nodes (capacity-weighted, anti-affinity aware). To pin replicas to specific nodes instead, name them:
+
+```sh
+linstor resource create worker-1 worker-2 myvolume --storage-pool data
+```
+
+### 5. Inspect state
+
+```sh
+linstor node list                 # nodes and their online status
+linstor storage-pool list         # pools, provider, free/total capacity
+linstor resource-definition list  # resource definitions and their groups
+linstor resource list             # per-node replica placement and DRBD state
+linstor volume list               # per-volume size and device path
+```
+
+A healthy 3-way replicated volume shows two `UpToDate` diskful replicas plus one `TieBreaker` (diskless) row in `linstor resource list`, all sharing the same DRBD port.
+
+## Cleanup
+
+Deleting the resource-definition removes every replica, frees the DRBD port, and tears down the backing volumes:
+
+```sh
+linstor resource-definition delete myvolume
+```


### PR DESCRIPTION
## What

Two related deliverables for shipping blockstor to users:

1. **Release CI** — a new `.github/workflows/release.yml` that builds the three blockstor container images and publishes them to `ghcr.io/cozystack` on every version tag (`v*`).
2. **User docs** — a new `docs/usage.md` covering install + a full basic setup driven by the upstream `linstor` client, linked from the README.

## Release workflow

- Triggers on `push` of a `v*` tag, plus `workflow_dispatch` for manual re-publish.
- Builds all three Dockerfile multi-stage targets and pushes them to the canonical registry:
  - `controller` target → `ghcr.io/cozystack/blockstor`
  - `apiserver` target → `ghcr.io/cozystack/blockstor-apiserver`
  - `satellite` target → `ghcr.io/cozystack/blockstor-satellite`
- Image names are derived from the Go module path (`github.com/cozystack/blockstor`) and the short names the dev-stand build script already uses (`stand/build-images.sh`: `blockstor` / `blockstor-apiserver` / `blockstor-satellite`).
- Tagging via `docker/metadata-action` semver rules: a `v1.33.2` push publishes `1.33.2`, `1.33`, and `latest`; pre-release tags (e.g. `v1.33.0-rc.1`) publish only their exact version, no `latest`.
- Authenticates to ghcr.io with the built-in `GITHUB_TOKEN` (`permissions: packages: write`); no new repository secrets required.
- Multi-arch `linux/amd64,linux/arm64` (the Go binaries cross-compile with `CGO_ENABLED=0`; the satellite's Debian base resolves per-arch packages under QEMU emulation).
- Stamps the real git SHA and build time via `--build-arg`, matching the stand build script (the Dockerfile excludes `.git` via `.dockerignore`).
- Follows the existing CI conventions: SHA-pinned actions, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, least-privilege `permissions`. Validated with `actionlint` (no findings).

## Docs

`docs/usage.md` walks an end user through:

- The three published images and their roles.
- Host requirements for satellite nodes (DRBD/ZFS kernel modules, userspace tools).
- Deploying CRDs, Node CRs, and the controller/apiserver/satellite workloads, pointing the manifests' image fields at the published ghcr.io tags.
- Pointing the `linstor` client at the apiserver (port-forward to the plain-HTTP debug port for ad-hoc use; mTLS Service port for in-cluster clients).
- A full happy-path setup: register nodes, create a storage pool from a physical device (`physical-storage create-device-pool`), define a resource group, spawn / autoplace a replicated volume, and inspect state.
- The user-visible divergences from upstream LINSTOR (intentional version stamp; `advise`/`backup`/`schedule` not implemented), cross-linking `docs/cli-parity-known-deltas.md`.

## Why

The repo had no release pipeline — images were only ever built into a throwaway `localhost:5000` registry by the dev stand. This adds a reproducible path to publish versioned, multi-arch images to the canonical public registry, and gives users a single page to go from zero to a replicated volume.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment guide covering Kubernetes setup, node registration, storage pool creation, volume management, and dynamic provisioning with CSI driver integration and mTLS certificate configuration.
  * Updated README to reference new usage documentation.

* **Chores**
  * Implemented automated multi-architecture container image publishing workflow for release builds when version tags are pushed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->