### PR TITLE
fix(zfs): promote dependent clones before destroying a clone source

### DIFF
--- a/pkg/storage/zfs/zfs.go
+++ b/pkg/storage/zfs/zfs.go
@@ -182,11 +182,12 @@ func (p *Provider) DeleteVolume(ctx context.Context, vol storage.Volume) error {
 	// Why: detach any surviving clones that depend on this dataset's
 	// snapshots before the destroy, so `zfs destroy -r` doesn't fail
 	// with "has dependent clones". No-op when there are no clones.
-	if err := p.promoteDependentClones(ctx, tgtDS); err != nil {
+	err := p.promoteDependentClones(ctx, tgtDS)
+	if err != nil {
 		return errors.Wrapf(err, "promote dependent clones of %s", tgtDS)
 	}
 
-	_, err := p.exec.Run(ctx, "zfs", "destroy", "-r", tgtDS)
+	_, err = p.exec.Run(ctx, "zfs", "destroy", "-r", tgtDS)
 	if err != nil {
 		return errors.Wrapf(err, "zfs destroy %s", tgtDS)
 	}
@@ -196,66 +197,6 @@ func (p *Provider) DeleteVolume(ctx context.Context, vol storage.Volume) error {
 	}
 
 	return nil
-}
-
-// promoteDependentClones reparents every clone whose `origin` is a
-// snapshot of dataset `ds` onto itself via `zfs promote`, so `ds`'s
-// snapshots are no longer referenced and `ds` can be destroyed.
-//
-// Why: blockstor's same-node clone is `zfs clone <ds>@<snap> <clone>`,
-// so the clone's origin lives under the source dataset. ZFS blocks
-// `zfs destroy` of a snapshot that still has dependent clones; this is
-// the canonical detach (promote, NOT `destroy -R`, which would take
-// the surviving clone with it).
-//
-// Idempotent + safe with no clones: the `zfs list` enumeration finds
-// nothing and we issue zero promotes. Discovery errors don't bubble
-// — they fall through to the destroy, which surfaces the real
-// "has dependent clones" error if a clone truly blocks it.
-func (p *Provider) promoteDependentClones(ctx context.Context, ds string) error {
-	clones := p.dependentClones(ctx, ds)
-	for _, clone := range clones {
-		if _, err := p.exec.Run(ctx, "zfs", "promote", clone); err != nil {
-			return errors.Wrapf(err, "zfs promote %s", clone)
-		}
-	}
-
-	return nil
-}
-
-// dependentClones lists datasets whose `origin` is a snapshot of `ds`
-// (i.e. origin starts with `<ds>@`). These are the clones that must be
-// promoted before `ds` can be destroyed. Best-effort: any enumeration
-// error yields an empty list (the subsequent destroy still reports the
-// true blocking error).
-func (p *Provider) dependentClones(ctx context.Context, ds string) []string {
-	out, err := p.exec.Run(ctx, "zfs",
-		"list", "-H", "-o", "name,origin", "-t", "filesystem,volume")
-	if err != nil {
-		return nil
-	}
-
-	prefix := ds + "@"
-
-	var clones []string
-
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) != 2 {
-			continue
-		}
-
-		name, originSnap := fields[0], fields[1]
-		if name == ds {
-			continue
-		}
-
-		if strings.HasPrefix(originSnap, prefix) {
-			clones = append(clones, name)
-		}
-	}
-
-	return clones
 }
 
 // VolumeStatus parses `zfs list -p` output (bytes, no suffixes). Bug
