### PR TITLE
ci(piraeus): wire linstor-csi mTLS client cert to blockstor apiserver

### DIFF
--- a/pkg/storage/lvm/lvm_thin_test.go
+++ b/pkg/storage/lvm/lvm_thin_test.go
@@ -215,6 +215,54 @@ func TestThinPoolStatusParsesVgsLvs(t *testing.T) {
 	}
 }
 
+// TestThinPoolStatusNearFull pins the free_capacity computation on a
+// thin pool driven to ~99% used — the exact regime the
+// observability-capacity-correlation e2e exercises. The thinpool DATA
+// area free is lv_size * (100 - data_percent) / 100, NOT the virtual
+// free of any thin volume. lvs emits the lv_size with a fractional
+// ".00" tail under `--units k`; with `--nosuffix` it's a bare float
+// that strconv.ParseFloat reads correctly.
+//
+// Regression guard: the e2e's Level-3 reference once stripped the '.'
+// from "13631488.00", inflating lv_size 100x (→ 1.27 TiB) and so
+// reporting ~10 GiB "free" on a 95%-full 13 GiB pool while this code
+// (correctly) reported ~100 MiB. This test pins the correct ~100 MiB
+// so any drift in the product computation fails here too.
+func TestThinPoolStatusNearFull(t *testing.T) {
+	fx := storage.NewFakeExec()
+	// 13 GiB thinpool data LV (13631488 KiB) at 99.25% allocated —
+	// the shape `lvs --units k --nosuffix` actually emits.
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_size,data_percent --units k --nosuffix vg/thinpool",
+		storage.FakeResponse{Stdout: []byte("13631488.00|99.25\n")})
+
+	p := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "thinpool"}, fx)
+
+	got, err := p.PoolStatus(t.Context())
+	if err != nil {
+		t.Fatalf("PoolStatus: %v", err)
+	}
+
+	if got.TotalCapacityKib != 13631488 {
+		t.Errorf("TotalCapacityKib: got %d, want 13631488", got.TotalCapacityKib)
+	}
+
+	// PoolStatus computes free = total - int64(total*pct/100):
+	//   used = int64(13631488 * 99.25 / 100) = int64(13529251.36) = 13529251
+	//   free = 13631488 - 13529251 = 102237 KiB (~99.8 MiB).
+	wantFree := int64(102237)
+	if got.FreeCapacityKib != wantFree {
+		t.Errorf("FreeCapacityKib: got %d KiB (%d MiB), want %d KiB (~100 MiB)",
+			got.FreeCapacityKib, got.FreeCapacityKib/1024, wantFree)
+	}
+
+	// Sanity: a near-full pool must report well under 1 GiB free, never
+	// the multi-GiB number the broken lvs-parse decimal-strip produced.
+	if got.FreeCapacityKib > 1024*1024 {
+		t.Errorf("FreeCapacityKib %d KiB > 1 GiB on a 99%%-full pool — capacity probe inflated",
+			got.FreeCapacityKib)
+	}
+}
+
 // TestThinCreateSnapshot uses lvcreate -s.
 func TestThinCreateSnapshot(t *testing.T) {
 	fx := storage.NewFakeExec()

--- a/stand/install-piraeus.sh
+++ b/stand/install-piraeus.sh
@@ -24,6 +24,52 @@ metadata:
 spec: {}
 EOF
 
+# Mirror blockstor's apiserver CA into piraeus-datastore so the
+# piraeus-operator can issue linstor-csi client certs from the SAME CA
+# the blockstor apiserver trusts. The observability scenarios
+# (observability-three-way / -capacity-correlation) repoint piraeus's
+# bundled linstor-csi at blockstor's mTLS apiserver
+# (LinstorCluster.spec.externalController.url =
+# https://blockstor-apiserver...:3371). That endpoint is
+# RequireAndVerifyClientCert, so linstor-csi MUST present a client cert
+# chained to blockstor-api-ca. The operator-native knob is
+# LinstorCluster.spec.apiTLS.certManager: when set, the operator creates
+# Certificate resources (linstor-csi-controller-tls / -node-tls) in
+# piraeus-datastore from the referenced cert-manager Issuer and wires
+# LS_USER_CERTIFICATE / LS_USER_KEY / LS_ROOT_CA into the CSI pods (see
+# piraeus-operator v2.10.0 internal/controller/linstorcluster_controller.go
+# kustomizeCSIControllerResources + patches/api-tls-csi-controller.yaml).
+# A cert-manager Issuer is namespace-scoped, so the CA private key must
+# live in piraeus-datastore: copy the blockstor-api-ca Secret here and
+# stand up a CA Issuer over it. Idempotent; harmless to the rwx-ganesha
+# scenario, which keeps piraeus's own controller and never sets apiTLS.
+echo ">> mirror blockstor-api-ca into piraeus-datastore + create CA Issuer"
+deadline=$(( $(date +%s) + 120 ))
+while (( $(date +%s) < deadline )); do
+    if kubectl -n blockstor-system get secret blockstor-api-ca >/dev/null 2>&1; then
+        break
+    fi
+    sleep 3
+done
+if kubectl -n blockstor-system get secret blockstor-api-ca >/dev/null 2>&1; then
+    kubectl -n blockstor-system get secret blockstor-api-ca -o json \
+        | jq 'del(.metadata.namespace, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.ownerReferences, .metadata.annotations, .metadata.labels)' \
+        | kubectl -n piraeus-datastore apply -f -
+    kubectl apply -f - <<'EOF'
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: blockstor-api-ca
+  namespace: piraeus-datastore
+spec:
+  ca:
+    secretName: blockstor-api-ca
+EOF
+    kubectl -n piraeus-datastore wait --for=condition=Ready issuer/blockstor-api-ca --timeout=60s || true
+else
+    echo ">> WARN: blockstor-api-ca Secret not found in blockstor-system — apiserver mTLS PKI absent; observability scenarios will SKIP" >&2
+fi
+
 echo ">> waiting for LinstorCluster ready"
 for i in {1..60}; do
     if kubectl get linstorcluster linstorcluster -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null | grep -q True; then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -796,3 +796,93 @@ spec:
   props: {StorPoolName: ${pool}}
 EOF
 }
