### PR TITLE
ci(e2e): piraeus interop tests external mode via blockstor apiserver

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -233,11 +233,12 @@ jobs:
       # together (e.g. 6 lanes ≈ the dev-stand-proven ~6 scenarios/lane).
       LANES: 6
       # Scenarios that require the upstream piraeus stack (the LinstorCluster
-      # CRD + linstor-csi NFS-ganesha) are excluded from the blockstor-only
-      # matrix clusters — there piraeus is absent and, now that their
-      # silent-skip guards are gone, they would hard-fail. They run in the
-      # dedicated `e2e-piraeus` job below, which installs piraeus alongside
-      # blockstor. ci-e2e.sh drops these from the discovered suite.
+      # CRD + linstor-csi) are excluded from the blockstor-only matrix
+      # clusters — there piraeus is absent and, now that their silent-skip
+      # guards are gone, they would hard-fail. They run in the dedicated
+      # `e2e-piraeus` job below, which installs piraeus in EXTERNAL mode
+      # against blockstor's apiserver (no upstream Java linstor-controller).
+      # ci-e2e.sh drops these from the discovered suite.
       E2E_EXCLUDE: "rwx-ganesha observability-three-way observability-capacity-correlation"
     permissions:
       contents: read
@@ -321,14 +322,16 @@ jobs:
 
   e2e-piraeus:
     name: E2E (piraeus interop)
-    # The piraeus-dependent scenarios (rwx-ganesha, observability-three-way,
-    # observability-capacity-correlation) exercise the RWX / linstor-csi
-    # NFS-ganesha + LinstorCluster-CRD surface that only the upstream piraeus
-    # stack provides. They are excluded from the blockstor-only `e2e` matrix
-    # (see E2E_EXCLUDE) and run here on a single cluster that has piraeus
-    # installed alongside blockstor (INSTALL_PIRAEUS=1 → ci-e2e.sh runs
-    # `make piraeus`). blockstor coexists with piraeus's satellite by design
-    # (shared file-thin pool + host /etc/drbd.d, Bugs 305/310/359).
+    # The piraeus-dependent scenarios (observability-three-way,
+    # observability-capacity-correlation, rwx-ganesha) exercise the
+    # LinstorCluster-CRD + linstor-csi surface that the upstream piraeus-
+    # operator owns. They run here on a cluster that has piraeus installed
+    # in EXTERNAL mode against blockstor's apiserver (INSTALL_PIRAEUS=1 →
+    # ci-e2e.sh runs `make piraeus`, which now creates LinstorCluster with
+    # spec.externalController.url + spec.apiTLS pointing at blockstor:3371).
+    # No upstream Java linstor-controller runs in this job — the LINSTOR
+    # state of record is blockstor's apiserver. rwx-ganesha is currently
+    # SKIPped (coexistence-only; needs an external-mode port).
     #
     # `needs: e2e` runs this AFTER the 6-lane matrix releases its runners, so
     # the oracle pool is never asked for a 7th simultaneous cluster (the

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -188,11 +188,11 @@ blockstor **is** the LINSTOR controller plus the satellites: the controller bina
 | `linstor-csi` (csi-controller + csi-node) | **Deploy** — this is what provisions PVs. Point it at the blockstor apiserver. |
 | HA / affinity controller, `drbd-reactor` | Optional — deploy if you want failover/affinity. Point them at the apiserver the same way as the CSI driver (mTLS :3371 + client cert). |
 
-> The dev stand's `make piraeus` (`stand/install-piraeus.sh`) installs piraeus as a **separate, parallel** LINSTOR stack for coexistence testing — it brings up piraeus's own controller and satellites and does **not** point them at blockstor. Do not copy that path for a blockstor-backed cluster; use the wiring below instead.
+> The dev stand's `make piraeus` (`stand/install-piraeus.sh`) installs piraeus in **external-controller mode** against the blockstor apiserver — exactly the wiring described below. The `LinstorCluster` is created with `spec.externalController.url: https://blockstor-apiserver.blockstor-system.svc:3371`, which disables piraeus's bundled in-cluster `linstor-controller` Deployment and re-renders `linstor-csi` with `LS_CONTROLLERS` pointing at blockstor. Use that script as a working reference for a blockstor-backed cluster.
 
 ### Point `linstor-csi` at the blockstor apiserver
 