@@ -725,6 +666,67 @@ func parseVolumeName(name string) (string, int32, bool) {
 // the per-RD volume index in dataset / LV names. Keep in sync with
 // volumeDataset / volumeLVName.
 const volNumberDigits = 5
+
+// promoteDependentClones reparents every clone whose `origin` is a
+// snapshot of dataset `ds` onto itself via `zfs promote`, so `ds`'s
+// snapshots are no longer referenced and `ds` can be destroyed.
+//
+// Why: blockstor's same-node clone is `zfs clone <ds>@<snap> <clone>`,
+// so the clone's origin lives under the source dataset. ZFS blocks
+// `zfs destroy` of a snapshot that still has dependent clones; this is
+// the canonical detach (promote, NOT `destroy -R`, which would take
+// the surviving clone with it).
+//
+// Idempotent + safe with no clones: the `zfs list` enumeration finds
+// nothing and we issue zero promotes. Discovery errors don't bubble
+// — they fall through to the destroy, which surfaces the real
+// "has dependent clones" error if a clone truly blocks it.
+func (p *Provider) promoteDependentClones(ctx context.Context, ds string) error {
+	clones := p.dependentClones(ctx, ds)
+	for _, clone := range clones {
+		_, err := p.exec.Run(ctx, "zfs", "promote", clone)
+		if err != nil {
+			return errors.Wrapf(err, "zfs promote %s", clone)
+		}
+	}
+
+	return nil
+}
+
+// dependentClones lists datasets whose `origin` is a snapshot of `ds`
+// (i.e. origin starts with `<ds>@`). These are the clones that must be
+// promoted before `ds` can be destroyed. Best-effort: any enumeration
+// error yields an empty list (the subsequent destroy still reports the
+// true blocking error).
+func (p *Provider) dependentClones(ctx context.Context, dataset string) []string {
+	out, err := p.exec.Run(ctx, "zfs",
+		"list", "-H", "-o", "name,origin", "-t", "filesystem,volume")
+	if err != nil {
+		return nil
+	}
+
+	prefix := dataset + "@"
+
+	var clones []string
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		name, originSnap := fields[0], fields[1]
+		if name == dataset {
+			continue
+		}
+
+		if strings.HasPrefix(originSnap, prefix) {
+			clones = append(clones, name)
+		}
+	}
+
+	return clones
+}
 
 // volumeOrigin reads the zvol's `origin` property — the snapshot
 // dataset name when this volume was created via `zfs clone`, or

--- a/pkg/storage/zfs/zfs.go
+++ b/pkg/storage/zfs/zfs.go
@@ -153,8 +153,19 @@ func (p *Provider) ResizeVolume(ctx context.Context, vol storage.Volume) error {
 // DeleteVolume `zfs destroy -r`s the zvol (recursive to clean up any
 // dependent snapshots automatically). Missing → no-op.
 //
-// Before the destroy we read the volume's `origin` property — if it
-// points at a deferred-delete marker (DeleteSnapshot's
+// Why: a same-node `zfs clone` (RestoreVolumeFromSnapshot) leaves the
+// clone's `origin` pointing at a snapshot UNDER this dataset. ZFS
+// refuses to `zfs destroy` a snapshot that still has dependent
+// clones, so deleting a clone *source* before its clone wedges with
+// "volume has dependent clones" and the satellite reconciler loops
+// forever. We must NOT `zfs destroy -R` (that would cascade-destroy
+// the surviving clone = data loss). Instead `zfs promote` every
+// dependent clone first — promotion reparents the origin snapshot
+// onto the clone, making the clone independent and freeing this
+// dataset's snapshots for destruction.
+//
+// Before the destroy we also read the volume's `origin` property — if
+// it points at a deferred-delete marker (DeleteSnapshot's
 // `__DELETED__<ts>` rename), drop the marker after the volume is
 // gone. That's the GC half of upstream's deferred-delete pattern:
 // snapshots blocked by clones get renamed; when the last clone goes
@@ -168,6 +179,13 @@ func (p *Provider) DeleteVolume(ctx context.Context, vol storage.Volume) error {
 
 	origin := p.volumeOrigin(ctx, tgtDS)
 
+	// Why: detach any surviving clones that depend on this dataset's
+	// snapshots before the destroy, so `zfs destroy -r` doesn't fail
+	// with "has dependent clones". No-op when there are no clones.
+	if err := p.promoteDependentClones(ctx, tgtDS); err != nil {
+		return errors.Wrapf(err, "promote dependent clones of %s", tgtDS)
+	}
+
 	_, err := p.exec.Run(ctx, "zfs", "destroy", "-r", tgtDS)
 	if err != nil {
 		return errors.Wrapf(err, "zfs destroy %s", tgtDS)
@@ -178,6 +196,66 @@ func (p *Provider) DeleteVolume(ctx context.Context, vol storage.Volume) error {
 	}
 
 	return nil
+}
+
+// promoteDependentClones reparents every clone whose `origin` is a
+// snapshot of dataset `ds` onto itself via `zfs promote`, so `ds`'s
+// snapshots are no longer referenced and `ds` can be destroyed.
+//
+// Why: blockstor's same-node clone is `zfs clone <ds>@<snap> <clone>`,
+// so the clone's origin lives under the source dataset. ZFS blocks
+// `zfs destroy` of a snapshot that still has dependent clones; this is
+// the canonical detach (promote, NOT `destroy -R`, which would take
+// the surviving clone with it).
+//
+// Idempotent + safe with no clones: the `zfs list` enumeration finds
+// nothing and we issue zero promotes. Discovery errors don't bubble
+// — they fall through to the destroy, which surfaces the real
+// "has dependent clones" error if a clone truly blocks it.
+func (p *Provider) promoteDependentClones(ctx context.Context, ds string) error {
+	clones := p.dependentClones(ctx, ds)
+	for _, clone := range clones {
+		if _, err := p.exec.Run(ctx, "zfs", "promote", clone); err != nil {
+			return errors.Wrapf(err, "zfs promote %s", clone)
+		}
+	}
+
+	return nil
+}
+
+// dependentClones lists datasets whose `origin` is a snapshot of `ds`
+// (i.e. origin starts with `<ds>@`). These are the clones that must be
+// promoted before `ds` can be destroyed. Best-effort: any enumeration
+// error yields an empty list (the subsequent destroy still reports the
+// true blocking error).
+func (p *Provider) dependentClones(ctx context.Context, ds string) []string {
+	out, err := p.exec.Run(ctx, "zfs",
+		"list", "-H", "-o", "name,origin", "-t", "filesystem,volume")
+	if err != nil {
+		return nil
+	}
+
+	prefix := ds + "@"
+
+	var clones []string
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		name, originSnap := fields[0], fields[1]
+		if name == ds {
+			continue
+		}
+
+		if strings.HasPrefix(originSnap, prefix) {
+			clones = append(clones, name)
+		}
+	}
+
+	return clones
 }
 
 // VolumeStatus parses `zfs list -p` output (bytes, no suffixes). Bug

--- a/pkg/storage/zfs/zfs_test.go
+++ b/pkg/storage/zfs/zfs_test.go
@@ -640,3 +640,120 @@ func TestDeleteSnapshotErrorWraps(t *testing.T) {
 		t.Errorf("wrap: %q must contain \"zfs destroy\" for operator grep", msg)
 	}
 }
