### PR TITLE
ci(release): rename controller image to blockstor-controller + link images to repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
 # Build and publish the three blockstor container images on a version tag.
 #
 # Images (Dockerfile multi-stage targets → canonical ghcr.io paths):
-#   - controller → ghcr.io/cozystack/blockstor
+#   - controller → ghcr.io/cozystack/blockstor-controller
 #   - apiserver  → ghcr.io/cozystack/blockstor-apiserver
 #   - satellite  → ghcr.io/cozystack/blockstor-satellite
 #
@@ -17,7 +17,7 @@ env:
 # `:dev` tag. This release flow instead pushes to the canonical public
 # registry (ghcr.io, derived from the Go module path
 # github.com/cozystack/blockstor and the short image names used by the stand
-# manifests: blockstor / blockstor-apiserver / blockstor-satellite).
+# manifests: blockstor-controller / blockstor-apiserver / blockstor-satellite).
 #
 # Tagging is handled by docker/metadata-action's `type=semver` rules:
 #   tag v1.33.2 → images tagged `1.33.2`, `1.33`, and `latest`.
@@ -55,7 +55,7 @@ jobs:
           # `target` is the Dockerfile stage; `image` is the ghcr.io repo
           # suffix under ghcr.io/${{ github.repository_owner }}/.
           - target: controller
-            image: blockstor
+            image: blockstor-controller
           - target: apiserver
             image: blockstor-apiserver
           - target: satellite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          # OCI labels from metadata-action include