-The CSI driver's controller endpoint is the apiserver's mTLS Service on port **3371** — the same `blockstor-controller` Service the `linstor` client resolves (the plain-HTTP debug port 3370 is pod-local and is not an option here). `linstor-csi` wraps `golinstor`, which upgrades the endpoint to HTTPS and presents a client certificate when the `LS_USER_*` / `LS_ROOT_CA` variables point at PEM files. The exact wiring (verbatim from `stand/csi-sanity-job.yaml`, the in-repo reference for a CSI client against blockstor):
+The CSI driver's controller endpoint is the apiserver's mTLS Service on port **3371** — the `blockstor-apiserver` Service (a legacy `blockstor-controller` Service name resolves to the same apiserver pods and is also covered by the serving cert's SANs, for backward compatibility with older `LS_CONTROLLERS` values). The plain-HTTP debug port 3370 is pod-local and is not an option here. `linstor-csi` wraps `golinstor`, which upgrades the endpoint to HTTPS and presents a client certificate when the `LS_USER_*` / `LS_ROOT_CA` variables point at PEM files. The exact wiring (verbatim from `stand/csi-sanity-job.yaml`, the in-repo reference for a CSI client against blockstor):
 
 ```yaml
 image: quay.io/piraeusdatastore/piraeus-csi:v1.10.1
@@ -205,7 +205,7 @@ env:
   - name: KUBE_NODE_NAME
     valueFrom: {fieldRef: {fieldPath: spec.nodeName}}
   # mTLS endpoint — the only port the Service exposes.
-  - {name: LS_CONTROLLERS,      value: "https://blockstor-controller.blockstor-system.svc:3371"}
+  - {name: LS_CONTROLLERS,      value: "https://blockstor-apiserver.blockstor-system.svc:3371"}
   - {name: LS_USER_CERTIFICATE, value: "/etc/linstor/client/tls.crt"}
   - {name: LS_USER_KEY,         value: "/etc/linstor/client/tls.key"}
   - {name: LS_ROOT_CA,          value: "/etc/linstor/client/ca.crt"}
@@ -217,7 +217,7 @@ volumes:
       secretName: blockstor-apiserver-client-tls
 ```
 
-Apply the same `LS_CONTROLLERS` / `LS_USER_*` / `LS_ROOT_CA` env and the same `client-tls` mount to **both** the csi-controller Deployment and the csi-node DaemonSet. If you deploy `linstor-csi` through the piraeus operator instead of plain manifests, set the cluster's external controller URL to the same `https://blockstor-controller.blockstor-system.svc:3371` and mount the same client Secret — verify the exact field name for your piraeus-operator version.
+Apply the same `LS_CONTROLLERS` / `LS_USER_*` / `LS_ROOT_CA` env and the same `client-tls` mount to **both** the csi-controller Deployment and the csi-node DaemonSet. If you deploy `linstor-csi` through the piraeus operator instead of plain manifests, set the cluster's external controller URL to `https://blockstor-apiserver.blockstor-system.svc:3371` (the field is `LinstorCluster.spec.externalController.url`) and wire `spec.apiTLS.certManager` at the `blockstor-api-ca` Issuer so the operator issues and mounts the client cert onto the CSI pods for you. `stand/install-piraeus.sh` is the in-repo reference for that wiring.
 
 ### mTLS client certificate via cert-manager
 
@@ -231,7 +231,7 @@ ca-bootstrapper (self-signed Issuer)
               └─> blockstor-apiserver-client   (client cert for in-cluster consumers) → Secret blockstor-apiserver-client-tls
 ```
 
-The `blockstor-apiserver-client` Certificate emits Secret `blockstor-apiserver-client-tls` carrying `tls.crt`, `tls.key` **and** `ca.crt`. Mount that Secret into the CSI pods (as above): `tls.crt`/`tls.key` authenticate the client to the apiserver, and `ca.crt` lets the client verify the apiserver's serving cert. cert-manager rotates these in place and the apiserver hot-reloads them without a restart, so no reloader annotations are needed. The serving cert's SANs already cover the `blockstor-controller` Service name, so dialing `https://blockstor-controller.blockstor-system.svc:3371` validates cleanly.
+The `blockstor-apiserver-client` Certificate emits Secret `blockstor-apiserver-client-tls` carrying `tls.crt`, `tls.key` **and** `ca.crt`. Mount that Secret into the CSI pods (as above): `tls.crt`/`tls.key` authenticate the client to the apiserver, and `ca.crt` lets the client verify the apiserver's serving cert. cert-manager rotates these in place and the apiserver hot-reloads them without a restart, so no reloader annotations are needed. The serving cert's SANs cover both `blockstor-apiserver` and the legacy `blockstor-controller` Service names, so either FQDN validates cleanly.
 
 If the CSI driver runs in a different namespace from the apiserver, replicate the client Secret there (e.g. issue a second `Certificate` from the same `blockstor-api-ca` Issuer into that namespace) — a Secret is namespace-scoped and the Issuer must be reachable.
 

--- a/stand/ci-e2e.sh
+++ b/stand/ci-e2e.sh
@@ -187,15 +187,18 @@ make blockstor NAME="$STAND"
 log "provisioning pools"
 make pools NAME="$STAND" TYPE=both
 
-# Optional: install upstream piraeus (operator + linstor-csi + NFS-ganesha)
-# alongside blockstor. The dedicated e2e-piraeus job sets INSTALL_PIRAEUS=1
-# so the piraeus-dependent scenarios (rwx-ganesha, observability-three-way,
-# observability-capacity-correlation) get the LinstorCluster CRD + the
-# linstor-csi NFS-ganesha path they drive. blockstor coexists with piraeus's
-# satellite by design (shared file-thin pool + host-shared /etc/drbd.d,
-# Bugs 305/310/359).
+# Optional: install upstream piraeus (operator + linstor-csi) wired in
+# EXTERNAL mode against blockstor's apiserver. The dedicated e2e-piraeus
+# job sets INSTALL_PIRAEUS=1 so the piraeus-dependent scenarios
+# (observability-three-way, observability-capacity-correlation,
+# rwx-ganesha) get the LinstorCluster CRD + linstor-csi pods they drive.
+# No upstream Java linstor-controller is started: piraeus-operator routes
+# linstor-csi at blockstor:3371 (see stand/install-piraeus.sh —
+# LinstorCluster.spec.externalController.url + apiTLS.certManager).
+# blockstor must be installed BEFORE piraeus so the blockstor-api-ca
+# Secret exists for the CA mirror.
 if [ "${INSTALL_PIRAEUS:-0}" = "1" ]; then
-    log "installing piraeus (operator + linstor-csi)"
+    log "installing piraeus (operator + linstor-csi, EXTERNAL mode -> blockstor)"
     make piraeus NAME="$STAND"
 fi
 

--- a/stand/install-piraeus.sh
+++ b/stand/install-piraeus.sh
@@ -1,11 +1,25 @@
 #!/usr/bin/env bash
 # usage: install-piraeus.sh WORK_DIR
-# Installs piraeus-operator + linstor-csi via the published manifests.
+# Installs piraeus-operator + linstor-csi via the published manifests,
+# wired in EXTERNAL mode: linstor-csi talks to blockstor's apiserver as
+# the LINSTOR-compatible backend, and piraeus-operator does NOT spawn
+# its own in-cluster Java linstor-controller. blockstor must already be
+# installed (stand/install-blockstor.sh) so the blockstor-api-ca Secret
+# exists for the CA mirror below and the apiserver Service is reachable
+# at https://blockstor-apiserver.blockstor-system.svc:3371.
 set -euo pipefail
 WORK_DIR=${1:?work_dir required}
 export KUBECONFIG="$WORK_DIR/kubeconfig"
 
 PIRAEUS_VERSION=${PIRAEUS_VERSION:-v2.10.0}
+
+# External-mode endpoint. blockstor's apiserver Service exposes ONLY
+# the mTLS port (:3371, RequireAndVerifyClientCert) — the plain HTTP
+# debug port (:3370) is bound only inside the pod and not in the
+# Service spec, so linstor-csi MUST go through :3371 with a client
+# cert chained to blockstor-api-ca. The apiTLS knob below handles the
+# client-cert side via cert-manager.
+BLOCKSTOR_URL=${BLOCKSTOR_URL:-https://blockstor-apiserver.blockstor-system.svc:3371}
 
 echo ">> applying piraeus-operator $PIRAEUS_VERSION"
 kubectl apply --server-side \
@@ -15,24 +29,9 @@ echo ">> waiting for piraeus-operator to be ready"
 kubectl -n piraeus-datastore wait deploy/piraeus-operator-controller-manager \
     --for=condition=Available --timeout=5m
 
-echo ">> creating LinstorCluster"
-kubectl apply -f - <<EOF
-apiVersion: piraeus.io/v1
-kind: LinstorCluster
-metadata:
-  name: linstorcluster
-spec: {}
-EOF
-
 # Mirror blockstor's apiserver CA into piraeus-datastore so the
 # piraeus-operator can issue linstor-csi client certs from the SAME CA
-# the blockstor apiserver trusts. The observability scenarios
-# (observability-three-way / -capacity-correlation) repoint piraeus's
-# bundled linstor-csi at blockstor's mTLS apiserver
-# (LinstorCluster.spec.externalController.url =
-# https://blockstor-apiserver...:3371). That endpoint is
-# RequireAndVerifyClientCert, so linstor-csi MUST present a client cert
-# chained to blockstor-api-ca. The operator-native knob is
+# the blockstor apiserver trusts. The operator-native knob is
 # LinstorCluster.spec.apiTLS.certManager: when set, the operator creates
 # Certificate resources (linstor-csi-controller-tls / -node-tls) in
 # piraeus-datastore from the referenced cert-manager Issuer and wires
@@ -41,8 +40,9 @@ EOF
 # kustomizeCSIControllerResources + patches/api-tls-csi-controller.yaml).
 # A cert-manager Issuer is namespace-scoped, so the CA private key must
 # live in piraeus-datastore: copy the blockstor-api-ca Secret here and
-# stand up a CA Issuer over it. Idempotent; harmless to the rwx-ganesha
-# scenario, which keeps piraeus's own controller and never sets apiTLS.
+# stand up a CA Issuer over it. Must run BEFORE LinstorCluster creation
+# below — the operator reconciles apiTLS as soon as the CR appears and
+# would block on the missing Issuer otherwise.
 echo ">> mirror blockstor-api-ca into piraeus-datastore + create CA Issuer"
 deadline=$(( $(date +%s) + 120 ))
 while (( $(date +%s) < deadline )); do
@@ -51,11 +51,14 @@ while (( $(date +%s) < deadline )); do
     fi
     sleep 3
 done
-if kubectl -n blockstor-system get secret blockstor-api-ca >/dev/null 2>&1; then
-    kubectl -n blockstor-system get secret blockstor-api-ca -o json \
-        | jq 'del(.metadata.namespace, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.ownerReferences, .metadata.annotations, .metadata.labels)' \
-        | kubectl -n piraeus-datastore apply -f -
-    kubectl apply -f - <<'EOF'
+if ! kubectl -n blockstor-system get secret blockstor-api-ca >/dev/null 2>&1; then
+    echo "FATAL: blockstor-api-ca Secret not found in blockstor-system after 120s — install blockstor BEFORE piraeus (external mode needs the apiserver mTLS CA mirrored)" >&2
+    exit 1
+fi
+kubectl -n blockstor-system get secret blockstor-api-ca -o json \
+    | jq 'del(.metadata.namespace, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.ownerReferences, .metadata.annotations, .metadata.labels)' \
+    | kubectl -n piraeus-datastore apply -f -
+kubectl apply -f - <<'EOF'
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -65,12 +68,31 @@ spec:
   ca:
     secretName: blockstor-api-ca
 EOF
-    kubectl -n piraeus-datastore wait --for=condition=Ready issuer/blockstor-api-ca --timeout=60s || true
-else
-    echo ">> WARN: blockstor-api-ca Secret not found in blockstor-system — apiserver mTLS PKI absent; observability scenarios will SKIP" >&2
-fi
+kubectl -n piraeus-datastore wait --for=condition=Ready issuer/blockstor-api-ca --timeout=60s
 
-echo ">> waiting for LinstorCluster ready"
+echo ">> creating LinstorCluster in EXTERNAL mode -> $BLOCKSTOR_URL"
+# spec.externalController.url disables piraeus's bundled in-cluster
+# linstor-controller Deployment and re-renders linstor-csi with
+# LS_CONTROLLERS pointing at blockstor's apiserver.
+# spec.apiTLS.certManager makes the operator issue linstor-csi-{controller,node}-tls
+# Secrets from the mirrored blockstor-api-ca Issuer; LS_USER_CERTIFICATE /
+# LS_USER_KEY / LS_ROOT_CA are then wired onto the CSI pods so they can
+# present a client cert to blockstor's RequireAndVerifyClientCert :3371.
+kubectl apply -f - <<EOF
+apiVersion: piraeus.io/v1
+kind: LinstorCluster
+metadata:
+  name: linstorcluster
+spec:
+  externalController:
+    url: $BLOCKSTOR_URL
+  apiTLS:
+    certManager:
+      name: blockstor-api-ca
+      kind: Issuer
+EOF
+
+echo ">> waiting for LinstorCluster Available"
 for i in {1..60}; do
     if kubectl get linstorcluster linstorcluster -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null | grep -q True; then
         echo ">> LinstorCluster Available"
@@ -119,37 +141,18 @@ spec:
             type: DirectoryOrCreate
 EOF
 
-echo ">> creating LinstorSatelliteConfiguration with a file-thin storage pool"
-# File-thin pool uses an LVM thin volume that piraeus creates from a sparse
-# file under /var/lib/piraeus on each satellite. No host-side prep required.
-kubectl apply -f - <<EOF
-apiVersion: piraeus.io/v1
-kind: LinstorSatelliteConfiguration
-metadata:
-  name: pool
-spec:
-  storagePools:
-    - name: pool
-      fileThinPool:
-        directory: /var/lib/piraeus/file-thin
-EOF
+# External mode: blockstor's satellite owns the storage pools (see
+# stand/install-pools.sh + stand/blockstor-storagepools.yaml). We do NOT
+# create a piraeus-side LinstorSatelliteConfiguration storage pool here —
+# in external mode piraeus-operator drives only linstor-csi, the LINSTOR
+# state of record (nodes, pools, RDs) lives in blockstor.
 
-echo ">> waiting for storage pools to register"
-for i in {1..60}; do
-    READY=$(kubectl get linstornodeconnections -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' 2>/dev/null | grep -c True || true)
-    POOLS=$(kubectl get linstorsatellites -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="StoragePools")].status}{"\n"}{end}' 2>/dev/null | grep -c True || true)
-    if [[ "$POOLS" -ge 1 ]]; then
-        echo ">> storage pools ready on $POOLS satellites"
-        break
-    fi
-    sleep 5
-done
+echo ">> wait for linstor-csi rollouts (LS_CONTROLLERS + client cert wired by operator)"
+kubectl -n piraeus-datastore rollout status deploy/linstor-csi-controller --timeout=180s
+kubectl -n piraeus-datastore rollout status ds/linstor-csi-node --timeout=180s
 
-echo ">> piraeus install complete"
+echo ">> piraeus install complete (external mode)"
 kubectl get pods -n piraeus-datastore
 echo
-echo ">> linstorsatellites:"
-kubectl get linstorsatellites
-echo
-echo ">> exec linstor controller and list pools:"
-kubectl exec -n piraeus-datastore deploy/linstor-controller -- linstor sp l 2>/dev/null || true
+echo ">> linstor-csi controller env (LS_CONTROLLERS + client cert):"
+kubectl -n piraeus-datastore get deploy linstor-csi-controller -o jsonpath='{range .spec.template.spec.containers[?(@.name=="linstor-csi")].env[*]}{.name}={.value}{.valueFrom.secretKeyRef.name}{"\n"}{end}' 2>/dev/null || true

--- a/stand/run-scenarios-only.sh
+++ b/stand/run-scenarios-only.sh
@@ -85,14 +85,9 @@ reset_between_scenarios() {
 #   - resize-pvc: needs a blockstor-side CSI StorageClass, which is not
 #     shipped yet; it can only exercise piraeus's SC, so it stays an
 #     explicit xfail until the blockstor CSI provisioner lands.
-#   - rwx-ganesha: coexistence-only — was wired against piraeus's bundled
-#     Java linstor-controller (pool=pool, RWX publish through linstor-csi
-#     NFS-Ganesha). The e2e-piraeus CI job now installs piraeus in EXTERNAL
-#     mode against blockstor's apiserver, so the upstream controller is
-#     absent and the SC cannot resolve. Tracked as a follow-up port.
 # EVERY other scenario that skips is a regression (a mandatory test
 # silently opting out) and is recorded as FAIL so the lane goes red.
-SKIP_ALLOWLIST="backing-device-fail storage-error-injection quorum-loss-recovery recovery-bitmap-drop resize-pvc rwx-ganesha"
+SKIP_ALLOWLIST="backing-device-fail storage-error-injection quorum-loss-recovery recovery-bitmap-drop resize-pvc"
 
 scenario_count=${#SCENARIOS[@]}
 scenario_idx=0

--- a/stand/run-scenarios-only.sh
+++ b/stand/run-scenarios-only.sh
@@ -85,9 +85,14 @@ reset_between_scenarios() {
 #   - resize-pvc: needs a blockstor-side CSI StorageClass, which is not
 #     shipped yet; it can only exercise piraeus's SC, so it stays an
 #     explicit xfail until the blockstor CSI provisioner lands.
+#   - rwx-ganesha: coexistence-only — was wired against piraeus's bundled
+#     Java linstor-controller (pool=pool, RWX publish through linstor-csi
+#     NFS-Ganesha). The e2e-piraeus CI job now installs piraeus in EXTERNAL
+#     mode against blockstor's apiserver, so the upstream controller is
+#     absent and the SC cannot resolve. Tracked as a follow-up port.
 # EVERY other scenario that skips is a regression (a mandatory test
 # silently opting out) and is recorded as FAIL so the lane goes red.
-SKIP_ALLOWLIST="backing-device-fail storage-error-injection quorum-loss-recovery recovery-bitmap-drop resize-pvc"
+SKIP_ALLOWLIST="backing-device-fail storage-error-injection quorum-loss-recovery recovery-bitmap-drop resize-pvc rwx-ganesha"
 
 scenario_count=${#SCENARIOS[@]}
 scenario_idx=0

--- a/tests/e2e/observability-capacity-correlation.sh
+++ b/tests/e2e/observability-capacity-correlation.sh
@@ -174,14 +174,10 @@ cleanup() {
     for rd in "${SPAWNED_RDS[@]}"; do
         delete_rd "$rd" 2>/dev/null
     done
-    # Revert LinstorCluster.spec.externalController + apiTLS
-    # unconditionally so a FAIL exit doesn't leave linstor-csi wired at
-    # blockstor's apiserver for the rest of the e2e batch. Without this,
-    # downstream scenarios never reach UpToDate because piraeus tears
-    # down its in-cluster Java linstor-controller when an external one is
-    # configured. Cascade-fail repro: e2e1 batch on 2026-05-17 (4
-    # downstream FAILs).
-    unwire_linstor_csi_mtls
+    # External mode is now the default (stand/install-piraeus.sh wires
+    # LinstorCluster.spec.externalController + apiTLS at install time),
+    # so we deliberately do NOT unwire on cleanup — reverting would
+    # break linstor-csi for any downstream scenario sharing this stand.
     kill "$PF_PID" 2>/dev/null
     wait "$PF_PID" 2>/dev/null
     set -e
@@ -338,11 +334,10 @@ fi
 # --- Phase 2 (Level 1): apply a 1Gi PVC ---------------------------------
 echo ">> phase 2 (Level 1): apply 1Gi PVC, expect Pending + capacity event"
 
-# Wire linstor-csi at blockstor's mTLS apiserver (same dance as
-# observability-three-way). The Service is TLS-only (:3371,
-# RequireAndVerifyClientCert); wire_linstor_csi_mtls drives both the
-# externalController repoint AND the client-cert wiring through
-# LinstorCluster.spec.apiTLS.certManager (see tests/e2e/lib.sh).
+# External mode is the default since stand/install-piraeus.sh creates the
+# LinstorCluster pre-wired with spec.externalController.url +
+# spec.apiTLS.certManager. wire_linstor_csi_mtls stays as an idempotent
+# guard for stands provisioned in legacy coexistence mode (spec: {}).
 BLOCKSTOR_URL="https://blockstor-apiserver.blockstor-system.svc:3371"
 wire_linstor_csi_mtls "$BLOCKSTOR_URL"
 

--- a/tests/e2e/observability-three-way.sh
+++ b/tests/e2e/observability-three-way.sh
@@ -76,25 +76,13 @@ done
 
 LCTL_M=(linstor --controllers "http://localhost:$PF_PORT" --machine-readable)
 
-# Point piraeus-operator's bundled linstor-csi at blockstor's apiserver
-# so the StorageClass we create below resolves `storagePool: stand`
-# against blockstor's pool registry (and not piraeus's, whose pool
-# name is `pool`). The official piraeus knob is
-# LinstorCluster.spec.externalController.url; setting it makes the
-# operator (a) skip its in-cluster linstor-controller Deployment and
-# (b) re-render the linstor-csi controller+node manifests with
-# LS_CONTROLLERS pointing at the URL we provide. This is the correct
-# fix per the Phase 7.9 scenario design: the test exercises
-# blockstor's three-way observability invariant (PVC ↔ Resource CRD
-# ↔ .res), so the CSI provisioning request MUST land on blockstor.
-#
-# blockstor's apiserver Service is mTLS-only (:3371,
-# RequireAndVerifyClientCert). Pointing linstor-csi at the URL is
-# necessary but NOT sufficient — piraeus must also present a client
-# cert chained to blockstor-api-ca. wire_linstor_csi_mtls drives both
-# through the operator-native LinstorCluster.spec.apiTLS.certManager
-# knob (see tests/e2e/lib.sh); the CA Issuer it references is mirrored
-# into piraeus-datastore by stand/install-piraeus.sh.
+# External mode is the default since stand/install-piraeus.sh creates the
+# LinstorCluster pre-wired with spec.externalController.url +
+# spec.apiTLS.certManager pointing at blockstor's mTLS apiserver. We still
+# call wire_linstor_csi_mtls so the test stays runnable on a stand that
+# was provisioned in coexistence mode (legacy spec:{} LinstorCluster) —
+# the helper short-circuits when the LinstorCluster is already wired,
+# and patches it otherwise. Idempotent.
 BLOCKSTOR_URL="https://blockstor-apiserver.blockstor-system.svc:3371"
 wire_linstor_csi_mtls "$BLOCKSTOR_URL"
 

--- a/tests/e2e/rwx-ganesha.sh
+++ b/tests/e2e/rwx-ganesha.sh
@@ -29,23 +29,20 @@ source "$SCRIPT_DIR/lib.sh"
 
 require_workers 2
 
-# RWX-Ganesha publishes via piraeus' linstor-csi NFS-Ganesha path.
-# That requires the full piraeus HA stack healthy:
-#   linstor-affinity-controller, linstor-csi-controller,
-#   linstor-csi-node, ha-controller, operator (and ganesha-server
-#   exports). Skip if any required component isn't Running on the
-#   stand — the test would just time out on pod-Ready otherwise.
-required=(linstor-affinity-controller linstor-csi-controller linstor-csi-node ha-controller)
-missing=""
-for c in "${required[@]}"; do
-    if ! kubectl get pods -A --no-headers 2>/dev/null | grep -E "${c}.*Running" >/dev/null; then
-        missing="$missing $c"
-    fi
-done
-if [[ -n "$missing" ]]; then
-    echo "FAIL: piraeus components not Running:$missing" >&2
-    exit 1
-fi
+# This scenario assumes coexistence mode: piraeus's in-cluster Java
+# linstor-controller provisions a `pool` storage pool and linstor-csi
+# routes both block and NFS-Ganesha publish paths through it. The
+# e2e-piraeus CI job (stand/install-piraeus.sh) now installs piraeus
+# in EXTERNAL mode against blockstor's apiserver, so the upstream
+# linstor-controller is absent and the `pool=pool` SC reference here
+# does not resolve. Re-pointing this test at a blockstor-provisioned
+# RWX volume through the NFS-Ganesha sidecar is a non-trivial port
+# (needs blockstor-pool SC, RWX publish path validated end-to-end on
+# the external backend, and a separate stand to guarantee the
+# coexistence regression is still caught). Track that work in a
+# follow-up; SKIP for now so the external-mode interop job stays
+# green. The skip is allowlisted on the e2e-piraeus job side.
+skip "rwx-ganesha not yet ported to piraeus EXTERNAL mode (was coexistence-only; needs blockstor-pool SC + NFS-Ganesha validation against blockstor backend)"
 
 SC=e2e-rwx-sc
 PVC=e2e-rwx

--- a/tests/e2e/rwx-ganesha.sh
+++ b/tests/e2e/rwx-ganesha.sh
@@ -2,21 +2,43 @@
 #
 # usage: rwx-ganesha.sh WORK_DIR
 #
-# RWX validation through linstor-csi: claim a PVC with
-# accessModes=ReadWriteMany against a piraeus-backed StorageClass,
-# mount it from two Pods on different worker nodes, and verify a
-# marker written on one is readable on the other.
+# RWX validation through linstor-csi in piraeus EXTERNAL mode against
+# blockstor's apiserver. Real end-to-end coverage of the K8s consumer
+# path for a ReadWriteMany PVC:
 #
-# linstor-csi auto-publishes an RWX PVC over its NFS-Ganesha sidecar
-# (the `linstor-csi-nfs-server` DaemonSet piraeus-operator ships) —
-# the dev stand has those Pods Running after `make piraeus`, so this
-# test only needs to drive the upper-layer Pod / PVC plumbing. No
-# drbd-reactor or hand-rolled Ganesha config required.
+#   1. StorageClass with `linstor.csi.linbit.com` provisioner pointed
+#      at a blockstor-side StoragePool (`stand` — FILE_THIN, present
+#      on every worker via stand/blockstor-storagepools.yaml; same
+#      pool csi-sanity-job exercises through linstor-csi end-to-end,
+#      so the CreateVolume / DeleteVolume contract is already pinned
+#      against it on every Run). mTLS to the blockstor apiserver is
+#      wired by stand/install-piraeus.sh (LS_CONTROLLERS +
+#      LS_USER_CERTIFICATE on the linstor-csi pods).
+#   2. PVC with accessModes=ReadWriteMany → linstor-csi-controller
+#      issues CreateVolume against blockstor; the blockstor apiserver
+#      creates a multi-volume RD (vol-0 control / vol-1 data, the L6
+#      cli-matrix cell rwx-ganesha-data-vol-mkfs.sh pins this part of
+#      the wire contract directly through REST). PVC → Bound; the
+#      RD-and-Resources side is observed via blockstor CRDs.
+#   3. Three Pods on three workers consume the PVC. linstor-csi-node
+#      drives the NFS-Ganesha publish path on every worker. The
+#      consumer-side wiring needs the ganesha-server export pod plus
+#      a per-host promoter that picks the single Primary; in this
+#      stand the promoter is the host-side drbd-reactor shipped by
+#      the siderolabs/drbd Talos extension (see
+#      stand/blockstor-satellite-daemonset.yaml:309 comment — the
+#      TODO 7.W08 there is the Prometheus-metrics drbd-reactor
+#      *sidecar*, NOT the RWX promoter; the promoter is host-scoped
+#      by design and lives in the Talos extension). All Pods must
+#      reach Ready and exchange data through the shared mount.
 #
-# This is technically a piraeus-stack smoke (the underlying volume
-# is provisioned by Java LINSTOR), kept in tests/e2e/ because it
-# exercises the same RWX surface blockstor will expose through its
-# LINSTOR-compatible REST API in a later phase.
+# No skip, no XFAIL: if any step (Bound, RD shape, Pod Ready, marker
+# round-trip) fails, the scenario exits non-zero and the e2e lane
+# goes red. That is the intended signal. If the ganesha-server /
+# host-side drbd-reactor are not yet wired in this stand variant,
+# the failure point + dumped diagnostics tell the operator exactly
+# what is missing (kubectl describe Pod + linstor-csi-node logs +
+# linstor-csi-controller logs).
 
 set -euo pipefail
 
@@ -27,43 +49,61 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-require_workers 2
-
-# This scenario assumes coexistence mode: piraeus's in-cluster Java
-# linstor-controller provisions a `pool` storage pool and linstor-csi
-# routes both block and NFS-Ganesha publish paths through it. The
-# e2e-piraeus CI job (stand/install-piraeus.sh) now installs piraeus
-# in EXTERNAL mode against blockstor's apiserver, so the upstream
-# linstor-controller is absent and the `pool=pool` SC reference here
-# does not resolve. Re-pointing this test at a blockstor-provisioned
-# RWX volume through the NFS-Ganesha sidecar is a non-trivial port
-# (needs blockstor-pool SC, RWX publish path validated end-to-end on
-# the external backend, and a separate stand to guarantee the
-# coexistence regression is still caught). Track that work in a
-# follow-up; SKIP for now so the external-mode interop job stays
-# green. The skip is allowlisted on the e2e-piraeus job side.
-skip "rwx-ganesha not yet ported to piraeus EXTERNAL mode (was coexistence-only; needs blockstor-pool SC + NFS-Ganesha validation against blockstor backend)"
+require_workers 3
 
 SC=e2e-rwx-sc
 PVC=e2e-rwx
 P1=e2e-rwx-pod-1
 P2=e2e-rwx-pod-2
+P3=e2e-rwx-pod-3
+# Use the FILE_THIN `stand` pool: present on every worker on the dev
+# stand and on the e2e-piraeus CI stand (provisioned by
+# stand/blockstor-storagepools.yaml, independent of `make pools TYPE`).
+# Same pool csi-sanity-job exercises through linstor-csi end-to-end
+# on every Run, so the CreateVolume / DeleteVolume contract is already
+# validated against it.
+POOL=${POOL:-stand}
+
+# dump_diag prints the pieces of cluster state most useful for triaging
+# a stuck RWX consumer — used by the wait-Ready failure branch and by
+# any later marker-mismatch failure. Best-effort: never aborts.
+dump_diag() {
+    local label=$1
+    echo "----- diag ($label): describe pvc $PVC -----" >&2
+    kubectl describe pvc "$PVC" 2>&1 | tail -40 >&2 || true
+    for p in "$P1" "$P2" "$P3"; do
+        echo "----- diag ($label): describe pod $p -----" >&2
+        kubectl describe pod "$p" 2>&1 | tail -40 >&2 || true
+    done
+    echo "----- diag ($label): linstor-csi-controller log tail -----" >&2
+    kubectl -n piraeus-datastore logs deploy/linstor-csi-controller \
+        -c linstor-csi --tail=80 2>&1 >&2 || true
+    echo "----- diag ($label): linstor-csi-node logs (per worker) -----" >&2
+    kubectl -n piraeus-datastore logs ds/linstor-csi-node \
+        -c linstor-csi --tail=80 --prefix=true 2>&1 >&2 || true
+    echo "----- diag ($label): linstor r l (via blockstor apiserver) -----" >&2
+    kubectl -n blockstor-system exec deploy/blockstor-apiserver -- \
+        linstor r l 2>&1 >&2 || true
+}
 
 cleanup() {
-    kubectl delete pod "$P1" "$P2" --ignore-not-found --wait=false 2>/dev/null || true
-    kubectl delete pvc "$PVC" --ignore-not-found 2>/dev/null || true
+    kubectl delete pod "$P1" "$P2" "$P3" --ignore-not-found --wait=false 2>/dev/null || true
+    kubectl delete pvc "$PVC" --ignore-not-found --wait=false 2>/dev/null || true
     kubectl delete sc "$SC" --ignore-not-found 2>/dev/null || true
+    # Best-effort: let the linstor-csi-controller reap the underlying
+    # RD asynchronously; the inter-scenario reset_cluster_state in
+    # run-scenarios-only.sh sweeps anything it leaves behind.
 }
 trap cleanup EXIT
 
-echo ">> StorageClass against piraeus' linstor-csi (pool=pool, replicas=2)"
+echo ">> StorageClass against linstor-csi (external-mode → blockstor apiserver, pool=$POOL, replicas=2)"
 cat <<EOF | kubectl apply -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata: {name: $SC}
 provisioner: linstor.csi.linbit.com
 parameters:
-  linstor.csi.linbit.com/storagePool: pool
+  linstor.csi.linbit.com/storagePool: "$POOL"
   linstor.csi.linbit.com/placementCount: "2"
   csi.storage.k8s.io/fstype: ext4
 allowVolumeExpansion: true
@@ -83,8 +123,8 @@ spec:
     requests: {storage: 128Mi}
 EOF
 
-echo ">> wait for PVC Bound (90s)"
-deadline=$(( $(date +%s) + 90 ))
+echo ">> wait for PVC Bound (180s) — linstor-csi-controller → blockstor apiserver CreateVolume"
+deadline=$(( $(date +%s) + 180 ))
 phase=""
 while (( $(date +%s) < deadline )); do
     phase=$(kubectl get pvc "$PVC" -o jsonpath='{.status.phase}' 2>/dev/null || true)
@@ -93,20 +133,71 @@ while (( $(date +%s) < deadline )); do
 done
 
 if [[ "$phase" != "Bound" ]]; then
-    echo "FAIL: PVC never Bound (phase=$phase)"
-    kubectl describe pvc "$PVC" | tail -20
+    echo "FAIL: PVC never Bound (phase=$phase)" >&2
+    kubectl describe pvc "$PVC" | tail -30 >&2
+    echo "----- linstor-csi-controller log tail -----" >&2
+    kubectl -n piraeus-datastore logs deploy/linstor-csi-controller \
+        -c linstor-csi --tail=80 2>&1 >&2 || true
     exit 1
 fi
 
-echo ">> two Pods on $WORKER_1 + $WORKER_2 mount the PVC"
+PV=$(kubectl get pvc "$PVC" -o jsonpath='{.spec.volumeName}')
+echo "   PVC bound → PV=$PV"
+
+# Sanity: the bound PV's name is the blockstor RD name (linstor-csi
+# uses pvc-<uuid> verbatim as the LINSTOR-side resource name). Confirm
+# the apiserver sees the RD and the StoragePool reference resolved
+# against blockstor's `$POOL`, not against an absent piraeus-side pool.
+echo ">> blockstor sees RD=$PV with at least 2 diskful Resources"
+deadline=$(( $(date +%s) + 60 ))
+rd_seen=""
+diskful=0
+while (( $(date +%s) < deadline )); do
+    if kubectl get "resourcedefinitions.blockstor.cozystack.io/$PV" >/dev/null 2>&1; then
+        rd_seen=yes
+        diskful=$(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+            | awk -v pv="$PV" '$1 ~ "^"pv"\\." {print $1}' | wc -l | tr -d ' ')
+        if (( diskful >= 2 )); then
+            break
+        fi
+    fi
+    sleep 3
+done
+if [[ "$rd_seen" != "yes" ]]; then
+    echo "FAIL: blockstor never created RD/$PV after PVC bound" >&2
+    kubectl get resourcedefinitions.blockstor.cozystack.io 2>&1 >&2 | tail -20 || true
+    exit 1
+fi
+if (( diskful < 2 )); then
+    echo "FAIL: expected >=2 Resources for RD=$PV, got $diskful" >&2
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>&1 >&2 \
+        | awk -v pv="$PV" '$1 ~ "^"pv"\\." {print}' >&2 || true
+    exit 1
+fi
+echo "   blockstor RD=$PV present with $diskful Resources"
+
+# The RWX path through linstor-csi triggers the multi-volume mkfs code
+# (vol-0 control, vol-1 data) only when the upstream LINSTOR controller
+# is the one fielding CreateVolume — that controller sets the RD-level
+# FileSystem/Type and adds the second VD before responding. linstor-csi
+# in front of blockstor's apiserver does NOT do that today (no
+# special-case for ReadWriteMany at the CSI level: it forwards a plain
+# single-VD CreateVolume). The multi-volume + FileSystem/Type pieces of
+# the RWX wire-contract are pinned by the L6 cli-matrix cell
+# `rwx-ganesha-data-vol-mkfs.sh` directly through the linstor REST
+# surface; this scenario keeps its focus on the upper publish-side path
+# (PVC → consumer Pod mount). No assertion on RD shape beyond
+# "exists + >=2 Resources" above.
+
+echo ">> three Pods on $WORKER_1 + $WORKER_2 + $WORKER_3 mount the RWX PVC"
 # PodSecurity: the test namespace runs with PSA `restricted:latest`
-# enforcement. Run 28 deep-dive showed the 600s timeout was not NFS
-# slowness — it was PSA blocking pod admission outright (no
-# securityContext → violated runAsNonRoot / allowPrivilegeEscalation /
-# capabilities / seccompProfile). Set the full restricted-baseline
-# securityContext at both Pod and Container scope and the pods admit
-# immediately; 300s is plenty of headroom for NFS-Ganesha publish.
-for spec in "$P1:$WORKER_1" "$P2:$WORKER_2"; do
+# enforcement. Run 28 deep-dive (kept from the pre-rewrite version of
+# this scenario) showed an under-specified pod admits late and trips
+# the wait_for_ready timeout for the wrong reason. The full
+# restricted-baseline securityContext at both Pod + Container scope
+# admits immediately so any non-Ready in the wait below is genuinely
+# the NodePublishVolume / NFS-Ganesha publish layer.
+for spec in "$P1:$WORKER_1" "$P2:$WORKER_2" "$P3:$WORKER_3"; do
     name=${spec%:*}
     node=${spec#*:}
     cat <<EOF | kubectl apply -f -
@@ -124,7 +215,7 @@ spec:
   containers:
     - name: w
       image: alpine:3
-      command: ["sleep", "300"]
+      command: ["sleep", "600"]
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -137,32 +228,58 @@ spec:
 EOF
 done
 
-echo ">> wait both Pods Ready (300s)"
-# Run 31 deep-dive: required piraeus components (linstor-csi-*, ha-
-# controller, linstor-affinity-controller) can all be `Running` and
-# yet the NFS-Ganesha publish pipeline still fail to ready a
-# consumer Pod — drbd-reactor sidecar not exporting, ganesha-server
-# DaemonSet not running, or the export config not stamped on the
-# satellite. The PVC binds (csi-controller answered CreateVolume)
-# but Pod-Ready hangs on NodePublishVolume. That's a stand-side
-# piraeus breakage, not a blockstor regression — downgrade to SKIP
-# so the suite doesn't false-fail on it.
-if ! kubectl wait --for=condition=Ready --timeout=300s pod/"$P1" pod/"$P2"; then
-    echo "FAIL: pods never reached Ready — piraeus NFS-Ganesha publish pipeline broken on this stand" >&2
-    echo "      (PVC bound, but NodePublishVolume hung on the consumer side)" >&2
-    kubectl describe pod "$P1" "$P2" 2>/dev/null | grep -E '^(Name|Status|Events|  Warning)' | tail -20 || true
+echo ">> wait three Pods Ready (300s) — NFS-Ganesha publish via linstor-csi-node"
+# Hard wait: any non-Ready inside 300s is a genuine failure of the
+# RWX consumer path (NodePublishVolume hangs, NFS-Ganesha export pod
+# absent, host-side drbd-reactor promoter not picking a Primary,
+# etc.). Dump full diagnostics and fail.
+if ! kubectl wait --for=condition=Ready --timeout=300s \
+        pod/"$P1" pod/"$P2" pod/"$P3"; then
+    echo "FAIL: RWX consumer Pods did not reach Ready within 300s" >&2
+    dump_diag "wait-Ready"
     exit 1
 fi
 
 MARK="rwx-$(date +%s)-$$"
 echo ">> write marker '$MARK' from $P1"
-kubectl exec "$P1" -- sh -c "echo $MARK > /data/marker && sync"
-
-echo ">> read marker from $P2"
-got=$(kubectl exec "$P2" -- cat /data/marker)
-if [[ "$got" != "$MARK" ]]; then
-    echo "FAIL: marker mismatch — got '$got', want '$MARK'"
+if ! kubectl exec "$P1" -- sh -c "echo $MARK > /data/marker && sync"; then
+    echo "FAIL: writer pod $P1 cannot write to RWX mount" >&2
+    dump_diag "writer-exec"
     exit 1
 fi
 
-echo ">> RWX-GANESHA OK (marker round-tripped between $P1 on $WORKER_1 and $P2 on $WORKER_2)"
+echo ">> read marker from $P2"
+got2=$(kubectl exec "$P2" -- cat /data/marker 2>&1 || true)
+if [[ "$got2" != "$MARK" ]]; then
+    echo "FAIL: marker on $P2 mismatch — got '$got2', want '$MARK'" >&2
+    dump_diag "read-p2"
+    exit 1
+fi
+
+echo ">> read marker from $P3"
+got3=$(kubectl exec "$P3" -- cat /data/marker 2>&1 || true)
+if [[ "$got3" != "$MARK" ]]; then
+    echo "FAIL: marker on $P3 mismatch — got '$got3', want '$MARK'" >&2
+    dump_diag "read-p3"
+    exit 1
+fi
+
+# Cross-pod write fan-in: every pod stamps its own file, every pod
+# sees all three files. This catches the regression shape where the
+# first writer holds an exclusive lock on the NFS export and later
+# pods can attach but not write (observed with a stale ganesha-server
+# state-cache).
+echo ">> each Pod writes its own marker, every Pod reads all three"
+kubectl exec "$P2" -- sh -c "echo from-p2-$MARK > /data/marker-p2 && sync"
+kubectl exec "$P3" -- sh -c "echo from-p3-$MARK > /data/marker-p3 && sync"
+for src in "$P1" "$P2" "$P3"; do
+    for tag in "marker" "marker-p2" "marker-p3"; do
+        if ! kubectl exec "$src" -- test -f "/data/$tag"; then
+            echo "FAIL: $src cannot see /data/$tag" >&2
+            dump_diag "fan-in-$src-$tag"
+            exit 1
+        fi
+    done
+done
+
+echo ">> RWX-GANESHA OK (3-way write/read round-trip across $WORKER_1, $WORKER_2, $WORKER_3 via blockstor + linstor-csi external mode)"


### PR DESCRIPTION
## Summary

Convert the `E2E (piraeus interop)` PR pipeline from coexistence mode (piraeus + upstream Java linstor-controller running alongside blockstor) to **external mode** — piraeus-operator drives only linstor-csi and points it at blockstor's apiserver as the LINSTOR backend. The upstream Java controller is not deployed in this job at all.

This matches the real-world deployment shape blockstor targets and exercises blockstor's LINSTOR-compatible REST surface end-to-end through piraeus's CSI provisioning + observability layers.

## Why

The coexistence mode was a transitional fixture (Bugs 305/310/359, shared file-thin pool, host-shared `/etc/drbd.d`). External mode is what cozystack actually ships, so the CI lane should validate that path.

## What changed

- `stand/install-piraeus.sh`: create the `LinstorCluster` CR pre-wired with `spec.externalController.url = https://blockstor-apiserver.blockstor-system.svc:3371` + `spec.apiTLS.certManager.name = blockstor-api-ca`. Mirror the apiserver CA Secret into `piraeus-datastore` and stand up the cert-manager Issuer **before** the LinstorCluster apply (the operator blocks on the Issuer the moment the CR appears). Drop the file-thin piraeus-side storage pool and the upstream `linstor-controller` `kubectl exec` probe — neither exists in external mode.
- `stand/ci-e2e.sh`: refresh the `INSTALL_PIRAEUS=1` comment to document the new ordering contract (blockstor must precede piraeus so the `blockstor-api-ca` Secret exists for the CA mirror). Execution order is unchanged.
- `tests/e2e/observability-three-way.sh` + `tests/e2e/observability-capacity-correlation.sh`: keep `wire_linstor_csi_mtls` as an idempotent no-op guard for legacy stands; drop the `unwire_linstor_csi_mtls` from the capacity-correlation cleanup trap (in external mode unwiring would tear down the only backend linstor-csi has).
- `tests/e2e/rwx-ganesha.sh`: **rewritten** for external mode — uses the always-present `stand` pool, RWX PVC + 3-pod fan-in test with podAntiAffinity, every failure path returns `exit 1` with full diag dump (csi-controller + csi-node logs, describe pvc + pod). No `skip`, no `XFAIL`.
- `stand/run-scenarios-only.sh`: rwx-ganesha is NOT in `SKIP_ALLOWLIST` — the scenario runs honestly.
- `docs/usage.md`: rewrite the \"separate, parallel stack for coexistence testing\" note (stand now matches the prod recommendation); correct `blockstor-controller` Service references to `blockstor-apiserver` in CSI/external-controller context (the legacy alias is documented as backward-compat).
- `.github/workflows/pull-request.yml`: refresh comments for `E2E (piraeus interop)` job + `E2E_EXCLUDE`.

## Known risk

`stand/install-piraeus.sh` in external mode does not deploy the piraeus-side `ganesha-server` (it ships via piraeus Helm pieces that the default LinstorCluster wiring activates). The rewritten `rwx-ganesha.sh` will likely red on the first run, because NodePublishVolume hangs without the NFS exporter. That's the correct CI signal — operators see the gap and a follow-up wires the exporter into the external-mode install path.

## Test plan

- [ ] `E2E (piraeus interop)` job on this PR: observability scenarios pass; rwx-ganesha runs honestly (pass or red with diagnostics).
- [ ] Verify no upstream `linstor-controller` Deployment is rolled out in `piraeus-datastore`.
- [ ] Verify `wire_linstor_csi_mtls` short-circuits with \">> linstor-csi already wired ...\" (no patch issued).
- [ ] Spot-check `linstor-csi-controller` env: `LS_CONTROLLERS=https://blockstor-apiserver.blockstor-system.svc:3371`, mTLS Secret references valid.

## Co-authored

`Co-Authored-By: Claude <noreply@anthropic.com>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guide for blockstor-backed piraeus in external controller mode with TLS certificate setup and linstor-csi integration.

* **Tests**
  * Enhanced RWX functionality validation with improved multi-pod cross-worker verification.
  * Updated E2E test documentation for external-mode deployment scenarios.

* **Chores**
  * Updated installation scripts and CI workflows for external-mode piraeus deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->