### PR TITLE
feat: shift default DRBD port/minor windows off upstream LINSTOR's

### DIFF
--- a/api/v1alpha1/node_types.go
+++ b/api/v1alpha1/node_types.go
@@ -61,14 +61,14 @@ type NodeSpec struct {
 	// drbdPortRange is the inclusive [min, max] TCP port range the
 	// allocator picks DRBD listen ports from for replicas placed on
 	// this node. Replaces `Props["DrbdOptions/TcpPortRange"]`. nil
-	// inherits the controller-wide default (7000–7999). Phase 10.3.
+	// inherits the controller-wide default (20000–20999). Phase 10.3.
 	// +optional
 	DRBDPortRange *PortRange `json:"drbdPortRange,omitempty"`
 
 	// drbdMinorRange is the inclusive [min, max] /dev/drbd<N> minor
 	// range the allocator picks from. Replaces
 	// `Props["DrbdOptions/MinorNrRange"]`. nil inherits the
-	// controller-wide default (1000–1099). Phase 10.3.
+	// controller-wide default (20000–65535). Phase 10.3.
 	// +optional
 	DRBDMinorRange *PortRange `json:"drbdMinorRange,omitempty"`
 }

--- a/api/v1alpha1/resource_types.go
+++ b/api/v1alpha1/resource_types.go
@@ -181,7 +181,7 @@ type ResourceSpec struct {
 	// taken-set is the ports already used by OTHER Resources ON THE
 	// SAME NODE, so the same port number is freely reused across
 	// different nodes — this scales to 1000+ resources per node
-	// instead of exhausting a cluster-unique 7000-7999 window at
+	// instead of exhausting a cluster-unique 20000-20999 window at
 	// ~1000 resources cluster-wide. The optional RD.Spec.DRBDPort
 	// preferred seed is tried first on each node.
 	//

--- a/config/crd/bases/blockstor.cozystack.io_nodes.yaml
+++ b/config/crd/bases/blockstor.cozystack.io_nodes.yaml
@@ -44,7 +44,7 @@ spec:
                   drbdMinorRange is the inclusive [min, max] /dev/drbd<N> minor
                   range the allocator picks from. Replaces
                   `Props["DrbdOptions/MinorNrRange"]`. nil inherits the
-                  controller-wide default (1000–1099). Phase 10.3.
+                  controller-wide default (20000–65535). Phase 10.3.
                 properties:
                   max:
                     description: max is the upper bound (inclusive). Must be ≥ Min.
@@ -65,7 +65,7 @@ spec:
                   drbdPortRange is the inclusive [min, max] TCP port range the
                   allocator picks DRBD listen ports from for replicas placed on
                   this node. Replaces `Props["DrbdOptions/TcpPortRange"]`. nil
-                  inherits the controller-wide default (7000–7999). Phase 10.3.
+                  inherits the controller-wide default (20000–20999). Phase 10.3.
                 properties:
                   max:
                     description: max is the upper bound (inclusive). Must be ≥ Min.

--- a/config/crd/bases/blockstor.cozystack.io_resources.yaml
+++ b/config/crd/bases/blockstor.cozystack.io_resources.yaml
@@ -244,7 +244,7 @@ spec:
                   taken-set is the ports already used by OTHER Resources ON THE
                   SAME NODE, so the same port number is freely reused across
                   different nodes — this scales to 1000+ resources per node
-                  instead of exhausting a cluster-unique 7000-7999 window at
+                  instead of exhausting a cluster-unique 20000-20999 window at
                   ~1000 resources cluster-wide. The optional RD.Spec.DRBDPort
                   preferred seed is tried first on each node.
 

--- a/internal/controller/adopted_subwindow_test.go
+++ b/internal/controller/adopted_subwindow_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	"github.com/cozystack/blockstor/pkg/drbd"
+)
+
+// TestAdoptedSubWindowPortMinorPreserved pins the migration/adoption
+// contract: resources adopted from an existing LINSTOR cluster keep
+// their original LINSTOR-assigned port/minor verbatim, even though
+// those values sit BELOW blockstor's allocation window (TCP
+// 20000-20999, minors 20000-65535). The allocator must NOT clamp,
+// reject, or re-allocate an explicit sub-window value, and a fresh
+// sibling on the SAME node must still allocate from the high window
+// (proving the low value isn't treated as "the default base").
+//
+// LINSTOR assigns e.g. port 7050 and minor 1042 — both below the
+// blockstor window. After the allocator runs, the adopted replica must
+// still carry exactly 7050 / 1042.
+func TestAdoptedSubWindowPortMinorPreserved(t *testing.T) {
+	t.Parallel()
+
+	const (
+		adoptedPort  int32 = 7050
+		adoptedMinor int32 = 1042
+	)
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(
+			&blockstoriov1alpha1.Resource{},
+			&blockstoriov1alpha1.ResourceDefinition{},
+		).
+		Build()
+
+	// Adopted RD: explicit sub-window minor on its volume-0 definition.
+	rdName := "pvc-adopted"
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: rdName},
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			VolumeDefinitions: []blockstoriov1alpha1.ResourceDefinitionVolume{
+				{VolumeNumber: 0, SizeKib: 1024, DRBDMinor: int32Ptr(adoptedMinor)},
+			},
+		},
+	}
+	if err := cli.Create(ctx, rd); err != nil {
+		t.Fatalf("create adopted rd: %v", err)
+	}
+
+	// Adopted replica on w1: explicit sub-window Spec.DRBDPort + node-id.
+	adopted := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: rdName + ".w1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: rdName,
+			NodeName:               "w1",
+			DRBDPort:               int32Ptr(adoptedPort),
+			DRBDNodeID:             int32Ptr(0),
+		},
+	}
+	if err := cli.Create(ctx, adopted); err != nil {
+		t.Fatalf("create adopted resource: %v", err)
+	}
+
+	// A freshly-created sibling RD also lands on w1 (same node) — its
+	// allocation must come from the high window and must NOT collide
+	// with the adopted low port.
+	freshRDName := "pvc-fresh"
+
+	freshRD := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: freshRDName},
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			VolumeDefinitions: []blockstoriov1alpha1.ResourceDefinitionVolume{
+				{VolumeNumber: 0, SizeKib: 1024},
+			},
+		},
+	}
+	if err := cli.Create(ctx, freshRD); err != nil {
+		t.Fatalf("create fresh rd: %v", err)
+	}
+
+	create(ctx, t, cli, freshRDName, "w1")
+
+	rec := &controllerpkg.ResourceReconciler{Client: cli, Scheme: scheme}
+	allocate(ctx, t, rec, cli, rdName)
+	allocate(ctx, t, rec, cli, freshRDName)
+
+	// The adopted replica's explicit sub-window port survives untouched.
+	gotAdopted := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: rdName + ".w1"}, gotAdopted); err != nil {
+		t.Fatalf("get adopted resource: %v", err)
+	}
+
+	if gotAdopted.Spec.DRBDPort == nil || *gotAdopted.Spec.DRBDPort != adoptedPort {
+		t.Errorf("adopted Spec.DRBDPort=%v, want %d preserved verbatim (no clamp/re-alloc)",
+			gotAdopted.Spec.DRBDPort, adoptedPort)
+	}
+
+	// The adopted RD's explicit sub-window minor survives untouched.
+	gotRD := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: rdName}, gotRD); err != nil {
+		t.Fatalf("get adopted rd: %v", err)
+	}
+
+	if len(gotRD.Spec.VolumeDefinitions) == 0 ||
+		gotRD.Spec.VolumeDefinitions[0].DRBDMinor == nil ||
+		*gotRD.Spec.VolumeDefinitions[0].DRBDMinor != adoptedMinor {
+		t.Errorf("adopted volume-0 minor=%v, want %d preserved verbatim (no clamp/re-alloc)",
+			minorOf(gotRD), adoptedMinor)
+	}
+
+	// The fresh sibling on the same node allocates from the high window
+	// and never lands on the adopted low values.
+	gotFresh := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: freshRDName + ".w1"}, gotFresh); err != nil {
+		t.Fatalf("get fresh resource: %v", err)
+	}
+
+	if gotFresh.Spec.DRBDPort == nil {
+		t.Fatalf("fresh Spec.DRBDPort not allocated")
+	}
+
+	freshPort := *gotFresh.Spec.DRBDPort
+	if freshPort < drbd.DefaultPortMin || freshPort > drbd.DefaultPortMax {
+		t.Errorf("fresh port %d outside default window [%d,%d]",
+			freshPort, drbd.DefaultPortMin, drbd.DefaultPortMax)
+	}
+
+	if freshPort == adoptedPort {
+		t.Errorf("fresh port %d collided with adopted sub-window port on same node", freshPort)
+	}
+
+	gotFreshRD := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: freshRDName}, gotFreshRD); err != nil {
+		t.Fatalf("get fresh rd: %v", err)
+	}
+
+	freshMinor := minorOf(gotFreshRD)
+	if freshMinor < drbd.DefaultMinorMin || freshMinor > drbd.DefaultMinorMax {
+		t.Errorf("fresh minor %d outside default window [%d,%d]",
+			freshMinor, drbd.DefaultMinorMin, drbd.DefaultMinorMax)
+	}
+
+	if freshMinor == adoptedMinor {
+		t.Errorf("fresh minor %d collided with adopted sub-window minor", freshMinor)
+	}
+}
+
+// minorOf returns the volume-0 minor of an RD, or -1 when unset.
+func minorOf(rd *blockstoriov1alpha1.ResourceDefinition) int32 {
+	for i := range rd.Spec.VolumeDefinitions {
+		if rd.Spec.VolumeDefinitions[i].VolumeNumber == 0 &&
+			rd.Spec.VolumeDefinitions[i].DRBDMinor != nil {
+			return *rd.Spec.VolumeDefinitions[i].DRBDMinor
+		}
+	}
+
+	return -1
+}