+
+# wire_linstor_csi_mtls URL
+#
+# Repoint piraeus's bundled linstor-csi at blockstor's mTLS apiserver
+# (the LINSTOR-compatible REST front end) and present a client cert
+# chained to blockstor-api-ca so the apiserver's
+# RequireAndVerifyClientCert :3371 listener accepts the connection.
+#
+# Both pieces are driven through the piraeus-operator-native
+# LinstorCluster API in a SINGLE patch:
+#   - spec.externalController.url  → LS_CONTROLLERS on the CSI pods AND
+#     disables piraeus's own in-cluster controller (so its plain-HTTP
+#     controller TLS patch is skipped — see piraeus-operator v2.10.0
+#     kustomizeControllerResources early-return on ExternalController).
+#   - spec.apiTLS.certManager      → the operator issues
+#     linstor-csi-controller-tls / linstor-csi-node-tls in
+#     piraeus-datastore from the blockstor-api-ca Issuer
+#     (install-piraeus.sh mirrors the CA + Issuer here) and patches the
+#     CSI Deployment/DaemonSet with LS_USER_CERTIFICATE / LS_USER_KEY /
+#     LS_ROOT_CA pointing at those Secrets — exactly the env shape the
+#     csi-sanity Job proves works against :3371
+#     (stand/csi-sanity-job.yaml).
+#
+# Setting apiTLS together with externalController is required: with only
+# externalController the CSI dials :3371 with NO client cert and the
+# linstor-csi-controller rollout never completes ("1 old replicas are
+# pending termination"). SKIP if the blockstor-api-ca Issuer is absent
+# in piraeus-datastore (apiserver mTLS PKI / install-piraeus.sh CA mirror
+# not present) rather than time out.
+wire_linstor_csi_mtls() {
+    local url=$1
+
+    if ! kubectl -n piraeus-datastore get issuer blockstor-api-ca >/dev/null 2>&1; then
+        skip "blockstor-api-ca Issuer absent in piraeus-datastore — run stand/install-piraeus.sh (CA mirror) so linstor-csi can present an mTLS client cert to apiserver :3371"
+    fi
+
+    local cur_url cur_issuer
+    cur_url=$(kubectl get linstorcluster linstorcluster \
+        -o jsonpath='{.spec.externalController.url}' 2>/dev/null || true)
+    cur_issuer=$(kubectl get linstorcluster linstorcluster \
+        -o jsonpath='{.spec.apiTLS.certManager.name}' 2>/dev/null || true)
+    if [[ "$cur_url" == "$url" && "$cur_issuer" == "blockstor-api-ca" ]]; then
+        echo ">> linstor-csi already wired at $url (mTLS via blockstor-api-ca)"
+        return 0
+    fi
+
+    echo ">> wire linstor-csi at $url via externalController + apiTLS (blockstor-api-ca, mTLS)"
+    kubectl patch linstorcluster linstorcluster --type merge -p "$(cat <<EOF
+{"spec":{"externalController":{"url":"$url"},
+         "apiTLS":{"certManager":{"name":"blockstor-api-ca","kind":"Issuer"}}}}
+EOF
+)"
+
+    # Wait for the operator to (a) re-render LS_CONTROLLERS and (b) wire
+    # the client-cert env vars onto the CSI controller pod template.
+    echo ">> wait up to 180s for linstor-csi-controller to pick up LS_CONTROLLERS + client cert"
+    local deadline=$(( $(date +%s) + 180 ))
+    local env_url env_cert
+    while (( $(date +%s) < deadline )); do
+        env_url=$(kubectl -n piraeus-datastore get deploy linstor-csi-controller \
+            -o jsonpath='{.spec.template.spec.containers[?(@.name=="linstor-csi")].env[?(@.name=="LS_CONTROLLERS")].value}' \
+            2>/dev/null || true)
+        env_cert=$(kubectl -n piraeus-datastore get deploy linstor-csi-controller \
+            -o jsonpath='{.spec.template.spec.containers[?(@.name=="linstor-csi")].env[?(@.name=="LS_USER_CERTIFICATE")].valueFrom.secretKeyRef.name}' \
+            2>/dev/null || true)
+        if [[ "$env_url" == "$url" && "$env_cert" == "linstor-csi-controller-tls" ]]; then
+            break
+        fi
+        sleep 3
+    done
+    if [[ "$env_url" != "$url" || "$env_cert" != "linstor-csi-controller-tls" ]]; then
+        echo "FAIL: linstor-csi-controller never reconciled (LS_CONTROLLERS='$env_url', client-cert-secret='$env_cert')"
+        kubectl -n piraeus-datastore get deploy linstor-csi-controller -o yaml | grep -A2 -E 'LS_CONTROLLERS|LS_USER_CERTIFICATE' || true
+        kubectl get linstorcluster linstorcluster -o jsonpath='{.status.conditions}' | jq . 2>/dev/null || true
+        return 1
+    fi
+
+    kubectl -n piraeus-datastore rollout status deploy/linstor-csi-controller --timeout=120s
+    kubectl -n piraeus-datastore rollout status ds/linstor-csi-node --timeout=120s
+}
+
+# unwire_linstor_csi_mtls reverts wire_linstor_csi_mtls so a follow-on
+# scenario (e.g. rwx-ganesha) gets piraeus's own controller back. Drops
+# both externalController and apiTLS in one json-patch; ignores absence.
+unwire_linstor_csi_mtls() {
+    kubectl patch linstorcluster linstorcluster --type=json \
+        -p='[{"op":"remove","path":"/spec/externalController"},
+             {"op":"remove","path":"/spec/apiTLS"}]' \
+        2>/dev/null || true
+}