+
+// TestDeleteVolumePromotesDependentClonesBeforeDestroy: deleting a
+// clone *source* whose snapshot still backs a surviving clone must
+// `zfs promote` the clone first so the recursive destroy of the source
+// no longer fails with "has dependent clones". The promote MUST come
+// before the destroy. This is the regression guard for the wedge where
+// `zfs destroy -r` looped forever on the source dataset.
+func TestDeleteVolumePromotesDependentClonesBeforeDestroy(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect("zfs list -H -o name tank/src_00000",
+		storage.FakeResponse{Stdout: []byte("tank/src_00000\n")})
+	// dst is a same-node clone of a snapshot under the source dataset.
+	fx.Expect("zfs list -H -o name,origin -t filesystem,volume",
+		storage.FakeResponse{Stdout: []byte(
+			"tank/src_00000\t-\n" +
+				"tank/dst_00000\ttank/src_00000@clone-1\n")})
+
+	p := zfs.NewProvider(zfs.Config{Pool: "tank"}, fx)
+
+	err := p.DeleteVolume(t.Context(), storage.Volume{
+		ResourceName: "src",
+		VolumeNumber: 0,
+	})
+	if err != nil {
+		t.Fatalf("DeleteVolume: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+
+	promote := "zfs promote tank/dst_00000"
+	destroy := "zfs destroy -r tank/src_00000"
+
+	pIdx := slices.Index(cmds, promote)
+	dIdx := slices.Index(cmds, destroy)
+
+	if pIdx < 0 {
+		t.Errorf("expected %q in calls; got %v", promote, cmds)
+	}
+
+	if dIdx < 0 {
+		t.Errorf("expected %q in calls; got %v", destroy, cmds)
+	}
+
+	if pIdx >= 0 && dIdx >= 0 && pIdx > dIdx {
+		t.Errorf("promote must precede destroy; promote@%d destroy@%d (%v)", pIdx, dIdx, cmds)
+	}
+}
+
+// TestDeleteVolumeNoDependentClonesStaysPlainDestroy: when nothing
+// clones the dataset's snapshots, no `zfs promote` is issued — the
+// fix must be a no-op on the common (no-clone) delete path.
+func TestDeleteVolumeNoDependentClonesStaysPlainDestroy(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect("zfs list -H -o name tank/pvc-1_00000",
+		storage.FakeResponse{Stdout: []byte("tank/pvc-1_00000\n")})
+	fx.Expect("zfs list -H -o name,origin -t filesystem,volume",
+		storage.FakeResponse{Stdout: []byte(
+			"tank/pvc-1_00000\t-\n" +
+				"tank/unrelated_00000\t-\n")})
+
+	p := zfs.NewProvider(zfs.Config{Pool: "tank"}, fx)
+
+	err := p.DeleteVolume(t.Context(), storage.Volume{
+		ResourceName: "pvc-1",
+		VolumeNumber: 0,
+	})
+	if err != nil {
+		t.Fatalf("DeleteVolume: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+	for _, cmd := range cmds {
+		if strings.HasPrefix(cmd, "zfs promote") {
+			t.Errorf("unexpected promote on no-clone delete: %v", cmds)
+		}
+	}
+
+	if !slices.Contains(cmds, "zfs destroy -r tank/pvc-1_00000") {
+		t.Errorf("expected plain destroy; got %v", cmds)
+	}
+}
+
+// TestDeleteVolumeCloneItselfStillDestroys: deleting the clone (dst)
+// rather than the source is unaffected — dst owns no dependent clones,
+// so it's a plain `zfs destroy -r`. Guards the reverse order (delete
+// clone first, then source) the bug report calls out.
+func TestDeleteVolumeCloneItselfStillDestroys(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect("zfs list -H -o name tank/dst_00000",
+		storage.FakeResponse{Stdout: []byte("tank/dst_00000\n")})
+	// dst clones a snapshot of src; nothing clones dst's own snapshots.
+	fx.Expect("zfs list -H -o name,origin -t filesystem,volume",
+		storage.FakeResponse{Stdout: []byte(
+			"tank/src_00000\t-\n" +
+				"tank/dst_00000\ttank/src_00000@clone-1\n")})
+
+	p := zfs.NewProvider(zfs.Config{Pool: "tank"}, fx)
+
+	err := p.DeleteVolume(t.Context(), storage.Volume{
+		ResourceName: "dst",
+		VolumeNumber: 0,
+	})
+	if err != nil {
+		t.Fatalf("DeleteVolume: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+	for _, cmd := range cmds {
+		if strings.HasPrefix(cmd, "zfs promote") {
+			t.Errorf("clone delete must not promote anything: %v", cmds)
+		}
+	}
+
+	if !slices.Contains(cmds, "zfs destroy -r tank/dst_00000") {
+		t.Errorf("expected plain destroy of clone; got %v", cmds)
+	}
+}

--- a/tests/e2e/zfs-clone-source-delete.sh
+++ b/tests/e2e/zfs-clone-source-delete.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# usage: zfs-clone-source-delete.sh WORK_DIR
+#
+# Regression for the "delete a ZFS clone SOURCE while a dependent clone
+# still exists" wedge.
+#
+# blockstor's same-node clone is `zfs clone <pool>/<src>_00000@<snap>
+# <pool>/<dst>_00000`, so the dst clone's `origin` is a snapshot UNDER
+# the source dataset. ZFS refuses to `zfs destroy` a snapshot that
+# still has dependent clones, so deleting the source RD made
+# DeleteVolume's `zfs destroy -r <src>` fail forever with
+#
+#   cannot destroy '<pool>/<src>_00000': volume has dependent clones
+#
+# → the satellite-resource reconciler hot-loops, the source Resource
+# finalizer never releases, the RD never finishes deleting, and the
+# node is left degraded for later scenarios.
+#
+# The fix `zfs promote`s the dependent clone(s) before destroying the
+# source (NOT `zfs destroy -R`, which would cascade-destroy the
+# surviving clone = data loss). After promotion the origin snapshot
+# reparents onto the clone, making it independent, and the source
+# destroys cleanly.
+#
+# Expected after fix:
+#   1. delete SOURCE RD          → fully deletes, no "has dependent
+#                                  clones" loop, finalizers release.
+#   2. dst clone survives        → its volume is still readable and the
+#                                  bytes match what was written to src.
+#   3. delete DST RD             → also clean (promote is a no-op when
+#                                  the source has no remaining clones).
+#
+# ZFS pool required: same-node clone uses `zfs clone`, which only the
+# ZFS provider implements. We place on the worker pair that has the
+# zfs-thin pool.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+RD_SRC=e2e-zcsd-src
+RD_DST=e2e-zcsd-dst
+STORPOOL=${STORPOOL:-zfs-thin}
+
+# The zfs-thin pool lives on worker-2 + worker-3 on the dev stand
+# (worker-1 carries the ZFS `data` pool, not zfs-thin). Override via
+# N1/N2 if a stand lays the pool out differently.
+N1=${N1:-$WORKER_2}
+N2=${N2:-$WORKER_3}
+
+if [[ -z "$N1" || -z "$N2" ]]; then
+    skip "scenario needs two workers carrying the ${STORPOOL} pool"
+fi
+
+DEL_TIMEOUT=${DEL_TIMEOUT:-90}
+
+dump_diag() {
+    echo "---- dump: resourcedefinitions / resources / snapshots ----"
+    kubectl get resourcedefinitions.blockstor.cozystack.io 2>/dev/null || true
+    kubectl get resources.blockstor.cozystack.io 2>/dev/null || true
+    kubectl get snapshots.blockstor.cozystack.io 2>/dev/null || true
+    echo "---- dump: satellite logs (grep dependent clones) ----"
+    for pod in $(kubectl -n "$NS" get pods -l app=blockstor-satellite -o name 2>/dev/null); do
+        kubectl -n "$NS" logs "$pod" --tail=60 2>/dev/null | grep -i "dependent clones\|DeleteResource" || true
+    done
+    echo "---- dump: zfs list on $N1 / $N2 ----"
+    on_node "$N1" bash -c "zfs list -t all -o name,origin 2>/dev/null | grep -E 'zcsd|zfs-thin' || true" || true
+    on_node "$N2" bash -c "zfs list -t all -o name,origin 2>/dev/null | grep -E 'zcsd|zfs-thin' || true" || true
+}
+
+trap 'rc=$?; (( rc != 0 )) && dump_diag; delete_rd "$RD_SRC"; delete_rd "$RD_DST"' EXIT
+
+# rd_gone returns 0 once the RD CRD and every Resource named after it
+# are absent — i.e. the satellite finalizer released and the delete
+# cascade completed. Times out non-zero so the wedge is caught as a
+# FAIL instead of hanging the whole batch.
+rd_gone() {
+    local rd=$1 timeout=$2
+    local deadline=$(( $(date +%s) + timeout ))
+    while (( $(date +%s) < deadline )); do
+        local count
+        count=$( {
+            kubectl get "resourcedefinitions.blockstor.cozystack.io/${rd}" \
+                --no-headers 2>/dev/null
+            kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+                | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}'
+        } | grep -cv '^$' || true )
+        if [[ "$count" == "0" ]]; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+# Self-defending pre-test wipe so leftovers from a prior scenario don't
+# get blamed on this one (and don't leave a stale zcsd-* dataset that
+# trips the clone).
+delete_all_rds 90 || {
+    echo "FAIL: stand not idle at test start"
+    kubectl get resourcedefinitions.blockstor.cozystack.io 2>/dev/null || true
+    exit 1
+}
+
+echo ">> apply source RD ${RD_SRC} on ${N1}+${N2} (pool=${STORPOOL})"
+rd_apply "$RD_SRC" "$N1" "$N2" 65536 "$STORPOOL"
+wait_uptodate "$RD_SRC" "$N1" "$N2"
+
+# Write known payload to the source so we can prove the clone keeps it
+# after the source is gone.
+DEV=$(device_for_rd "$RD_SRC" "$N1")
+RD=$RD_SRC
+md5_src=$(write_random "$N1" "$DEV" 262144)
+echo ">> source payload md5=${md5_src}"
+
+# Same-node clone: snapshot the source then snapshot-restore into dst.
+# This is exactly the plumbing clone.sh exercises; the result is a
+# `zfs clone` whose origin is a snapshot under the SOURCE dataset.
+SNAP=zcsd-$(date +%s)
+
+echo ">> take transient snapshot ${SNAP} of ${RD_SRC}"
+rest_post "/v1/resource-definitions/${RD_SRC}/snapshots" \
+    "{\"name\":\"${SNAP}\",\"nodes\":[\"${N1}\",\"${N2}\"]}"
+
+echo ">> clone ${RD_SRC} → ${RD_DST}"
+rest_post "/v1/resource-definitions/${RD_SRC}/snapshot-restore-resource" \
+    "{\"to_resource\":\"${RD_DST}\",\"snapshot_name\":\"${SNAP}\"}"
+
+rest_post "/v1/resource-definitions/${RD_DST}/autoplace" \
+    "{\"select_filter\":{\"place_count\":2,\"storage_pool\":\"${STORPOOL}\"}}"
+
+wait_uptodate "$RD_DST" "$N1" "$N2"
+echo ">> clone ${RD_DST} is UpToDate on ${N1}+${N2}"
+
+# --- the bug: delete the SOURCE while the clone still depends on it ---
+echo ">> delete SOURCE RD ${RD_SRC} (clone ${RD_DST} still depends on it)"
+delete_rd "$RD_SRC"
+
+if ! rd_gone "$RD_SRC" "$DEL_TIMEOUT"; then
+    echo "FAIL: source RD ${RD_SRC} did not finish deleting within ${DEL_TIMEOUT}s"
+    echo "       (likely 'zfs destroy ... has dependent clones' hot-loop)"
+    exit 1
+fi
+echo ">> SOURCE RD fully deleted, finalizers released"
+
+# The surviving clone must still be UpToDate and its bytes intact —
+# the promote must have reparented the data, not destroyed it.
+RD=$RD_DST
+wait_uptodate "$RD_DST" "$N1" "$N2"
+DEV_DST=$(device_for_rd "$RD_DST" "$N1")
+md5_dst=$(read_md5 "$N1" "$DEV_DST" 262144)
+
+if [[ "$md5_src" != "$md5_dst" ]]; then
+    echo "FAIL: clone data lost/changed after source delete (src=${md5_src} dst=${md5_dst})"
+    exit 1
+fi
+echo ">> clone ${RD_DST} survived with intact data (md5=${md5_dst})"
+
+# Reverse case: deleting the clone after the source is gone must also
+# be clean (promote is a no-op — the clone owns its data now).
+echo ">> delete DST RD ${RD_DST}"
+delete_rd "$RD_DST"
+
+if ! rd_gone "$RD_DST" "$DEL_TIMEOUT"; then
+    echo "FAIL: clone RD ${RD_DST} did not finish deleting within ${DEL_TIMEOUT}s"
+    exit 1
+fi
+
+echo ">> ZFS-CLONE-SOURCE-DELETE OK"


### PR DESCRIPTION
## What

Deleting a ZFS clone **source** resource while a dependent ZFS clone still exists wedged the satellite: `zfs destroy` of the source dataset failed forever with `volume has dependent clones`, the resource reconciler spun in a hot loop, the finalizer never released, and the node was left degraded (a later autoplacement on that node could come up Diskless instead of diskful).

## Why

blockstor's same-node clone is a `zfs clone` of a snapshot taken under the source dataset, so the clone's `origin` lives beneath the source. ZFS refuses to destroy a dataset/snapshot that still has dependent clones. `DeleteVolume` ran `zfs destroy -r <src>` with no handling for that case (the handling existed only in `DeleteSnapshot`), so the error surfaced and the reconciler retried indefinitely.

## Fix

Before destroying, `DeleteVolume` now enumerates dependent clones (`zfs list -H -o name,origin`, matching origins under `<dataset>@`) and `zfs promote`s each one. Promote reparents the origin snapshot onto the clone, making it independent, after which the source destroys cleanly. This deliberately does **not** use `zfs destroy -R` (that would destroy the surviving clone — data loss). Idempotent and a no-op when there are no dependent clones; deleting the clone itself stays a plain destroy.

## Tests

- **Unit** (`pkg/storage/zfs/zfs_test.go`): promote is issued before destroy when a dependent clone exists; no-clone case stays a plain destroy; deleting the clone itself still destroys.
- **E2E** (`tests/e2e/zfs-clone-source-delete.sh`): create a source RD on a ZFS pool, snapshot+clone it, delete the **source**, and assert the source RD fully deletes (finalizer released, no `has dependent clones` loop), the clone survives with intact data (md5), and the clone then deletes cleanly.

Validated on real ZFS: the pre-fix build reproduces the `has dependent clones` wedge; the fixed build deletes the source cleanly and the clone survives intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting storage volumes could hang when dependent data copies exist. The system now resolves these dependencies automatically before deletion.

* **Tests**
  * Added comprehensive test coverage for volume deletion scenarios with dependent copies and end-to-end regression validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->