--- a/internal/controller/bug_306_batch_autoplace_port_collision_test.go
+++ b/internal/controller/bug_306_batch_autoplace_port_collision_test.go
@@ -35,7 +35,7 @@ import (
 // /autoplace & done; wait` — and the controller's per-RD port
 // allocator races on the cluster-wide taken-set read. Two RDs
 // reconciling concurrently both observe taken=∅, both pick the
-// lowest free port (7000), and both Status().Update succeed
+// lowest free port (20000), and both Status().Update succeed
 // because Kubernetes optimistic concurrency is per-object: two
 // different RDs writing to their OWN statuses don't conflict.
 // Result: N RDs get the SAME DRBD port, the satellite-side .res
@@ -177,7 +177,7 @@ func TestBug306BatchAutoplacePortsUnique(t *testing.T) {
 	}
 
 	// Assert (identity-to-spec / per-node port model):
-	//   1. Every replica has a non-nil Spec.DRBDPort, inside 7000-7999.
+	//   1. Every replica has a non-nil Spec.DRBDPort, inside 20000-20999.
 	//   2. PER-NODE port uniqueness: no two replicas on the same node
 	//      share a port (this is the same-node collision that would
 	//      break drbdadm adjust). Reuse across nodes is fine.
@@ -203,8 +203,8 @@ func TestBug306BatchAutoplacePortsUnique(t *testing.T) {
 
 		port := *res.Spec.DRBDPort
 
-		if port < 7000 || port > 7999 {
-			t.Errorf("%s: port %d outside default 7000-7999 range", res.Name, port)
+		if port < 20000 || port > 20999 {
+			t.Errorf("%s: port %d outside default 20000-20999 range", res.Name, port)
 		}
 
 		node := res.Spec.NodeName

--- a/internal/controller/resource_allocator_port_collision_test.go
+++ b/internal/controller/resource_allocator_port_collision_test.go
@@ -32,7 +32,7 @@ import (
 // THE SAME NODE must get DISTINCT ports (a collision breaks drbdadm
 // adjust), while the SAME port number is freely reused across
 // DIFFERENT nodes — that is exactly what lets a node host 1000+
-// resources inside the 7000-7999 window instead of the whole cluster
+// resources inside the 20000-20999 window instead of the whole cluster
 // sharing it.
 //
 // This is the inverse of the pre-refactor per-RD contract (which
@@ -50,14 +50,15 @@ func TestBug266DRBDPortPerNodeReuseAndUniqueness(t *testing.T) {
 		).
 		Build()
 
-	// Pre-seed RD-A on w1+w2 with port 7000 (Spec.DRBDPort), so the
-	// per-node taken-set on both w1 and w2 already holds {7000}.
-	preSeedPort(ctx, t, cli, "pvc-bug266-rdA", "w1", 7000)
-	preSeedPort(ctx, t, cli, "pvc-bug266-rdA", "w2", 7000)
+	// Pre-seed RD-A on w1+w2 with port 20000 (Spec.DRBDPort) — the
+	// lowest port in the default window — so the per-node taken-set on
+	// both w1 and w2 already holds {20000}.
+	preSeedPort(ctx, t, cli, "pvc-bug266-rdA", "w1", 20000)
+	preSeedPort(ctx, t, cli, "pvc-bug266-rdA", "w2", 20000)
 
-	// RD-B lands on w1 and w3. On w1 the taken-set is {7000} (from
-	// RD-A.w1) → must pick 7001. On w3 nothing is taken → may pick
-	// 7000 (reuse across nodes is fine).
+	// RD-B lands on w1 and w3. On w1 the taken-set is {20000} (from
+	// RD-A.w1) → must pick 20001. On w3 nothing is taken → may pick
+	// 20000 (reuse across nodes is fine).
 	rdB := &blockstoriov1alpha1.ResourceDefinition{}
 	rdB.Name = "pvc-bug266-rdB"
 	rdB.Spec.VolumeDefinitions = []blockstoriov1alpha1.ResourceDefinitionVolume{
@@ -105,14 +106,14 @@ func TestBug266DRBDPortPerNodeReuseAndUniqueness(t *testing.T) {
 		portsByNode[node][port] = name
 	}
 
-	// RD-B.w1 must NOT be 7000 (RD-A.w1 holds it on the same node).
+	// RD-B.w1 must NOT be 20000 (RD-A.w1 holds it on the same node).
 	rbw1 := &blockstoriov1alpha1.Resource{}
 	if err := cli.Get(ctx, client.ObjectKey{Name: "pvc-bug266-rdB.w1"}, rbw1); err != nil {
 		t.Fatalf("get RD-B.w1: %v", err)
 	}
 
-	if rbw1.Spec.DRBDPort == nil || *rbw1.Spec.DRBDPort == 7000 {
-		t.Errorf("RD-B.w1 port=%v, must differ from RD-A.w1's 7000 (same node)", rbw1.Spec.DRBDPort)
+	if rbw1.Spec.DRBDPort == nil || *rbw1.Spec.DRBDPort == 20000 {
+		t.Errorf("RD-B.w1 port=%v, must differ from RD-A.w1's 20000 (same node)", rbw1.Spec.DRBDPort)
 	}
 }
 

--- a/internal/controller/resource_controller.go
+++ b/internal/controller/resource_controller.go
@@ -737,7 +737,7 @@ func backfillResourceSpecFromStatus(target *blockstoriov1alpha1.Resource) {
 // port: PER-NODE scope (Bug 266 scaling fix). The taken-set is the
 // ports already used by OTHER Resources ON THE SAME NODE
 // (Spec.DRBDPort), so the same port number is reused across different
-// nodes — a node can host 1000+ resources within the 7000-7999 window
+// nodes — a node can host 1000+ resources within the 20000-20999 window
 // instead of the whole cluster sharing it. The optional RD.Spec.
 // DRBDPort preferred seed is tried first on the node; on collision the
 // allocator falls back to the lowest per-node-free port.
@@ -1685,7 +1685,7 @@ func (r *ResourceReconciler) intersectRange(
 // Resource ON THE SAME NODE (PER-NODE port scope, Bug 266 scaling fix),
 // excluding `selfName`. The taken-set is per-node — the same port
 // number is reusable on a different node — so a node can host 1000+
-// resources inside the 7000-7999 window instead of the whole cluster
+// resources inside the 20000-20999 window instead of the whole cluster
 // sharing it.
 //
 // Reads the authoritative Spec.DRBDPort. Uses APIReader (uncached) so
@@ -1791,7 +1791,7 @@ func anyVolumeMinorSet(rd *blockstoriov1alpha1.ResourceDefinition) bool {
 //  3. ControllerConfig.Spec.ExtraProps["TcpPortAutoRange"] —
 //     cluster-scope dynamic-port range, the upstream-LINSTOR knob
 //     (`linstor controller set-property TcpPortAutoRange ...`).
-//  4. drbd.DefaultPortMin..drbd.DefaultPortMax (7000-7999).
+//  4. drbd.DefaultPortMin..drbd.DefaultPortMax (20000-20999).
 //
 // A malformed value at any tier surfaces as an error so the
 // operator notices the typo. Scenario 3.W05.

--- a/internal/controller/tcp_port_auto_range_test.go
+++ b/internal/controller/tcp_port_auto_range_test.go
@@ -38,7 +38,7 @@ import (
 // §3.W05 and the implementation pointer in
 // tests/advanced-config-scenarios.md §5:
 //
-//  1. The cluster-scope range overrides the compiled-in 7000-7999
+//  1. The cluster-scope range overrides the compiled-in 20000-20999
 //     default for a vanilla node.
 //  2. The per-node range still wins when both are set — cluster
 //     scope is a default, not an override.
@@ -53,7 +53,7 @@ import (
 // TestTcpPortAutoRangeConstrainsAllocator pins fact 1: an
 // otherwise-bare cluster (no per-Node overrides) draws ports
 // from the cluster-scope `TcpPortAutoRange` rather than the
-// hard-coded 7000-7999 default.
+// hard-coded 20000-20999 default.
 func TestTcpPortAutoRangeConstrainsAllocator(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -1080,13 +1080,15 @@ func DerivePort(rd string) int { return derivePort(rd) }
 // DeriveMinor mirrors DerivePort for /dev/drbd<N>.
 func DeriveMinor(rd string) int { return deriveMinor(rd) }
 
-// derivePort hashes the RD name into the drbd-9 reserved range
-// 7000–7999. Matches what upstream LINSTOR's TcpPortPool does for
-// fresh deployments — collisions on a real cluster are handled by
-// the autoplacer, but for the smoke we live with the hash.
+// derivePort hashes the RD name into blockstor's default TCP-port
+// allocation window 20000–20999 — disjoint from upstream LINSTOR's
+// 7000–7999 so the two can coexist on the same nodes. This is only the
+// transitional fallback used before the controller's allocator stamps a
+// real port; collisions on a real cluster are handled by the autoplacer,
+// but for the smoke we live with the hash.
 func derivePort(rd string) int {
 	const (
-		portBase  = 7000
+		portBase  = 20000
 		portRange = 1000
 	)
 
@@ -1095,10 +1097,11 @@ func derivePort(rd string) int {
 	return portBase + int(binary.BigEndian.Uint16(digest[:2])%portRange)
 }
 
-// deriveMinor likewise hashes into 1000–9999.
+// deriveMinor likewise hashes into 20000–28999 — blockstor's default
+// minor window, disjoint from upstream LINSTOR's 1000+ defaults.
 func deriveMinor(rd string) int {
 	const (
-		minorBase  = 1000
+		minorBase  = 20000
 		minorRange = 9000
 	)
 

--- a/pkg/drbd/portpool.go
+++ b/pkg/drbd/portpool.go
@@ -50,27 +50,39 @@ func ParseRange(s string) (int32, int32, error) {
 	return int32(low), int32(high), nil
 }
 
-// DefaultPortRange mirrors the upstream LINSTOR TcpPortPool default.
-// Operators can override via controller config; the allocator only
-// hands out ports inside [min, max].
+// Default TCP-port and /dev/drbd<N> minor allocation windows.
+// Operators can override via Node CRD ranges or controller config; the
+// allocator only hands out values inside [min, max].
 //
-// DefaultMinorMin mirrors upstream LINSTOR's DEFAULT_MINOR_NR_MIN
-// (1000). Collision-freedom does not come from offsetting this base:
-// LowestFreeMinor scans the cluster-wide taken set (every
-// Resource.Status.DRBDMinor) and hands out the lowest free value, so
-// two replicas can never land on the same /dev/drbd<N>. The cozystack
-// migration model also removes the only reason an offset was ever
-// considered — LINSTOR is shut down before blockstor adopts, and
-// adoption preserves the original LINSTOR minors verbatim, so there is
-// no live second allocator to stay clear of. This is exactly how the
-// TCP-port allocator behaves: it shares upstream LINSTOR's 7000-7999
-// window and relies on the same taken-set scan rather than a base
-// offset to avoid collisions.
+// These windows are deliberately DISJOINT from upstream LINSTOR's
+// defaults (LINSTOR uses TCP 7000-7999 and minors 1000+) so that
+// blockstor can run on the same nodes as a live upstream LINSTOR
+// without colliding on the shared kernel /dev/drbd<N> namespace or on
+// TCP ports. blockstor allocates from 20000-20999 (ports) and
+// 20000-65535 (minors); LINSTOR keeps its low defaults, and the two
+// allocators never overlap.
+//
+// Resources ADOPTED/MIGRATED from an existing LINSTOR cluster keep
+// their original LINSTOR-assigned ports/minors verbatim (e.g. port
+// 7042, minor 1037). Those sit BELOW the allocation window, but that is
+// fine on both counts:
+//
+//   - The allocator only assigns a value when the per-replica
+//     Spec.DRBDPort / per-volume Spec.DRBDMinor is nil. Adoption writes
+//     the explicit low value, so the allocator never reissues it.
+//   - LowestFreePort / LowestFreeMinor scan the cluster's taken set and
+//     hand out the lowest free value inside [min, max]; the in-range
+//     filter on the taken set only decides which values participate in
+//     collision avoidance WITHIN the window — an explicit out-of-window
+//     value is still excluded from being handed to a fresh allocation
+//     because it is never nil. So a freshly allocated value never lands
+//     on an adopted low value, and an adopted low value is never
+//     clamped or re-allocated.
 const (
-	DefaultPortMin = 7000
-	DefaultPortMax = 7999
+	DefaultPortMin = 20000
+	DefaultPortMax = 20999
 
-	DefaultMinorMin = 1000
+	DefaultMinorMin = 20000
 	DefaultMinorMax = 65535
 )
 

--- a/pkg/store/k8s/nodes.go
+++ b/pkg/store/k8s/nodes.go
@@ -156,8 +156,8 @@ func (n *nodes) Update(ctx context.Context, in *apiv1.Node) error {
 	// spec that always omits them. Without an explicit carry-across,
 	// a routine REST modify (`linstor n set-property ...`) wipes
 	// the operator-pinned per-node DRBD port/minor range and pushes
-	// new replicas back onto the cluster-wide default 7000-7999 /
-	// 1000-1099 range, frequently into firewall-blocked ports
+	// new replicas back onto the cluster-wide default 20000-20999 /
+	// 20000-65535 range, frequently into firewall-blocked ports
 	// (Bug 208). Same root-cause class as Bug 206's Spec.Volumes
 	// carry-across — mirror that pattern here.
 	prevPortRange := existing.Spec.DRBDPortRange

--- a/tests/e2e/recovery-port-collision.sh
+++ b/tests/e2e/recovery-port-collision.sh
@@ -13,7 +13,7 @@
 #
 # Pre-Bug-306, two RDs reconciling at the same time both observed a
 # stale (cached) cluster-wide taken-set, both picked the lowest
-# free port (7000), and both Status().Update succeeded because
+# free port (20000), and both Status().Update succeeded because
 # Kubernetes optimistic concurrency is per-object: two RDs writing
 # to their OWN statuses don't conflict. Result: N RDs got the SAME
 # DRBD port, the satellite-side .res files collided, neither
@@ -251,17 +251,17 @@ if (( fail_cross > 0 )); then
     exit 1
 fi
 
-# Sanity: every port inside the default 7000-7999 range.
-echo ">> sanity: every port inside default 7000-7999 range"
+# Sanity: every port inside the default 20000-20999 range.
+echo ">> sanity: every port inside default 20000-20999 range"
 for i in $(seq 1 "$NUM_RDS"); do
     rd="${RD_PREFIX}-${i}"
     port="${rd_port_n1[$rd]}"
-    if (( port < 7000 || port > 7999 )); then
-        echo "FAIL: $rd port $port outside default 7000-7999 range"
+    if (( port < 20000 || port > 20999 )); then
+        echo "FAIL: $rd port $port outside default 20000-20999 range"
         exit 1
     fi
 done
 
 unique_count=${#seen[@]}
 echo ">> RECOVERY-PORT-COLLISION OK ($unique_count unique ports for $NUM_RDS RDs," \
-    "all in 7000-7999, no cross-RD collisions under parallel batch autoplace)"
+    "all in 20000-20999, no cross-RD collisions under parallel batch autoplace)"


### PR DESCRIPTION
## What

Move blockstor's **default** DRBD allocation windows so they no longer overlap upstream LINSTOR's defaults:

- TCP ports: `7000–7999` → **`20000–20999`**
- DRBD minors: min `1000` → **`20000`** (max stays `65535`)

## Why

blockstor used the same windows upstream LINSTOR allocates from (TCP 7000–7999, minors 1000+). Sharing them is only safe when LINSTOR is shut down before adoption — a *live* upstream LINSTOR on the same nodes would collide on the shared kernel `/dev/drbdN` namespace and on TCP ports, because blockstor's collision scan only sees its own CRDs. Disjoint windows let blockstor and a live upstream coexist on the same hosts.

## Migration safety

Resources adopted/migrated from LINSTOR **keep their original lower ports/minors verbatim**. Adoption writes explicit `Spec.DRBDPort` / `VolumeDefinition.DRBDMinor`; the allocator only fills `nil` values, so it never rewrites an adopted value, and the taken-set collision scan still avoids any explicit value regardless of range. Covered by a new `TestAdoptedSubWindowPortMinorPreserved`.

Per-node overrides (`Node.Spec.DRBDPortRange` / `DRBDMinorRange`) are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DRBD port and minor allocation range defaults across API documentation and configuration schemas.
  * Port range changed from 7000-7999 to 20000-20999.
  * Minor range changed from 1000-1099 to 20000-65535.

* **Chores**
  * Updated internal constants, tests, and validation assertions to align with revised DRBD allocation windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->