### PR TITLE
fix(e2e): strict inter-test cleanup + pre-flight check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,8 @@ make e2e NAME=alice SCENARIO=luks-layer
 
 Scenarios live under `tests/e2e/` and each takes a `WORK_DIR` argument.
 
+New scenarios SHOULD register their cleanup via `register_strict_cleanup` from `tests/e2e/lib.sh` instead of a bare `trap 'delete_rd X' EXIT`. The strict helper deletes the named RDs, waits for any Terminating satellite pods to actually go away (with `kubectl delete --grace-period=0 --force` as a fallback), and verifies the cluster is back to the baseline (0 orphan RDs, 3 Running satellite pods, none Terminating). If the cluster cannot be drained, a passing scenario is demoted to FAIL — preventing the next scenario from inheriting a dirty cluster and being misblamed by `require_workers`. Existing bare-trap scenarios keep working (the harness still runs `reset_cluster_state` between scenarios, and the lane runner's pre-flight check rewrites the previous scenario's PASS to `FAIL <prev> (LEFTOVER: ...)` if the cluster is dirty).
+
 ## Tests
 
 `go test ./...` runs the unit suite (the envtest-backed integration tests skip

--- a/stand/run-scenarios-only.sh
+++ b/stand/run-scenarios-only.sh
@@ -74,6 +74,67 @@ reset_between_scenarios() {
     ( set +e; source "$LIB"; reset_cluster_state 120 ) >> "$RESULTS" 2>&1 || true
 }
 
+# preflight_check polls the cluster until it is back to the baseline
+# state the next scenario expects:
+#   - exactly 3 satellite pods, all in phase=Running, none Terminating
+#     (DeletionTimestamp must be unset — kubelet/containerd can keep a
+#     pod in "Running" + DeletionTimestamp for tens of minutes)
+#   - no ResourceDefinition CRDs (zero orphan RDs across all namespaces)
+#
+# On success: echo "preflight: clean" to $RESULTS, return 0.
+# On timeout: echo a single-line "LEFTOVER: ..." summary to stdout AND
+# set NS=$NS NS-local "$PREFLIGHT_REASON" via a temp file. The caller
+# decides who to blame (previous scenario vs harness setup).
+#
+# Why up to 60s: reset_between_scenarios already runs cleanup, but the
+# kernel-side teardown (drbdsetup down + udev settle) can lag a few
+# seconds even after delete_all_rds() returns. 60s is the same envelope
+# require_workers() uses when probing pod readiness.
+PREFLIGHT_REASON_FILE=/tmp/e2e-$NAME.preflight-reason
+preflight_check() {
+    local deadline=$(( $(date +%s) + 60 ))
+    local reason=""
+    while (( $(date +%s) < deadline )); do
+        # Satellite pod state: count Running + count Terminating.
+        local total running terminating
+        total=$(kubectl --request-timeout=3s -n blockstor-system \
+            get pods -l app=blockstor-satellite --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        running=$(kubectl --request-timeout=3s -n blockstor-system \
+            get pods -l app=blockstor-satellite \
+            -o 'jsonpath={range .items[?(@.status.phase=="Running")]}{.metadata.name} {end}' \
+            2>/dev/null | wc -w | tr -d ' ')
+        terminating=$(kubectl --request-timeout=3s -n blockstor-system \
+            get pods -l app=blockstor-satellite \
+            -o 'jsonpath={range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name} {end}' \
+            2>/dev/null | wc -w | tr -d ' ')
+
+        # Orphan RD CRDs across all namespaces.
+        local rd_count
+        rd_count=$(kubectl --request-timeout=3s get resourcedefinitions.blockstor.cozystack.io \
+            -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+
+        if [ "$total" = "3" ] && [ "$running" = "3" ] && [ "$terminating" = "0" ] && [ "$rd_count" = "0" ]; then
+            echo "preflight: clean (running=3 terminating=0 rd_count=0)" >> "$RESULTS"
+            : > "$PREFLIGHT_REASON_FILE"
+            return 0
+        fi
+
+        reason="running=${running}/${total} terminating=${terminating} rd_count=${rd_count}"
+        sleep 2
+    done
+
+    # Final snapshot for the LEFTOVER message — include pod-by-pod state
+    # so the responsible scenario is obvious in the log.
+    {
+        echo "preflight: NOT clean after 60s — ${reason}"
+        kubectl --request-timeout=3s -n blockstor-system get pods -l app=blockstor-satellite \
+            -o wide 2>/dev/null || true
+        kubectl --request-timeout=3s get resourcedefinitions.blockstor.cozystack.io -A 2>/dev/null || true
+    } >> "$RESULTS"
+    echo "$reason" > "$PREFLIGHT_REASON_FILE"
+    return 1
+}
+
 # Scenarios ALLOWED to emit the SKIP sentinel (tests/e2e/lib.sh skip()).
 # These are environment-gated cases that cannot run on the Talos+QEMU CI
 # substrate and are deliberately observational:
@@ -91,6 +152,7 @@ SKIP_ALLOWLIST="backing-device-fail storage-error-injection quorum-loss-recovery
 
 scenario_count=${#SCENARIOS[@]}
 scenario_idx=0
+prev_sc=""
 for sc in "${SCENARIOS[@]}"; do
     scenario_idx=$((scenario_idx + 1))
     # L6 cli-matrix cells are referenced as `cli-matrix/<cell>` so
@@ -100,6 +162,48 @@ for sc in "${SCENARIOS[@]}"; do
     # (parent dir doesn't exist), so sanitize for the log name only.
     sc_log=${sc//\//__}
     logf=/tmp/e2e-$NAME-$sc_log.log
+
+    # Pre-flight: cluster must be back to the baseline before launching
+    # the next scenario, otherwise blame the LEFTOVER on the previous
+    # scenario (it had its chance via reset_between_scenarios) — not on
+    # the upcoming one, which would otherwise get "scenario needs 3
+    # Ready satellite pods, found 2 (previous-test cascade)" and look
+    # like a flake (Bug 298 cascade-misattribution pattern).
+    #
+    # First scenario of the lane is special: no `prev_sc` to blame, and
+    # a stand that fails pre-flight on its first scenario is a harness
+    # setup bug — fail FATAL so it's visible immediately.
+    if ! preflight_check; then
+        reason=$(cat "$PREFLIGHT_REASON_FILE" 2>/dev/null || echo "unknown")
+        if [ -n "$prev_sc" ]; then
+            # Rewrite the previous scenario's verdict line in $RESULTS.
+            # Match either PASS / SKIP / TIMEOUT — only "PASS $prev_sc"
+            # gets demoted (a FAIL prev_sc is already correctly blamed,
+            # a SKIP/TIMEOUT line is also better left intact). Use a
+            # python rewrite to keep awk-portable across stand busybox.
+            python3 - "$RESULTS" "$prev_sc" "$reason" <<'PY' || true
+import sys
+path, prev_sc, reason = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    lines = f.readlines()
+rewritten = False
+for i, ln in enumerate(lines):
+    if ln.startswith(f"PASS {prev_sc}\n"):
+        lines[i] = f"FAIL {prev_sc} (LEFTOVER: {reason})\n"
+        rewritten = True
+        break
+if rewritten:
+    with open(path, "w") as f:
+        f.writelines(lines)
+PY
+            echo "preflight: blamed LEFTOVER on previous scenario '$prev_sc' (reason: ${reason})" >> "$RESULTS"
+        else
+            echo "FATAL: pre-flight failed on FIRST scenario of lane ($sc) — harness setup, not scenario fault (reason: ${reason})" >> "$RESULTS"
+            echo "all-scenarios-done: $(date -Iseconds)" >> "$RESULTS"
+            exit 1
+        fi
+    fi
+
     echo "=== START $(date -Iseconds) $sc ===" >> "$RESULTS"
     if timeout 600 make e2e NAME=$NAME SCENARIO=$sc > "$logf" 2>&1; then
         # exit 0 from make — but a scenario may have emitted the SKIP
@@ -136,6 +240,11 @@ for sc in "${SCENARIOS[@]}"; do
         reset_between_scenarios
         echo "=== CLEANUP-DONE $(date -Iseconds) after $sc ===" >> "$RESULTS"
     fi
+
+    # Remember the scenario that just finished so the NEXT iteration's
+    # pre-flight check can blame LEFTOVER state on it (not on its
+    # innocent successor).
+    prev_sc=$sc
 done
 
 echo "all-scenarios-done: $(date -Iseconds)" >> "$RESULTS"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -499,6 +499,129 @@ wait_cluster_idle() {
     return 0
 }
 
+# register_strict_cleanup — install an EXIT trap that runs
+# strict_cleanup_on_exit() for the RDs named in $@. Idempotent: stacks
+# safely with existing scenario traps via _STRICT_CLEANUP_RDS append.
+#
+# Use this from a scenario instead of bare `trap 'delete_rd X' EXIT` so
+# the lane harness (stand/run-scenarios-only.sh) gets a strict guarantee
+# that the cluster is back to the baseline before the next scenario
+# launches. Skips quietly for scenarios that don't migrate (existing
+# bare-trap scenarios keep working as before — strict_cleanup_on_exit
+# is purely additive).
+#
+# Usage in a scenario:
+#   register_strict_cleanup "$RD" "$RD2"
+# instead of:
+#   trap 'delete_rd "$RD"; delete_rd "$RD2"' EXIT
+#
+# Multiple register_strict_cleanup calls accumulate RDs (handy when a
+# scenario creates them progressively).
+_STRICT_CLEANUP_RDS=()
+register_strict_cleanup() {
+    local rd
+    for rd in "$@"; do
+        _STRICT_CLEANUP_RDS+=("$rd")
+    done
+    trap _strict_cleanup_trap EXIT
+}
+
+_strict_cleanup_trap() {
+    local rc=$?
+    strict_cleanup_on_exit "${_STRICT_CLEANUP_RDS[@]}"
+    local cleanup_rc=$?
+    # Demote a PASSing scenario to FAIL if cleanup couldn't drain the
+    # cluster — the harness pre-flight would catch this on the next
+    # scenario anyway, but failing here pins the blame on THIS script
+    # rather than letting the next one inherit a dirty cluster.
+    if [[ $rc -eq 0 && $cleanup_rc -ne 0 ]]; then
+        echo "FAIL: strict_cleanup_on_exit could not drain the cluster — scenario PASS demoted to FAIL" >&2
+        exit 1
+    fi
+    exit "$rc"
+}
+
+# strict_cleanup_on_exit <rd> [<rd>...] — per-scenario EXIT cleanup that
+# guarantees the cluster goes back to the baseline (no orphan RDs, no
+# Terminating satellite pods) before the next scenario launches.
+#
+# Steps (each idempotent, swallow their own errors):
+#   1. delete_rd for every passed RD (same teardown chain the per-test
+#      traps used: Snapshot+Resource+RD cascade + per-node drbdsetup
+#      down + .res / .md-created scrub).
+#   2. kubectl wait --for=delete pod ... --timeout=60s on any satellite
+#      pod that is currently Terminating (DeletionTimestamp set).
+#   3. For any pod that DID NOT clear within step 2, kubectl delete
+#      --grace-period=0 --force, then wait again.
+#   4. Final state check: 0 orphan RDs across the cluster AND every
+#      satellite pod in phase=Running with no DeletionTimestamp. Return
+#      1 if either invariant still doesn't hold.
+#
+# Calling with zero RDs is allowed (only do the pod sweep). Safe to call
+# on an already-clean cluster.
+strict_cleanup_on_exit() {
+    local rds=("$@")
+
+    # Step 1: delete the RDs the scenario tracked.
+    local rd
+    for rd in "${rds[@]}"; do
+        [[ -n "$rd" ]] || continue
+        delete_rd "$rd" 2>/dev/null || true
+    done
+
+    # Step 2: wait for any Terminating satellite pod to actually go away.
+    # `kubectl wait --for=delete` returns 0 only after the pod is fully
+    # gone from the API; if nothing matches the selector, it's also a
+    # no-op (returns 0 immediately).
+    local terminating
+    terminating=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o 'jsonpath={range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name} {end}' \
+        2>/dev/null)
+    if [[ -n "${terminating// /}" ]]; then
+        local pod
+        for pod in $terminating; do
+            kubectl -n "$NS" wait --for=delete "pod/$pod" \
+                --timeout=60s >/dev/null 2>&1 || true
+        done
+    fi
+
+    # Step 3: force-kill anything that did not clear gracefully. This is
+    # the kubelet-stuck-stop pattern (rolling-upgrade leftover) — same
+    # treatment reset_cluster_state's step 0 applies.
+    local still_terminating
+    still_terminating=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o 'jsonpath={range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name} {end}' \
+        2>/dev/null)
+    if [[ -n "${still_terminating// /}" ]]; then
+        local pod
+        for pod in $still_terminating; do
+            kubectl -n "$NS" delete pod "$pod" \
+                --grace-period=0 --force >/dev/null 2>&1 || true
+            kubectl -n "$NS" wait --for=delete "pod/$pod" \
+                --timeout=30s >/dev/null 2>&1 || true
+        done
+    fi
+
+    # Step 4: final invariant check.
+    local rd_count running terminating_final total
+    rd_count=$(kubectl get resourcedefinitions.blockstor.cozystack.io \
+        -A --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    total=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    running=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o 'jsonpath={range .items[?(@.status.phase=="Running")]}{.metadata.name} {end}' \
+        2>/dev/null | wc -w | tr -d ' ')
+    terminating_final=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o 'jsonpath={range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name} {end}' \
+        2>/dev/null | wc -w | tr -d ' ')
+
+    if [[ "$rd_count" != "0" || "$running" != "$total" || "$terminating_final" != "0" ]]; then
+        echo "strict_cleanup_on_exit: cluster NOT clean (rd_count=${rd_count} running=${running}/${total} terminating=${terminating_final})" >&2
+        return 1
+    fi
+    return 0
+}
+
 # reset_cluster_state forces the cluster back to a clean slate between
 # back-to-back e2e scenarios run by stand/run-scenarios-only.sh.
 #


### PR DESCRIPTION
## Problem

Lane e2e on the shared QEMU+Talos stand sees recurring cascade failures: scenario N leaves Terminating satellite pods or orphan RDs, and scenario N+1 hits `require_workers` skip with the message `scenario needs 3 Ready satellite pods, found 2 (previous-test cascade — check for Terminating pods)`. The skip is correct in spirit but blames the wrong scenario in the lane log — N+1 looks like a flake, while the real culprit (N) silently passes. Memory `feedback_e2e_parallel_fanout` shows this class has repeated across multiple runs.

Recent example: PR #31 (`test/tiebreaker-r-d-cleanup`) lane 3 — `toggle-disk` got `FAIL toggle-disk (unexpected skip, not allowlisted: scenario needs 3 Ready satellite pods, found 2 (previous-test cascade — check for Terminating pods))`. The bug is not in toggle-disk; the preceding scenario exited dirty.

## Changes (two independent layers)

**A. Lane runner pre-flight check** (`stand/run-scenarios-only.sh`)

`preflight_check()` runs BEFORE each scenario. It polls for up to 60s waiting for: 3 satellite pods all `Running`, none `Terminating`, and zero `ResourceDefinition` CRDs cluster-wide.

- If the check fails AND there is a previous scenario in the lane, that previous scenario's `PASS` line in `$RESULTS` is rewritten to `FAIL <prev> (LEFTOVER: <state>)`. The culprit is now visible.
- If the check fails on the first scenario of the lane, the runner exits FATAL — that's a harness setup bug, not a scenario fault.

**B. Strict cleanup helper** (`tests/e2e/lib.sh`)

`strict_cleanup_on_exit` + `register_strict_cleanup`:

- Deletes the tracked RDs via the existing `delete_rd` chain.
- `kubectl wait --for=delete pod ...` (60s) on every Terminating satellite pod, with `kubectl delete --grace-period=0 --force` as the fallback.
- Final invariant check; if the cluster has not drained, a passing scenario is **demoted to FAIL** so the blame stays on this script.

Both pieces are additive: existing scenarios with bare `trap 'delete_rd X' EXIT` keep working unchanged (the harness still runs `reset_cluster_state` between scenarios). New scenarios should opt in via `register_strict_cleanup "$RD" "$RD2"`; this is documented in AGENTS.md.

## Migration

- No existing scenarios touched.
- New scenarios SHOULD use `register_strict_cleanup` per the AGENTS.md note.

## Test plan

- After merge: pull to all e2e stands and run the full e2e suite on lane 3 (the lane that currently exhibits the cascade misattribution). Expected behaviour: on a cascade run, the lane log no longer contains `FAIL <innocent> (unexpected skip, not allowlisted: scenario needs 3 Ready satellite pods, found 2)`. Instead, the actual culprit shows up as `FAIL <real-culprit> (LEFTOVER: running=... terminating=... rd_count=...)`.
- Cannot be exercised locally (no QEMU+Talos stand here); validation requires a real lane run.

## Limitations / edge cases

- `strict_cleanup_on_exit`'s final invariant check is racy in a narrow window: the controller's reconciler can transiently observe an RD that is mid-delete (the API row is gone but a `Resource` finalizer is still draining). In practice `delete_rd` already waits on RD deletion with a 30s timeout per RD, so the window is small, but a scenario that creates many RDs and deletes them at the last moment might still trip the post-cleanup `rd_count != 0` check and self-demote. Acceptable tradeoff vs. silently passing a dirty cluster to the next scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test suite with stricter cluster cleanup between scenarios
  * Added preflight validation to ensure cluster returns to baseline state before each test scenario
  * Implemented orphaned resource detection and prevention to reduce test contamination

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->