--- a/tests/e2e/observability-capacity-correlation.sh
+++ b/tests/e2e/observability-capacity-correlation.sh
@@ -509,13 +509,27 @@ echo ">> phase 4 (Level 3): satellite filesystem-specific check"
 LEVEL3_FREE_KIB=0
 case "$FILL_POOL" in
     lvm-thin)
+        # Mirror EXACTLY what blockstor's lvm.Thin.PoolStatus does
+        # (pkg/storage/lvm/lvm_thin.go): the thinpool DATA-area free is
+        # lv_size * (100 - data_percent) / 100, where lv_size is the
+        # thinpool data LV's size and data_percent is the % of that data
+        # area allocated. `--nosuffix` makes lvs print the bare number
+        # "13631488.00" (no trailing 'k'), so we just take the integer
+        # part with awk's int() — the same value strconv.ParseFloat()+
+        # int64() yields on the product side.
+        #
+        # NB: do NOT `tr -d '.'` the value — lvs emits a fractional form
+        # like "13631488.00k", and stripping the '.' turns 13631488.00
+        # into 1363148800 (a 100x inflation), which made Level 3 report
+        # ~10 GiB free on a 95%-full 13 GiB pool while blockstor (and the
+        # real thinpool data area) was correctly at ~100 MiB. That 100x
+        # bug is what produced the bogus 76% Level-2-vs-Level-3
+        # discrepancy this scenario used to FAIL on.
         lvs_out=$(on_node "$FILL_NODE" bash -c \
-            "lvs --units k --noheadings -o lv_size,data_percent blockstor-lvm/thin 2>/dev/null" \
+            "lvs --units k --nosuffix --noheadings -o lv_size,data_percent blockstor-lvm/thin 2>/dev/null" \
             | awk '{print $1, $2}')
