### PR TITLE
fix(satellite): observe existing filesystem on reconcile

### DIFF
--- a/pkg/satellite/controllers/filesystem_formatted_stamper.go
+++ b/pkg/satellite/controllers/filesystem_formatted_stamper.go
@@ -57,12 +57,42 @@ type FilesystemFormattedStamper struct {
 }
 
 // StampFilesystemFormatted SSA-patches a `FilesystemFormatted=True`
-// Condition onto Resource <resourceName>.Status.Conditions.
-// Idempotent — SSA's listMap merging on `type` means a repeat
-// patch with the same fields is a no-op at the apiserver level
-// (LastTransitionTime is preserved because the apiserver only
-// updates it when the Condition's Status actually changes).
+// Condition onto Resource <resourceName>.Status.Conditions with
+// Reason="MkfsSucceeded" — i.e. the satellite ran `mkfs.<type>` on
+// every diskful volume itself. Idempotent — SSA's listMap merging
+// on `type` means a repeat patch with the same fields is a no-op at
+// the apiserver level (LastTransitionTime is preserved because the
+// apiserver only updates it when the Condition's Status actually
+// changes).
 func (s *FilesystemFormattedStamper) StampFilesystemFormatted(ctx context.Context, resourceName string) error {
+	return s.stamp(ctx, resourceName, "MkfsSucceeded", "all diskful volumes formatted")
+}
+
+// StampFilesystemObserved SSA-patches the same
+// `FilesystemFormatted=True` Condition but with
+// Reason="FilesystemObserved" — used when the satellite observed an
+// existing filesystem on every diskful volume's DRBD device (via
+// `blkid -o export`) WITHOUT having issued mkfs itself. Common
+// real-world shape: NFS-Ganesha RWX PVCs where mkfs runs from inside
+// the ganesha sidecar pod (not from the satellite), or operator
+// recovery flows that ran `mkfs.<type>` manually on the DRBD device.
+//
+// Without this entry point `needsAutoMkfsRetry` short-circuits only
+// on the Condition / on-disk marker the mkfs path writes, so a
+// resource whose FS appeared externally would loop forever — the
+// observe path stamps the Condition so subsequent reconciles
+// fast-path past auto-mkfs / observer churn.
+func (s *FilesystemFormattedStamper) StampFilesystemObserved(ctx context.Context, resourceName string) error {
+	return s.stamp(ctx, resourceName, "FilesystemObserved",
+		"filesystem detected on every diskful volume (mkfs not run by satellite)")
+}
+
+// stamp is the shared SSA body for the two Reason variants. Same
+// FieldOwner so both entry points layer cleanly under SSA's listMap
+// merge on `type` — the apiserver only flips LastTransitionTime when
+// the Condition's Status actually changes, so a successful mkfs path
+// (MkfsSucceeded) is never overwritten by a later observe pass.
+func (s *FilesystemFormattedStamper) stamp(ctx context.Context, resourceName, reason, message string) error {
 	apply := &blockstoriov1alpha1.Resource{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       resourceKind,
@@ -74,8 +104,8 @@ func (s *FilesystemFormattedStamper) StampFilesystemFormatted(ctx context.Contex
 				{
 					Type:               blockstoriov1alpha1.ConditionFilesystemFormatted,
 					Status:             metav1.ConditionTrue,
-					Reason:             "MkfsSucceeded",
-					Message:            "all diskful volumes formatted",
+					Reason:             reason,
+					Message:            message,
 					LastTransitionTime: metav1.Now(),
 				},
 			},
@@ -91,7 +121,7 @@ func (s *FilesystemFormattedStamper) StampFilesystemFormatted(ctx context.Contex
 		client.Apply, //nolint:staticcheck // SA1019: applyconfiguration-gen output not yet available for our CRDs
 		client.FieldOwner(filesystemFormattedFieldOwner))
 	if err != nil {
-		return errors.Wrapf(err, "ssa FilesystemFormatted Condition on Resource %s", resourceName)
+		return errors.Wrapf(err, "ssa FilesystemFormatted Condition (reason=%s) on Resource %s", reason, resourceName)
 	}
 
 	return nil

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -178,8 +178,26 @@ type FilesystemFormattedStamper interface {
 	// <resourceName>.Status.Conditions. Idempotent — repeat calls
 	// converge on the same Condition shape (LastTransitionTime
 	// moves forward on apiserver-side transition only, not on
-	// every patch).
+	// every patch). Reason="MkfsSucceeded": the satellite ran
+	// `mkfs.<type>` on every diskful volume itself.
 	StampFilesystemFormatted(ctx context.Context, resourceName string) error
+
+	// StampFilesystemObserved SSA-patches the same
+	// `FilesystemFormatted=True` Condition but with
+	// Reason="FilesystemObserved" — used when the filesystem was
+	// detected on the DRBD device WITHOUT the satellite running
+	// mkfs (e.g. an NFS-Ganesha sidecar formatted the device from
+	// inside its own pod, or an operator ran `mkfs.ext4` manually
+	// to recover a volume). The Condition value (True) is the same
+	// as the mkfs-succeeded path — the only difference is the
+	// audit-trail reason / message. Idempotent under SSA's
+	// listMap merge on `type`. Without this entry point the
+	// reconciler's auto-mkfs fast-path never stamps the Condition
+	// for ganesha-shaped RDs (`FileSystem/Type` prop unset on the
+	// RD because ganesha owns mkfs), and `needsAutoMkfsRetry` /
+	// observers retrigger reconciles forever (`~28 RV updates/sec
+	// per Resource` measured on the cli-matrix RWX scenario).
+	StampFilesystemObserved(ctx context.Context, resourceName string) error
 }
 
 // SkipDiskClearer abstracts the "release the satellite's SSA claim
@@ -2193,74 +2211,237 @@ func (r *Reconciler) finishDRBDApply(ctx context.Context, dr *intent.DesiredReso
 	autoPromote := firstActivation && autoPrimaryReplica
 	_ = cloned
 
-	if autoPromote && !r.shouldForcePromote(ctx, dr) {
-		// Bug 342 force-promote gate fired: a data-bearing peer exists,
-		// so SKIP `drbdadm primary --force`. The fresh replica stays
-		// Inconsistent and SyncTargets from the peer (full resync,
-		// data-safe). Returning here also skips the mkfs-retry below —
-		// correct, since the replica adopts the peer's filesystem via
-		// the resync rather than formatting locally.
+	skip, err := r.runAutoPrimarySeed(ctx, dr, autoPromote, autoPrimaryReplica)
+	if err != nil {
+		return err
+	}
+
+	if skip {
 		return nil
 	}
 
-	// Reaching UpToDate no longer depends on this promote. The elected
-	// winner already declared itself Consistent+UpToDate via the
-	// `drbdmeta set-gi` seed (seedInitialGI's case-B winner slot), so
-	// the kernel comes up UpToDate from metadata alone. `primary
-	// --force` is now PURELY an mkfs concern: we promote only when the
-	// RD requests a filesystem (and quorum may not be satisfiable yet
-	// because peers haven't connected), run mkfs, then demote
-	// immediately. When no filesystem is requested we skip the promote
-	// entirely — which is exactly what avoids the old bug, where
-	// `primary --force` minted a fresh current-UUID that diverged from
-	// the day0 bitmap-base the peers carry, flipping them to SyncTarget
-	// for a full initial sync even on empty thin/ZFS volumes.
-	if autoPromote && needsMkfs(dr) {
-		err := r.runAutoPromote(ctx, dr)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Bug 311: the auto-mkfs path used to live ONLY inside
-	// runAutoPromote (above), wedged between `drbdadm primary --force`
-	// and `drbdadm secondary`. That coupling meant any transient
-	// failure in the promote/demote dance — primary --force racing the
-	// initial-sync handshake, secondary racing an in-flight Open —
-	// left `.mkfs.done` unwritten while `.md-created` persisted, so the
-	// next reconcile saw firstActivation=false, skipped the whole
-	// auto-promote branch, and mkfs never ran again. piraeus' NFS-
-	// ganesha multi-volume RD (RWX PVC, two VDs, `FileSystem/Type=ext4`
-	// on the RD) reproduced this every time: the resource bound but
-	// `/dev/drbd/by-res/<pvc>/1` had no filesystem and ganesha's
-	// `mount-recovery@<pvc>.service` failed with `fsck.ext2: Bad magic
-	// number in super-block`.
-	//
-	// The retry path runs ONLY when firstActivation has already
-	// happened (so we never double-promote a healthy fresh replica)
-	// AND the `.mkfs.done` marker is still missing AND the RD asks
-	// for a filesystem. It re-enters runAutoPromote which is
-	// idempotent: primary --force on an already-Primary slot is a
-	// kernel no-op, `runAutoMkfs` blkid-probes each device and skips
-	// volumes that already carry a filesystem, and `secondary`
-	// matches the regular post-mkfs demote. Once every diskful
-	// volume passes the blkid probe (either freshly-mkfs'd here or
-	// already populated from a previous attempt), runAutoMkfs writes
-	// the marker and this branch becomes a no-op for the rest of the
-	// resource's life.
-	if !autoPromote && autoPrimaryReplica && r.needsAutoMkfsRetry(dr) {
-		err := r.runAutoPromote(ctx, dr)
-		if err != nil {
-			return err
-		}
+	// Observe-existing-filesystem: stamp `FilesystemFormatted=True`
+	// when blkid sees a filesystem on every diskful volume but
+	// runAutoMkfs never wrote the Condition (it can't — its only
+	// trigger is `FileSystem/Type` on the RD). NFS-Ganesha RWX PVCs
+	// land here: ganesha mkfs's the device from inside its sidecar
+	// pod, the satellite never owns the format step, the Condition
+	// never lands, and `needsAutoMkfsRetry` together with the
+	// observer keeps re-driving reconciles forever (~28 RV
+	// updates/sec/Resource measured on the cli-matrix RWX cell). The
+	// stamp short-circuits that loop without touching the device.
+	// Idempotent: re-runs cheap-stat the Condition cache before any
+	// shell-out and bail when the Condition is already True.
+	err = r.observeExistingFilesystem(ctx, dr, diskless)
+	if err != nil {
+		return err
 	}
 
 	// Bug 366 recovery-promote self-heal — re-arm the auto-primary seed
 	// when a fresh RD wedged with the late replica stuck Inconsistent and
 	// no Primary anywhere. See maybeRecoveryPromote for the full why.
-	err := r.maybeRecoveryPromote(ctx, dr, autoPromote, autoPrimaryReplica)
+	err = r.maybeRecoveryPromote(ctx, dr, autoPromote, autoPrimaryReplica)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// runAutoPrimarySeed runs the auto-primary seed dance — the
+// `drbdadm primary --force` → mkfs → `secondary` chain — on a fresh
+// replica AND the Bug 311 retry path on a steady-state replica.
+// Extracted from `finishDRBDApply` so the orchestrator stays under
+// the gocyclo budget.
+//
+// Returns (skip=true, nil) when the Bug 342 force-promote gate
+// fired: a data-bearing peer already exists, so the fresh replica
+// must SyncTarget from it instead of promoting itself. The caller
+// MUST return early in that case — the mkfs-retry below is also
+// suppressed (the replica adopts the peer's filesystem via the
+// resync rather than formatting locally), and the observe-existing
+// + recovery-promote helpers run only on a non-skip path.
+//
+// Returns (skip=false, err) on a real promote failure. (skip=false,
+// nil) on the steady-state path (whether or not retry fired) so the
+// caller continues with the observe-existing-filesystem + Bug 366
+// recovery-promote helpers.
+func (r *Reconciler) runAutoPrimarySeed(ctx context.Context, dr *intent.DesiredResource, autoPromote, autoPrimaryReplica bool) (bool, error) {
+	if autoPromote && !r.shouldForcePromote(ctx, dr) {
+		// Bug 342 force-promote gate fired: a data-bearing peer
+		// exists, so SKIP `drbdadm primary --force`. The fresh
+		// replica stays Inconsistent and SyncTargets from the peer
+		// (full resync, data-safe). Returning skip=true also bails
+		// out the mkfs-retry below — correct, since the replica
+		// adopts the peer's filesystem via the resync rather than
+		// formatting locally.
+		return true, nil
+	}
+
+	// Reaching UpToDate no longer depends on this promote. The
+	// elected winner already declared itself Consistent+UpToDate
+	// via the `drbdmeta set-gi` seed (seedInitialGI's case-B winner
+	// slot), so the kernel comes up UpToDate from metadata alone.
+	// `primary --force` is now PURELY an mkfs concern: we promote
+	// only when the RD requests a filesystem (and quorum may not be
+	// satisfiable yet because peers haven't connected), run mkfs,
+	// then demote immediately. When no filesystem is requested we
+	// skip the promote entirely — which is exactly what avoids the
+	// old bug, where `primary --force` minted a fresh current-UUID
+	// that diverged from the day0 bitmap-base the peers carry,
+	// flipping them to SyncTarget for a full initial sync even on
+	// empty thin/ZFS volumes.
+	if autoPromote && needsMkfs(dr) {
+		err := r.runAutoPromote(ctx, dr)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// Bug 311: the auto-mkfs path used to live ONLY inside
+	// runAutoPromote (above), wedged between `drbdadm primary
+	// --force` and `drbdadm secondary`. That coupling meant any
+	// transient failure in the promote/demote dance — primary
+	// --force racing the initial-sync handshake, secondary racing
+	// an in-flight Open — left `.mkfs.done` unwritten while
+	// `.md-created` persisted, so the next reconcile saw
+	// firstActivation=false, skipped the whole auto-promote
+	// branch, and mkfs never ran again. piraeus' NFS-ganesha
+	// multi-volume RD (RWX PVC, two VDs, `FileSystem/Type=ext4` on
+	// the RD) reproduced this every time: the resource bound but
+	// `/dev/drbd/by-res/<pvc>/1` had no filesystem and ganesha's
+	// `mount-recovery@<pvc>.service` failed with `fsck.ext2: Bad
+	// magic number in super-block`.
+	//
+	// The retry path runs ONLY when firstActivation has already
+	// happened (so we never double-promote a healthy fresh
+	// replica) AND the `.mkfs.done` marker is still missing AND
+	// the RD asks for a filesystem. It re-enters runAutoPromote
+	// which is idempotent: primary --force on an already-Primary
+	// slot is a kernel no-op, `runAutoMkfs` blkid-probes each
+	// device and skips volumes that already carry a filesystem,
+	// and `secondary` matches the regular post-mkfs demote. Once
+	// every diskful volume passes the blkid probe (either
+	// freshly-mkfs'd here or already populated from a previous
+	// attempt), runAutoMkfs writes the marker and this branch
+	// becomes a no-op for the rest of the resource's life.
+	if !autoPromote && autoPrimaryReplica && r.needsAutoMkfsRetry(dr) {
+		err := r.runAutoPromote(ctx, dr)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+// observeExistingFilesystem stamps the `FilesystemFormatted=True`
+// Status Condition (with Reason="FilesystemObserved") when every
+// diskful volume of `dr` already carries a recognised filesystem
+// signature on its DRBD device, but the satellite never ran mkfs
+// itself.
+//
+// Motivation — closes the hot-reconcile loop on volumes whose
+// filesystem was created OUTSIDE the satellite's auto-mkfs path:
+//
+//   - NFS-Ganesha RWX PVCs: linstor-csi runs mkfs inside the
+//     ganesha-server sidecar pod, not via the RG
+//     `FileSystem/Type` prop, so `runAutoMkfs` early-returns and
+//     the Condition is never stamped.
+//   - Operator-recovery flows: someone ran `mkfs.ext4 -F /dev/drbdN`
+//     manually from within the satellite container (or via
+//     `talosctl`) to revive a stuck volume. Same shape: the
+//     satellite never observes the format step.
+//
+// On the stand (`ssh ubuntu@150.136.95.115`,
+// pvc-d966dcf3-fdde-4fb6-bc2b-d7a24e5be3e3) the missing Condition
+// left `KernelLoaded.LastTransitionTime` being SSA-rewritten by the
+// observer on every events2 frame; combined with the reconciler
+// reading `Conditions` and re-emitting Status, the Resource churned
+// ~28 RV updates/sec per node with no user-data activity.
+//
+// Idempotency layers:
+//
+//   - Condition fast path: skip outright when the parent Resource
+//     already carries `FilesystemFormatted=True` in
+//     `dr.GetFilesystemFormatted()` — no shell-out, no SSA write.
+//   - blkid probe: read-only, matches `runAutoMkfs`'s probe shape
+//     so the FakeExec contract pins the same `blkid -o export
+//     /dev/drbd<N>` line in tests.
+//   - Stamp failure tolerated: best-effort like the other Phase
+//     11.3 stamps. A transient apiserver hiccup defers stamping to
+//     the next reconcile; nothing on disk changed.
+//
+// Skip conditions (early return, no shell-out):
+//
+//   - Diskless replica: no local device → blkid would fail; the
+//     diskful peers stamp the Condition.
+//   - No FilesystemFormattedStamper wired: unit tests that don't
+//     mock the apiserver path. The reconciler still produces
+//     correct behaviour without the Condition cache; only the
+//     fast-path optimisation is disabled.
+//   - No Exec wrapper: same shape — unit tests that disable shell
+//     dispatch. blkid can't run without one.
+//   - No volumes: empty Volumes list → nothing to probe; treat as
+//     "not eligible".
+//   - The Condition is already True on the parent Resource.
+//
+// On a populated, diskful resource the probe issues at most one
+// `blkid -o export` per volume per reconcile pass; once the
+// Condition lands the fast path bails on a single map lookup.
+func (r *Reconciler) observeExistingFilesystem(ctx context.Context, dr *intent.DesiredResource, diskless bool) error {
+	if diskless {
+		return nil
+	}
+
+	if r.cfg.FilesystemFormattedStamper == nil || r.cfg.Exec == nil {
+		return nil
+	}
+
+	if dr.GetFilesystemFormatted() {
+		return nil
+	}
+
+	vols := dr.GetVolumes()
+	if len(vols) == 0 {
+		return nil
+	}
+
+	// FileSystem/Type set: the auto-mkfs path owns the Condition
+	// stamp on this RD. Skip to avoid a redundant SSA write and to
+	// keep the audit-trail reason accurate (MkfsSucceeded comes from
+	// runAutoMkfs, FilesystemObserved comes from here). If
+	// runAutoMkfs is mid-failure and `.mkfs.done` is absent, we
+	// MUST NOT stamp the Condition either — that would defeat the
+	// Bug 311 retry gate. The auto-mkfs path is the single source of
+	// truth when FileSystem/Type is set.
+	if strings.TrimSpace(dr.GetProps()["FileSystem/Type"]) != "" {
+		return nil
+	}
+
+	minor, _ := strconv.Atoi(dr.GetDrbdOptions()["minor"])
+
+	for _, vol := range vols {
+		device := fmt.Sprintf("/dev/drbd%d", volMinorOrBase(vol, minor))
+		if !r.deviceHasFilesystem(ctx, device) {
+			// At least one volume is still empty — stamping the
+			// Condition now would falsely advertise the RD as fully
+			// formatted. Wait for the external mkfs (ganesha sidecar,
+			// operator) to finish the remaining volumes.
+			return nil
+		}
+	}
+
+	// Every diskful volume carries a filesystem. Stamp the
+	// Condition with the observed-reason so subsequent reconciles
+	// short-circuit. Best-effort: a transient apiserver error
+	// defers the stamp to the next pass, nothing else moves.
+	resourceCRDName := dr.GetName() + "." + dr.GetNodeName()
+
+	stampErr := r.cfg.FilesystemFormattedStamper.StampFilesystemObserved(ctx, resourceCRDName)
+	if stampErr != nil {
+		log.FromContext(ctx).Error(stampErr, "stamp observed FilesystemFormatted Condition; will retry next reconcile",
+			"resource", resourceCRDName)
 	}
 
 	return nil

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -6423,15 +6423,23 @@ func TestApplyFallsBackToUpOnAdjust158(t *testing.T) {
 	}
 }
 
-// fakeFilesystemStamper records every StampFilesystemFormatted call
-// so multi-volume mkfs tests can assert the Condition lands exactly
-// when every diskful volume of the RD has reached a filesystem
-// (freshly mkfs'd or adopted via blkid). Concurrency-safe to match
-// fakeMetadataStamper's contract.
+// fakeFilesystemStamper records every StampFilesystemFormatted /
+// StampFilesystemObserved call so multi-volume mkfs tests can assert
+// the Condition lands exactly when every diskful volume of the RD has
+// reached a filesystem (freshly mkfs'd or adopted via blkid; or
+// observed externally without satellite-driven mkfs). Concurrency-safe
+// to match fakeMetadataStamper's contract.
+//
+// `calls` holds only the StampFilesystemFormatted (Reason=MkfsSucceeded)
+// invocations so existing Bug 311 tests stay green; observed (Reason=
+// FilesystemObserved) invocations are recorded under `observedCalls`
+// so the observe-existing-fs path can be pinned independently.
 type fakeFilesystemStamper struct {
-	mu     sync.Mutex
-	calls  []string
-	stamps func(string) bool // optional: return true to fail the call
+	mu             sync.Mutex
+	calls          []string
+	observedCalls  []string
+	stamps         func(string) bool // optional: return true to fail the formatted call
+	observedStamps func(string) bool // optional: return true to fail the observed call
 }
 
 func (f *fakeFilesystemStamper) StampFilesystemFormatted(_ context.Context, resourceName string) error {
@@ -6447,12 +6455,35 @@ func (f *fakeFilesystemStamper) StampFilesystemFormatted(_ context.Context, reso
 	return nil
 }
 
+func (f *fakeFilesystemStamper) StampFilesystemObserved(_ context.Context, resourceName string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.observedCalls = append(f.observedCalls, resourceName)
+
+	if f.observedStamps != nil && f.observedStamps(resourceName) {
+		return os.ErrPermission
+	}
+
+	return nil
+}
+
 func (f *fakeFilesystemStamper) Calls() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
 	out := make([]string, len(f.calls))
 	copy(out, f.calls)
+
+	return out
+}
+
+func (f *fakeFilesystemStamper) ObservedCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]string, len(f.observedCalls))
+	copy(out, f.observedCalls)
 
 	return out
 }
@@ -6961,5 +6992,312 @@ func TestBug278NoClearWhenKernelStillDiskless(t *testing.T) {
 	// the attach the observer just detached for.
 	if calls := clearer.Calls(); len(calls) != 0 {
 		t.Errorf("expected NO ClearSkipDisk calls when kernel is still Diskless; got %v", calls)
+	}
+}
+
+// TestApplyObserveExistingFilesystemStampsCondition pins the
+// observe-existing-filesystem path: when blkid -o export reports a
+// recognised filesystem on every diskful volume of a Resource whose
+// RD has NO `FileSystem/Type` prop (typical NFS-Ganesha RWX shape:
+// mkfs runs inside the ganesha sidecar pod, not via the RG), the
+// satellite MUST stamp `FilesystemFormatted=True` with
+// Reason=FilesystemObserved so subsequent reconciles short-circuit
+// past the auto-mkfs gate. Without this stamp the resource churns
+// at ~28 RV updates/sec (cli-matrix RWX cell measurement).
+//
+// Companion contract: NO mkfs.* command line is emitted — the
+// observe path is read-only.
+func TestApplyObserveExistingFilesystemStampsCondition(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-observefs_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	// blkid sees ext4 on the device — mimics a ganesha-sidecar mkfs
+	// or an operator-recovery `mkfs.ext4 -F /dev/drbd20000` run from
+	// the satellite pod. Same shape as the existing Bug 311 blkid
+	// fixture (TestApplyAutoMkfsBlkidProbeSkipsPopulatedVolume).
+	fx.Expect("blkid -o export /dev/drbd20000",
+		storage.FakeResponse{Stdout: []byte("DEVNAME=/dev/drbd20000\nTYPE=ext4\nUSAGE=filesystem\n")})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	stamper := &fakeFilesystemStamper{}
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:                  map[string]storage.Provider{"thin1": thin},
+		Adm:                        drbd.NewAdm(fx),
+		Exec:                       fx,
+		StateDir:                   dir,
+		NodeName:                   "n1",
+		FilesystemFormattedStamper: stamper,
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-observefs",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			// No FileSystem/Type prop — ganesha owns the format step.
+			SkipInitialSync: skipInitTrue(),
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "20000",
+				"auto-primary": "true",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// No mkfs.* invocations — observe is read-only.
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "mkfs.") || strings.Contains(line, " mkfs.") {
+			t.Errorf("observe path must NOT run mkfs; saw %q in %v", line, fx.CommandLines())
+		}
+	}
+
+	// Exactly one StampFilesystemObserved call — the resource name
+	// is `<rd>.<node>` per the Phase 11.3 Stage 2 stamp contract.
+	if got := stamper.ObservedCalls(); len(got) != 1 || got[0] != "pvc-observefs.n1" {
+		t.Errorf("StampFilesystemObserved: want exactly one call for pvc-observefs.n1; got %v", got)
+	}
+
+	// And the mkfs-succeeded path MUST NOT fire — that reason is
+	// reserved for the satellite-driven runAutoMkfs path.
+	if got := stamper.Calls(); len(got) != 0 {
+		t.Errorf("StampFilesystemFormatted (MkfsSucceeded) must not fire on the observe path; got %v", got)
+	}
+}
+
+// TestApplyObserveExistingFilesystemSkipsWhenNoFS pins the inverse:
+// blkid returns empty (no TYPE= line) → no filesystem present yet →
+// observe path MUST NOT stamp the Condition. Otherwise a half-
+// initialised RWX PVC (ganesha still pending mkfs inside its
+// sidecar) would falsely advertise itself as formatted and the
+// CSI/ganesha layer would mount it raw.
+func TestApplyObserveExistingFilesystemSkipsWhenNoFS(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-observefs-empty_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	// blkid response left unregistered → FakeExec returns empty
+	// stdout / nil err → deviceHasFilesystem reports false.
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	stamper := &fakeFilesystemStamper{}
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:                  map[string]storage.Provider{"thin1": thin},
+		Adm:                        drbd.NewAdm(fx),
+		Exec:                       fx,
+		StateDir:                   dir,
+		NodeName:                   "n1",
+		FilesystemFormattedStamper: stamper,
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-observefs-empty",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			SkipInitialSync: skipInitTrue(),
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "20100",
+				"auto-primary": "true",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if got := stamper.ObservedCalls(); len(got) != 0 {
+		t.Errorf("StampFilesystemObserved must not fire when blkid finds no FS; got %v", got)
+	}
+
+	if got := stamper.Calls(); len(got) != 0 {
+		t.Errorf("StampFilesystemFormatted must not fire when blkid finds no FS; got %v", got)
+	}
+}
+
+// TestApplyObserveExistingFilesystemMultiVolumePartialSkips pins
+// the "stamp only after ALL volumes carry a filesystem" contract
+// for the multi-volume NFS-Ganesha shape: vol-0 already has ext4,
+// vol-1 is still blank. Stamping `FilesystemFormatted=True` now
+// would falsely advertise vol-1 as formatted and break ganesha's
+// `mount-recovery@<pvc>.service` (the same shape Bug 311 closed for
+// the auto-mkfs path).
+func TestApplyObserveExistingFilesystemMultiVolumePartialSkips(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-observefs-multi_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-observefs-multi_00001",
+		storage.FakeResponse{Stdout: []byte("")})
+	// vol-0 has ext4, vol-1 is unregistered → blkid returns empty.
+	fx.Expect("blkid -o export /dev/drbd20200",
+		storage.FakeResponse{Stdout: []byte("DEVNAME=/dev/drbd20200\nTYPE=ext4\nUSAGE=filesystem\n")})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	stamper := &fakeFilesystemStamper{}
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:                  map[string]storage.Provider{"thin1": thin},
+		Adm:                        drbd.NewAdm(fx),
+		Exec:                       fx,
+		StateDir:                   dir,
+		NodeName:                   "n1",
+		FilesystemFormattedStamper: stamper,
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-observefs-multi",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 131072, StoragePool: "thin1"},
+				{VolumeNumber: 1, SizeKib: 307200, StoragePool: "thin1"},
+			},
+			SkipInitialSync: skipInitTrue(),
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "20200",
+				"auto-primary": "true",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if got := stamper.ObservedCalls(); len(got) != 0 {
+		t.Errorf("partial-FS multi-volume RD MUST NOT stamp observed; got %v", got)
+	}
+}
+
+// TestApplyObserveExistingFilesystemSkipsWhenFileSystemTypeSet
+// pins the "owner separation" contract: when the RD carries the
+// `FileSystem/Type` prop the auto-mkfs path owns the Condition
+// stamp (Reason=MkfsSucceeded). The observe path MUST early-return
+// without calling blkid, so the audit-trail reason stays accurate
+// and Bug 311's retry gate is not bypassed.
+func TestApplyObserveExistingFilesystemSkipsWhenFileSystemTypeSet(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-observefs-owned_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	// blkid would mark /dev/drbd20300 populated — but with
+	// FileSystem/Type set the observe path must not invoke it at
+	// all. Register the response anyway: a regression that calls
+	// blkid would consume this expectation and the assertion below
+	// would have to grow; with the early-return contract the
+	// command count for blkid stays 0.
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	stamper := &fakeFilesystemStamper{}
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:                  map[string]storage.Provider{"thin1": thin},
+		Adm:                        drbd.NewAdm(fx),
+		Exec:                       fx,
+		StateDir:                   dir,
+		NodeName:                   "n1",
+		FilesystemFormattedStamper: stamper,
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-observefs-owned",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			Props: map[string]string{
+				"FileSystem/Type": "ext4",
+			},
+			SkipInitialSync: skipInitTrue(),
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "20300",
+				"auto-primary": "true",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// The auto-mkfs path owns the Condition stamp here. The
+	// observe path's StampFilesystemObserved MUST NOT fire.
+	if got := stamper.ObservedCalls(); len(got) != 0 {
+		t.Errorf("FileSystem/Type set → observe path must early-return; got observed calls %v", got)
+	}
+
+	// No `blkid -o export /dev/drbd20300` line from the observe
+	// path. (runAutoMkfs may still call it as part of its own
+	// per-volume probe — assert via prefix-count that it landed
+	// at most once.)
+	blkidLines := 0
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "blkid -o export /dev/drbd20300") {
+			blkidLines++
+		}
+	}
+
+	if blkidLines > 1 {
+		t.Errorf("observe path must not double-blkid /dev/drbd20300; got %d lines in %v",
+			blkidLines, fx.CommandLines())
+	}
+}
+
+// TestApplyObserveExistingFilesystemSkipsWhenConditionAlready pins
+// the fast-path optimisation: when the parent Resource already
+// carries `FilesystemFormatted=True` (the dispatcher folded the
+// Condition into DesiredResource.FilesystemFormatted), the observe
+// path MUST early-return without calling blkid or the stamper.
+// Stops a hot stamper call on every reconcile pass even after the
+// Condition has landed.
+func TestApplyObserveExistingFilesystemSkipsWhenConditionAlready(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-observefs-cached_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	stamper := &fakeFilesystemStamper{}
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:                  map[string]storage.Provider{"thin1": thin},
+		Adm:                        drbd.NewAdm(fx),
+		Exec:                       fx,
+		StateDir:                   dir,
+		NodeName:                   "n1",
+		FilesystemFormattedStamper: stamper,
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:                "pvc-observefs-cached",
+			NodeName:            "n1",
+			FilesystemFormatted: true,
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			SkipInitialSync: skipInitTrue(),
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "20400",
+				"auto-primary": "true",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "blkid ") {
+			t.Errorf("cached Condition → no blkid expected; saw %q in %v", line, fx.CommandLines())
+		}
+	}
+
+	if got := stamper.ObservedCalls(); len(got) != 0 {
+		t.Errorf("cached Condition → StampFilesystemObserved must not fire; got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes a hot reconcile loop on Resources whose DRBD device already
carries a filesystem the satellite never formatted itself —
typical shapes are NFS-Ganesha RWX PVCs (mkfs runs inside the
ganesha-server sidecar pod) and operator-recovery flows
(`mkfs.ext4 -F /dev/drbdN` invoked manually from the satellite
container or via `talosctl`). Without this fix
`FilesystemFormatted=True` is never stamped, so
`needsAutoMkfsRetry` together with the events2-driven observer
keeps re-driving Resource Status SSA writes forever.

Measured on the cli-matrix RWX cell (PVC
`pvc-d966dcf3-fdde-4fb6-bc2b-d7a24e5be3e3`, all 3 workers
UpToDate / Unused): `ResourceVersion` advanced by ~285 per 10s
per node, i.e. ~28 RV updates/sec/Resource, with
`KernelLoaded.LastTransitionTime` rewriting itself every
reconcile and `FilesystemFormatted` never landing.

## Why

`runAutoMkfs` only stamps `FilesystemFormatted=True` after it
finishes its own per-volume mkfs loop, which itself only fires
when `FileSystem/Type` is set on the RD. ganesha-shaped RWX RDs
deliberately leave that prop unset (the sidecar owns the format
step), so the Condition is structurally unreachable on that path.
Once the Condition is missing the dispatcher folds
`FilesystemFormatted=false` into every `DesiredResource`, the
reconciler re-evaluates the auto-mkfs gate on every pass, and the
observer SSA-stamps `KernelLoaded` on every events2 frame, which
the apiserver rolls into a Status update, which triggers the next
reconcile. Steady-state churn at ~28 Hz with zero user activity.

## What changed

- New `observeExistingFilesystem` helper in
  `pkg/satellite/reconciler.go` runs after the auto-primary seed
  on diskful replicas. Probes every volume's DRBD device with
  `blkid -o export`; when every volume reports a recognised
  filesystem signature it SSA-stamps
  `FilesystemFormatted=True` with `Reason=FilesystemObserved`,
  `Message="filesystem detected on every diskful volume (mkfs
  not run by satellite)"`.
- Extended the `FilesystemFormattedStamper` interface with a
  parallel `StampFilesystemObserved` entry point — distinct
  `Reason` so the audit trail differentiates satellite-driven
  mkfs from externally-created filesystems while sharing the
  same SSA `FieldOwner` and listMap merge semantics.
- Extracted the auto-primary seed dance into
  `runAutoPrimarySeed` so `finishDRBDApply` stays under the
  gocyclo budget after the new helper landed. No behaviour
  change in that extraction.

Idempotency guards (in order, all read-only / no shell-out
unless every prior gate is passed):

1. Diskless replica → skip (no local device).
2. Stamper / Exec wrapper missing → skip (unit-test shape).
3. `dr.GetFilesystemFormatted()` already True → skip.
4. RD has `FileSystem/Type` set → skip (auto-mkfs owns the
   stamp under `Reason=MkfsSucceeded`; avoids double-write and
   keeps Bug 311's retry gate intact).
5. Any volume's `blkid -o export` returns no `TYPE=` line →
   skip (partial-FS RDs MUST NOT advertise themselves
   formatted; would falsely converge a half-initialised RWX
   PVC).

## Test plan

- `go test ./pkg/satellite/... ./pkg/drbd/... ./pkg/storage/...`
  passes.
- `make lint` reports 0 issues.
- Five new FakeExec-driven unit tests pin the observe path:
  single-volume happy path, no-FS short-circuit, multi-volume
  partial skip, `FileSystem/Type`-owns-stamp early-return,
  cached-Condition fast path.
- Live verify on the stand
  (`ssh ubuntu@150.136.95.115`,
  `pvc-d966dcf3-fdde-4fb6-bc2b-d7a24e5be3e3`) manually after
  merge: expected outcome is `FilesystemFormatted=True` lands
  with `Reason=FilesystemObserved` and the
  `ResourceVersion`-per-second rate drops to a low single digit.

## Related

- Regression-like of Bug 311 (auto-mkfs retry gate) — same
  Condition, same RWX-ganesha shape, but the externally-created
  filesystem case the Bug 311 fix never covered.
- Phase 11.3 Stage 2 missing observe handler: the
  `FilesystemFormatted` Condition was wired into the
  reconciler's fast path but never grew an observe path for
  filesystems the satellite did not create itself.