+          # org.opencontainers.image.source=<repo URL>, which lets GHCR
+          # auto-link each published package to cozystack/blockstor and inherit
+          # the repo's visibility. `annotations` carries the same metadata onto
+          # the multi-arch image index manifest.
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             GIT_HASH=${{ steps.stamp.outputs.git_hash }}
             BUILD_TIME=${{ steps.stamp.outputs.build_time }}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,7 +48,7 @@ The reference manifests live under `config/crd/bases/` (CRDs) and `stand/` (the 
          address: 10.0.0.11   # the node's InternalIP, used for DRBD replication
    ```
 
-3. **Workloads** — the controller, apiserver, and satellite DaemonSet. The manifests in `stand/` carry an `__REGISTRY__/<image>:dev` placeholder for the dev stand; for a real cluster set the `image:` fields to the published tags, e.g. `ghcr.io/cozystack/blockstor:<TAG>`, `ghcr.io/cozystack/blockstor-apiserver:<TAG>`, `ghcr.io/cozystack/blockstor-satellite:<TAG>`:
+3. **Workloads** — the controller, apiserver, and satellite DaemonSet. The manifests in `stand/` carry an `__REGISTRY__/<image>:dev` placeholder for the dev stand; for a real cluster set the `image:` fields to the published tags, e.g. `ghcr.io/cozystack/blockstor-controller:<TAG>`, `ghcr.io/cozystack/blockstor-apiserver:<TAG>`, `ghcr.io/cozystack/blockstor-satellite:<TAG>`:
 
    - `stand/blockstor-deploy.yaml` — controller + RBAC + the `blockstor-system` namespace.
    - `stand/blockstor-apiserver-deploy.yaml` — apiserver Deployment + Service.

--- a/stand/blockstor-deploy.yaml
+++ b/stand/blockstor-deploy.yaml
@@ -73,7 +73,7 @@ spec:
       serviceAccountName: blockstor-controller
       containers:
         - name: manager
-          image: __REGISTRY__/blockstor:dev
+          image: __REGISTRY__/blockstor-controller:dev
           imagePullPolicy: Always
           args:
             # REST API moved to the separate apiserver Deployment

--- a/stand/build-images.sh
+++ b/stand/build-images.sh
@@ -92,8 +92,8 @@ push() {
     echo ">> $short pinned: $digest"
 }
 
-echo ">> docker build $REGISTRY/blockstor:dev (controller stage)"
-docker build "${BUILD_ARGS[@]}" --target controller -t "$REGISTRY/blockstor:dev" .
+echo ">> docker build $REGISTRY/blockstor-controller:dev (controller stage)"
+docker build "${BUILD_ARGS[@]}" --target controller -t "$REGISTRY/blockstor-controller:dev" .
 
 echo ">> docker build $REGISTRY/blockstor-apiserver:dev (apiserver stage)"
 docker build "${BUILD_ARGS[@]}" --target apiserver -t "$REGISTRY/blockstor-apiserver:dev" .
@@ -101,7 +101,7 @@ docker build "${BUILD_ARGS[@]}" --target apiserver -t "$REGISTRY/blockstor-apise
 echo ">> docker build $REGISTRY/blockstor-satellite:dev (satellite stage)"
 docker build "${BUILD_ARGS[@]}" --target satellite  -t "$REGISTRY/blockstor-satellite:dev" .
 
-push blockstor
+push blockstor-controller
 push blockstor-apiserver
 push blockstor-satellite
 

--- a/stand/render-manifest.sh
+++ b/stand/render-manifest.sh
@@ -4,7 +4,7 @@
 #
 # Reads stand/blockstor-*.yaml on stdin via $2, substitutes:
 #   __REGISTRY__                              → <bridge-gateway>:5000
-#   __REGISTRY__/blockstor:dev                → <reg>/blockstor@sha256:<digest>
+#   __REGISTRY__/blockstor-controller:dev     → <reg>/blockstor-controller@sha256:<digest>
 #   __REGISTRY__/blockstor-apiserver:dev      → <reg>/blockstor-apiserver@sha256:<digest>
 #   __REGISTRY__/blockstor-satellite:dev      → <reg>/blockstor-satellite@sha256:<digest>
 # and writes the result to stdout. Digests come from
@@ -56,7 +56,7 @@ render_image() {
     fi
 }
 
-CONTROLLER_IMG=$(render_image blockstor)
+CONTROLLER_IMG=$(render_image blockstor-controller)
 APISERVER_IMG=$(render_image blockstor-apiserver)
 SATELLITE_IMG=$(render_image blockstor-satellite)
 
@@ -64,7 +64,7 @@ SATELLITE_IMG=$(render_image blockstor-satellite)
 # the catch-all `__REGISTRY__` doesn't rewrite the image line before
 # the digest can attach. After the first match the image line no
 # longer contains `__REGISTRY__` and the second sed is a no-op.
-sed -e "s|__REGISTRY__/blockstor:dev|$CONTROLLER_IMG|g" \
+sed -e "s|__REGISTRY__/blockstor-controller:dev|$CONTROLLER_IMG|g" \
     -e "s|__REGISTRY__/blockstor-apiserver:dev|$APISERVER_IMG|g" \
     -e "s|__REGISTRY__/blockstor-satellite:dev|$SATELLITE_IMG|g" \
     -e "s|__REGISTRY__|$REGISTRY|g" \


### PR DESCRIPTION
## What

Rename the published controller image from `blockstor` to `blockstor-controller`, so all three images share a consistent `blockstor-*` naming scheme:

- `ghcr.io/cozystack/blockstor-controller` — reconcilers (was `blockstor`)
- `ghcr.io/cozystack/blockstor-apiserver` — LINSTOR-compatible REST API
- `ghcr.io/cozystack/blockstor-satellite` — per-node DRBD / storage agent

## Why

`blockstor` (unqualified) read as "the whole product" rather than "the controller component", which was confusing next to the two already-suffixed images. A uniform `blockstor-<component>` scheme makes the package list self-describing.

## Image → repository link

`docker/metadata-action` already emits the `org.opencontainers.image.source` label (wired via `labels: ${{ steps.meta.outputs.labels }}` in the build-push step), which is what links each GHCR package back to this repository. This PR additionally passes `annotations: ${{ steps.meta.outputs.annotations }}` so the `source` annotation lands on the multi-arch **index** manifest as well, not just the per-arch image configs — so the link is visible on the top-level package.

## Changes

- `.github/workflows/release.yml` — controller matrix target `blockstor` → `blockstor-controller`; emit OCI annotations.
- `stand/build-images.sh`, `stand/render-manifest.sh`, `stand/blockstor-deploy.yaml` — local build + deploy short-name kept in sync with the published name.
- `docs/usage.md` — published controller image reference.

No code changes; image rename + CI metadata only.