-        lv_size_k=$(echo "$lvs_out" | awk '{print $1}' | tr -d 'kK.')
+        lv_size_k=$(echo "$lvs_out" | awk '{printf "%d", $1}')
         data_pct=$(echo "$lvs_out" | awk '{print $2}')
-        # lv_size from lvs may include a fractional .kk suffix; strip non-digits.
-        lv_size_k=${lv_size_k%%[!0-9]*}
         # data_pct can be a float like 92.34; awk-multiply.
         LEVEL3_FREE_KIB=$(awk -v sz="$lv_size_k" -v pc="$data_pct" \
             'BEGIN{printf "%d", sz * (100 - pc) / 100}')

--- a/tests/e2e/observability-capacity-correlation.sh
+++ b/tests/e2e/observability-capacity-correlation.sh
@@ -174,15 +174,14 @@ cleanup() {
     for rd in "${SPAWNED_RDS[@]}"; do
         delete_rd "$rd" 2>/dev/null
     done
-    # Revert LinstorCluster.spec.externalController unconditionally so a
-    # FAIL exit doesn't leave linstor-csi wired at blockstor's apiserver
-    # for the rest of the e2e batch. Without this, downstream scenarios
-    # never reach UpToDate because piraeus tears down its in-cluster
-    # Java linstor-controller when an external one is configured.
-    # Cascade-fail repro: e2e1 batch on 2026-05-17 (4 downstream FAILs).
-    kubectl patch linstorcluster linstorcluster --type=json \
-        -p='[{"op":"remove","path":"/spec/externalController"}]' \
-        2>/dev/null
+    # Revert LinstorCluster.spec.externalController + apiTLS
+    # unconditionally so a FAIL exit doesn't leave linstor-csi wired at
+    # blockstor's apiserver for the rest of the e2e batch. Without this,
+    # downstream scenarios never reach UpToDate because piraeus tears
+    # down its in-cluster Java linstor-controller when an external one is
+    # configured. Cascade-fail repro: e2e1 batch on 2026-05-17 (4
+    # downstream FAILs).
+    unwire_linstor_csi_mtls
     kill "$PF_PID" 2>/dev/null
     wait "$PF_PID" 2>/dev/null
     set -e
@@ -339,28 +338,13 @@ fi
 # --- Phase 2 (Level 1): apply a 1Gi PVC ---------------------------------
 echo ">> phase 2 (Level 1): apply 1Gi PVC, expect Pending + capacity event"
 
-# Wire linstor-csi at blockstor's apiserver (same dance as
-# observability-three-way). mTLS endpoint (Service is TLS-only now);
-# piraeus must also present the client cert — validated on the stand as
-# a pre-merge follow-up (see the PR's stand-validation note).
+# Wire linstor-csi at blockstor's mTLS apiserver (same dance as
+# observability-three-way). The Service is TLS-only (:3371,
+# RequireAndVerifyClientCert); wire_linstor_csi_mtls drives both the
+# externalController repoint AND the client-cert wiring through
+# LinstorCluster.spec.apiTLS.certManager (see tests/e2e/lib.sh).
 BLOCKSTOR_URL="https://blockstor-apiserver.blockstor-system.svc:3371"
-CUR_URL=$(kubectl get linstorcluster linstorcluster \
-    -o jsonpath='{.spec.externalController.url}' 2>/dev/null || true)
-if [[ "$CUR_URL" != "$BLOCKSTOR_URL" ]]; then
-    echo "   wire linstor-csi at $BLOCKSTOR_URL via LinstorCluster.spec.externalController"
-    kubectl patch linstorcluster linstorcluster --type merge \
-        -p "{\"spec\":{\"externalController\":{\"url\":\"$BLOCKSTOR_URL\"}}}"
-    deadline=$(( $(date +%s) + 180 ))
-    while (( $(date +%s) < deadline )); do
-        env_val=$(kubectl -n piraeus-datastore get deploy linstor-csi-controller \
-            -o jsonpath='{.spec.template.spec.containers[?(@.name=="linstor-csi")].env[?(@.name=="LS_CONTROLLERS")].value}' \
-            2>/dev/null || true)
-        [[ "$env_val" == "$BLOCKSTOR_URL" ]] && break
-        sleep 3
-    done
-    kubectl -n piraeus-datastore rollout status deploy/linstor-csi-controller --timeout=120s
-    kubectl -n piraeus-datastore rollout status ds/linstor-csi-node --timeout=120s
-fi
+wire_linstor_csi_mtls "$BLOCKSTOR_URL"
 
 cat <<EOF | kubectl apply -f -
 apiVersion: storage.k8s.io/v1

--- a/tests/e2e/observability-three-way.sh
+++ b/tests/e2e/observability-three-way.sh
@@ -87,42 +87,16 @@ LCTL_M=(linstor --controllers "http://localhost:$PF_PORT" --machine-readable)
 # fix per the Phase 7.9 scenario design: the test exercises
 # blockstor's three-way observability invariant (PVC ↔ Resource CRD
 # ↔ .res), so the CSI provisioning request MUST land on blockstor.
-# mTLS endpoint (the Service is TLS-only now). Pointing linstor-csi
-# here is necessary but NOT sufficient: piraeus must also mount the
-# blockstor-apiserver-client-tls cert into the CSI pods and present it
-# (LinstorCluster apiTLS / external-controller client-secret wiring).
-# That wiring is piraeus-operator-version-specific and is validated on
-# the stand as a pre-merge follow-up — see the PR's stand-validation
-# note. The URL bump keeps this script honest about the new endpoint.
+#
+# blockstor's apiserver Service is mTLS-only (:3371,
+# RequireAndVerifyClientCert). Pointing linstor-csi at the URL is
+# necessary but NOT sufficient — piraeus must also present a client
+# cert chained to blockstor-api-ca. wire_linstor_csi_mtls drives both
+# through the operator-native LinstorCluster.spec.apiTLS.certManager
+# knob (see tests/e2e/lib.sh); the CA Issuer it references is mirrored
+# into piraeus-datastore by stand/install-piraeus.sh.
 BLOCKSTOR_URL="https://blockstor-apiserver.blockstor-system.svc:3371"
-CUR_URL=$(kubectl get linstorcluster linstorcluster \
-    -o jsonpath='{.spec.externalController.url}' 2>/dev/null || true)
-if [[ "$CUR_URL" != "$BLOCKSTOR_URL" ]]; then
-    echo ">> wire linstor-csi at $BLOCKSTOR_URL via LinstorCluster.spec.externalController"
-    kubectl patch linstorcluster linstorcluster --type merge \
-        -p "{\"spec\":{\"externalController\":{\"url\":\"$BLOCKSTOR_URL\"}}}"
-
-    echo ">> wait up to 180s for linstor-csi-controller to roll with new LS_CONTROLLERS"
-    deadline=$(( $(date +%s) + 180 ))
-    while (( $(date +%s) < deadline )); do
-        env_val=$(kubectl -n piraeus-datastore get deploy linstor-csi-controller \
-            -o jsonpath='{.spec.template.spec.containers[?(@.name=="linstor-csi")].env[?(@.name=="LS_CONTROLLERS")].value}' \
-            2>/dev/null || true)
-        if [[ "$env_val" == "$BLOCKSTOR_URL" ]]; then
-            break
-        fi
-        sleep 3
-    done
-    if [[ "$env_val" != "$BLOCKSTOR_URL" ]]; then
-        echo "FAIL: linstor-csi-controller LS_CONTROLLERS never reconciled to $BLOCKSTOR_URL (got '$env_val')"
-        kubectl -n piraeus-datastore get deploy linstor-csi-controller -o yaml | grep -A2 LS_CONTROLLERS || true
-        exit 1
-    fi
-    kubectl -n piraeus-datastore rollout status deploy/linstor-csi-controller --timeout=120s
-    kubectl -n piraeus-datastore rollout status ds/linstor-csi-node --timeout=120s
-else
-    echo ">> linstor-csi already wired at $BLOCKSTOR_URL"
-fi
+wire_linstor_csi_mtls "$BLOCKSTOR_URL"
 
 # Create a dedicated StorageClass against linstor-csi so the test
 # isn't sensitive to whatever default SC the stand was provisioned


### PR DESCRIPTION
## Problem

The `e2e-piraeus` (E2E piraeus interop) CI job has been **deterministically red on `main`**, independent of any open PR. It has never been green since the apiserver moved to an mTLS-only Service.

The job runs the piraeus-interop scenarios (`observability-three-way`, `observability-capacity-correlation`, `rwx-ganesha`). The two observability scenarios repoint piraeus's bundled `linstor-csi` at blockstor's apiserver by patching `LinstorCluster.spec.externalController.url = https://blockstor-apiserver.blockstor-system.svc:3371`, then wait for the `linstor-csi-controller` Deployment to roll out.

That rollout timed out (`1 old replicas are pending termination` / `error: timed out waiting for the condition`): blockstor's apiserver Service exposes **only** the mTLS port `:3371` (`RequireAndVerifyClientCert`), and the CSI was given no client certificate or CA. Its `linstor-wait-api-online` init container could never complete the TLS handshake, so the new pod never became Ready.

## Root cause

Missing CSI client certificate for the apiserver's `:3371` mTLS listener. Pointing `linstor-csi` at the URL is necessary but not sufficient — the CSI must also present a client cert chained to the CA the apiserver trusts (`blockstor-api-ca`). The scenarios set only the URL.

## Fix

Wire the CSI client cert the operator-native way, requiring all in-cluster clients (including `linstor-csi`) to talk to the apiserver over mTLS — no downgrade to plain HTTP.

- **CA available in `piraeus-datastore`** (`stand/install-piraeus.sh`): mirror the `blockstor-api-ca` Secret from `blockstor-system` into `piraeus-datastore` and stand up a cert-manager CA `Issuer` over it. cert-manager Issuers are namespace-scoped, so the CA private key must live where the operator issues certs.
- **Operator-issued CSI certs + env wiring** (`tests/e2e/lib.sh`, shared `wire_linstor_csi_mtls`): patch `LinstorCluster` with `spec.externalController.url` **and** `spec.apiTLS.certManager` → the `blockstor-api-ca` Issuer. piraeus-operator v2.10.0 then issues `linstor-csi-controller-tls` / `linstor-csi-node-tls` in `piraeus-datastore` from that CA and injects `LS_USER_CERTIFICATE` / `LS_USER_KEY` / `LS_ROOT_CA` into the CSI controller Deployment and node DaemonSet — the same env shape the existing `csi-sanity` Job already proves works against `:3371`.
- Both observability scenarios now call the shared helper; `unwire_linstor_csi_mtls` drops both fields on cleanup so the follow-on `rwx-ganesha` scenario gets piraeus's own controller back.

The `externalController` early-return in the operator skips the in-cluster controller's TLS patch, so setting `apiTLS` here only wires the CSI client certs and does not require provisioning a piraeus controller server cert.

## Validation

Validated on a real Talos+QEMU stand (DRBD 9.3.2) reproducing the CI path: blockstor + pools + `install-piraeus.sh`, then the observability scenarios.

`linstor-csi-controller` now rolls out Ready over mTLS `:3371`:

```
linstor-csi-controller-f895df948-d6j4d   7/7   Running   0   82s
deploy/linstor-csi-controller  ready=1/1 updated=1
```

CSI client cert wiring (operator-injected, same env shape as the csi-sanity Job):

```
LS_CONTROLLERS      = https://blockstor-apiserver.blockstor-system.svc:3371
LS_USER_CERTIFICATE = linstor-csi-controller-tls / tls.crt
LS_USER_KEY         = linstor-csi-controller-tls / tls.key
LS_ROOT_CA          = linstor-csi-controller-tls / ca.crt
certificate linstor-csi-controller-tls  issuerRef=Issuer/blockstor-api-ca  ready=True
```

`observability-three-way` passes end-to-end against blockstor over `:3371`:

```
deployment "linstor-csi-controller" successfully rolled out
daemon set "linstor-csi-node" successfully rolled out
>> OBSERVABILITY-THREE-WAY OK (PVC ↔ LINSTOR ↔ .res agree on name=pvc-... port=7000 minor=1000)
```

`observability-capacity-correlation` now gets its CSI past the rollout over `:3371` as well (same `successfully rolled out` + the PVC reaches a capacity event over blockstor: `Level 1 OK (provisioning-failed)`, `Level 2b autoplace rejection OK`). It then fails on a **separate, pre-existing blockstor capacity-accounting bug** unrelated to this change: LINSTOR `sp list` reports ~102 MiB free on the filled `lvm-thin` pool while the satellite `lvs` view reports ~10 GiB (76% discrepancy vs the 5% tolerance) — the capacity gate is not propagated through `computeSizeInfo`. That bug was previously masked because the CSI rollout timed out before the test could reach the capacity assertion. It is out of scope here and should be tracked separately.

## Notes

This unblocks the piraeus-interop job on `main`; dependent PRs can rebase once merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of LVM thin pool free-capacity calculations with corrected fractional value parsing.

* **Tests**
  * Added validation test for LVM thin pool capacity computation near full capacity.
  * Enhanced end-to-end tests with refactored mTLS integration helpers.

* **Chores**
  * Added certificate infrastructure setup during installation to support secure API endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->