### PR TITLE
fix(controller): drop orphan-witness collapse grace

### DIFF
--- a/internal/controller/ensure_tiebreaker_test.go
+++ b/internal/controller/ensure_tiebreaker_test.go
@@ -956,22 +956,16 @@ func TestBug338TiebreakerCollapsesWhenDiskfulDropsToOne(t *testing.T) {
 	// User just ran `linstor r d n1 pvc-bug338`: the REST handler
 	// (or the cascade) already removed the n1 Resource from the
 	// store. The reconciler is now firing on the resulting state.
-	// Snapshot: n2 diskful + n3 tiebreaker.
-	//
-	// This is a GENUINE Bug-338 standalone (operator deleted a diskful
-	// and stopped), not the transient relocate-onto-the-tiebreaker
-	// window. Pre-stamp the orphan-witness grace with a timestamp
-	// safely older than orphanWitnessCollapseGrace so the collapse
-	// fires this reconcile rather than being deferred. (A fresh
-	// transient — no stamp — is exercised by
-	// TestEnsureTiebreakerRelocateDefersOrphanCollapse.)
-	seenAt := time.Now().Add(-2 * controllerpkg.OrphanWitnessCollapseGrace).UTC().Format(time.RFC3339)
-
+	// Snapshot: n2 diskful + n3 tiebreaker. The orphan-witness
+	// collapse fires on this first observation — no grace timer.
+	// The race the prior grace gate guarded (in-flight relocate
+	// `r c <tiebreaker-node>` promoting the witness in-place while
+	// the controller deletes the same row) is now closed at the
+	// node-id-allocator layer by Bug 342's kernel-confirmed
+	// PeerDRBDNodeID union (see resource_controller.go
+	// collectTakenNodeIDs).
 	rd := &blockstoriov1alpha1.ResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "pvc-bug338",
-			Annotations: map[string]string{controllerpkg.OrphanWitnessSeenAtAnnotation: seenAt},
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug338"},
 	}
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
@@ -1013,125 +1007,6 @@ func TestBug338TiebreakerCollapsesWhenDiskfulDropsToOne(t *testing.T) {
 			t.Errorf("Bug 338: surviving replica should be diskful, has DISKLESS; flags=%v",
 				post[0].Flags)
 		}
-	}
-}
-
-// TestEnsureTiebreakerRelocateDefersOrphanCollapse pins the
-// relocate-onto-the-tiebreaker stability gate. A FRESH 1-diskful +
-// 1-orphan-witness snapshot (no grace stamp yet) is the transient
-// mid-relocate shape: after `r d <one-of-two-diskful>` the RD sits at
-// 1 diskful + 1 orphan witness for the sub-second window before
-// `r c <tiebreaker-node>` promotes the witness into the relocate
-// target. The reconciler MUST NOT collapse the witness on this first
-// observation — it must defer (keep the witness, stamp the seen-at
-// grace) so the in-flight promote isn't raced and the placement
-// decision doesn't oscillate.
-//
-// Contrast TestBug338TiebreakerCollapsesWhenDiskfulDropsToOne, which
-// pre-stamps a past-grace timestamp to exercise the genuine
-// standalone (operator deleted a diskful and stopped) where the
-// collapse SHOULD fire.
-func TestEnsureTiebreakerRelocateDefersOrphanCollapse(t *testing.T) {
-	t.Parallel()
-
-	scheme := newScheme(t)
-	st := store.NewInMemory()
-	ctx := context.Background()
-
-	for _, n := range []string{"n1", "n2", "n3"} {
-		if err := st.Nodes().Create(ctx, &apiv1.Node{
-			Name: n, Type: apiv1.NodeTypeSatellite,
-		}); err != nil {
-			t.Fatalf("seed node %s: %v", n, err)
-		}
-	}
-
-	const rdName = "pvc-relocate-defer"
-
-	// Transient mid-relocate snapshot: lone diskful on n2 + orphan
-	// witness on n3, NO grace stamp (this is the first observation).
-	if err := st.Resources().Create(ctx, &apiv1.Resource{
-		Name: rdName, NodeName: "n2",
-	}); err != nil {
-		t.Fatalf("seed n2 diskful: %v", err)
-	}
-
-	if err := st.Resources().Create(ctx, &apiv1.Resource{
-		Name: rdName, NodeName: "n3",
-		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
-	}); err != nil {
-		t.Fatalf("seed n3 witness: %v", err)
-	}
-
-	rd := &blockstoriov1alpha1.ResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{Name: rdName},
-	}
-
-	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
-
-	rec := &controllerpkg.ResourceDefinitionReconciler{
-		Client: cli,
-		Scheme: scheme,
-		Store:  st,
-	}
-
-	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
-		t.Fatalf("EnsureTiebreaker: %v", err)
-	}
-
-	// Deferral invariant: the witness MUST still be present (collapse
-	// deferred), and the grace stamp MUST now be set so the next
-	// reconcile after the grace can act.
-	if _, err := st.Resources().Get(ctx, rdName, "n3"); err != nil {
-		t.Fatalf("relocate-defer: witness on n3 was collapsed on first observation: %v", err)
-	}
-
-	final := &blockstoriov1alpha1.ResourceDefinition{}
-	if err := cli.Get(ctx, types.NamespacedName{Name: rdName}, final); err != nil {
-		t.Fatalf("Get RD: %v", err)
-	}
-
-	if final.Annotations[controllerpkg.OrphanWitnessSeenAtAnnotation] == "" {
-		t.Errorf("relocate-defer: orphan-witness grace stamp not set; annotations=%v", final.Annotations)
-	}
-
-	// Now simulate the relocate `r c n3` landing inside the grace:
-	// promote n3's witness to diskful. The next reconcile sees 2
-	// diskful + 0 witness, must CLEAR the grace stamp and want a fresh
-	// witness (no orphan-collapse, no flip).
-	if err := st.Resources().Update(ctx, &apiv1.Resource{
-		Name: rdName, NodeName: "n3",
-		Props: map[string]string{"StorPoolName": "stand"},
-	}); err != nil {
-		t.Fatalf("promote n3 witness to diskful: %v", err)
-	}
-
-	if err := rec.EnsureTiebreaker(ctx, final); err != nil {
-		t.Fatalf("EnsureTiebreaker after promote: %v", err)
-	}
-
-	cleared := &blockstoriov1alpha1.ResourceDefinition{}
-	if err := cli.Get(ctx, types.NamespacedName{Name: rdName}, cleared); err != nil {
-		t.Fatalf("Get RD after promote: %v", err)
-	}
-
-	if cleared.Annotations[controllerpkg.OrphanWitnessSeenAtAnnotation] != "" {
-		t.Errorf("relocate-defer: grace stamp not cleared after relocate landed; annotations=%v",
-			cleared.Annotations)
-	}
-
-	all, err := st.Resources().ListByDefinition(ctx, rdName)
-	if err != nil {
-		t.Fatalf("list after promote: %v", err)
-	}
-
-	diskful, _, witness := classifyReplicas(all)
-	if diskful != 2 {
-		t.Errorf("after relocate: diskful=%d, want 2 (n2 + relocated n3); entries=%v", diskful, all)
-	}
-
-	if witness != 1 {
-		t.Errorf("after relocate: witness=%d, want 1 (fresh on n1); entries=%v", witness, all)
 	}
 }
 

--- a/internal/controller/export_test.go
+++ b/internal/controller/export_test.go
@@ -220,12 +220,3 @@ func IsAutoQuorumDisabled(rd *blockstoriov1alpha1.ResourceDefinition) bool {
 // key for tests so a regression that renamed the key on one side
 // would fail to compile here.
 const AutoTiebreakerSuppressedUntilAnnotation = apiv1.AutoTiebreakerSuppressedUntilAnnotation
-
-// OrphanWitnessSeenAtAnnotation exposes the Bug-338 orphan-witness
-// grace-stamp key so tests can simulate a persisted (past-grace)
-// standalone vs a fresh transient relocate window.
-const OrphanWitnessSeenAtAnnotation = orphanWitnessSeenAtAnnotation
-
-// OrphanWitnessCollapseGrace exposes the grace duration so tests can
-// stamp a seen-at timestamp safely older than the collapse window.
-const OrphanWitnessCollapseGrace = orphanWitnessCollapseGrace

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -57,36 +57,6 @@ import (
 // roadmap) keep concurrent grow-shrink decisions distinguishable.
 const Bug148ResizePendingAnnotationPrefix = "bug136.blockstor.cozystack.io/resize-pending-size-kib-vol-"
 
-// orphanWitnessSeenAtAnnotation records the first wall-clock time the
-// RD-reconciler observed the Bug-338 orphan-witness shape (exactly 1
-// diskful + 1 TIE_BREAKER + 0 user-diskless). The collapse only fires
-// once this shape has PERSISTED past orphanWitnessCollapseGrace.
-//
-// Why: the orphan-witness shape is indistinguishable at a single
-// snapshot from the in-flight relocate-onto-the-tiebreaker transition
-// (`r-full-lifecycle.sh` Phase 3). After `r d <one-of-two-diskful>`
-// the RD momentarily sits at 1 diskful + 1 orphan witness — the exact
-// Bug-338 trigger — but the operator immediately follows with
-// `r c <tiebreaker-node>`, promoting the witness into the diskful
-// relocate target. Collapsing on the first snapshot races that
-// promote and churns the witness/placement decision (diskful 1<->2,
-// willRemove<->willCreate) so the relocate target never settles, and
-// the resulting Resource create/delete storm starves the apiserver
-// cache (the relocate `r c` then 404s on a stale RD read). Deferring
-// the collapse by a short grace lets the relocate `r c` land first:
-// the topology changes, the orphan shape is gone, and the collapse
-// never destructively fires. A genuine Bug-338 standalone (operator
-// deletes a diskful and stops) still collapses once the grace lapses.
-const orphanWitnessSeenAtAnnotation = "blockstor.io/orphan-witness-seen-at"
-
-// orphanWitnessCollapseGrace is how long the 1-diskful + 1-witness
-// shape must persist before the Bug-338 collapse fires. Sized to
-// comfortably cover the `r d` -> `r c` relocate gap (sub-second on
-// the stand) plus apiserver-cache trail, while staying far below the
-// 5-minute AutoTiebreaker suppression window so a real standalone
-// diskful sheds its orphan witness promptly.
-const orphanWitnessCollapseGrace = 15 * time.Second
-
 // ResourceDefinitionReconciler watches RD CRDs and maintains the
 // tiebreaker invariant: an RD with exactly 2 diskful replicas in a
 // cluster with 3+ satellite nodes auto-gains a 3rd DISKLESS replica
@@ -258,14 +228,25 @@ func (r *ResourceDefinitionReconciler) ensureTiebreaker(ctx context.Context, rd 
 
 	wantWitness := shouldTieBreakerExist(rd, diskful, diskless, witness)
 
-	// Relocate-onto-the-tiebreaker stability gate (see
-	// deferOrphanWitnessCollapse): hold the witness across the
-	// transient mid-relocate window so the placement decision settles
-	// instead of oscillating against the in-flight `r c` promote.
-	wantWitness, err = r.deferOrphanWitnessCollapse(ctx, rd, diskful, diskless, witness, wantWitness)
-	if err != nil {
-		return err
-	}
+	// Bug 338: the orphan-witness shape (1 diskful + 1 TIE_BREAKER +
+	// 0 user-diskless) collapses on this reconcile — no grace timer.
+	// The race the earlier grace gate guarded (in-flight relocate
+	// `r c <tiebreaker-node>` promoting the witness in-place via
+	// promoteDisklessReplica while the controller deletes the same
+	// row) is now closed at the node-id-allocator layer by Bug 342's
+	// kernel-confirmed PeerDRBDNodeID union (see
+	// resource_controller.go:collectTakenNodeIDs). If the relocate
+	// `r c` lands after the witness is gone, promoteDisklessReplica
+	// falls through to a fresh Create with a freshly-allocated DRBD
+	// node-id that the allocator guarantees does not collide with
+	// the kernel slot the just-freed witness held — so the relocate
+	// converges via the create-fresh path instead of the in-place
+	// promote-fast-path. One extra Resource CRD cycle in the narrow
+	// `r d → r c` overlap, no oscillation, no kernel-slot reuse.
+	// removeWitnesses still re-checks each row's live Flags before
+	// Delete so a witness that already promoted to the relocate
+	// target (TIE_BREAKER stripped) is skipped — the same layered
+	// guard the relocate-onto-tiebreaker integration test exercises.
 
 	willCreate := wantWitness && len(witness) == 0
 	willRemove := !wantWitness && len(witness) > 0
@@ -892,132 +873,6 @@ func (r *ResourceDefinitionReconciler) setQuorum(ctx context.Context, rd *blocks
 		// Refetch and retry.
 		err = r.Get(ctx, client.ObjectKey{Name: rd.Name}, rd)
 		if err != nil {
-			return err
-		}
-	}
-
-	return apierrors.NewConflict(
-		blockstoriov1alpha1.GroupVersion.WithResource("resourcedefinitions").GroupResource(),
-		rd.Name, nil)
-}
-
-// deferOrphanWitnessCollapse implements the relocate-onto-the-tiebreaker
-// stability gate. The Bug-338 orphan-witness collapse (1 diskful +
-// 1 TIE_BREAKER + 0 user-diskless -> drop the witness) is
-// indistinguishable at a single snapshot from the transient
-// mid-relocate shape: after `r d <one-of-two-diskful>` the RD
-// momentarily holds 1 diskful + 1 orphan witness, then
-// `r c <tiebreaker-node>` promotes that witness into the diskful
-// relocate target. Collapsing on the first snapshot races the promote
-// and oscillates the placement decision (diskful 1<->2,
-// willRemove<->willCreate); the resulting Resource create/delete storm
-// also starves the apiserver cache so the relocate `r c` 404s on a
-// stale RD read.
-//
-// When the snapshot matches the orphan-collapse shape, defer the
-// collapse (return wantWitness=true) until it has PERSISTED past
-// orphanWitnessCollapseGrace — the 5s RequeueAfter in Reconcile
-// re-checks, and a relocate `r c` landing inside the grace changes
-// the shape so the collapse never fires. A genuine Bug-338 standalone
-// still sheds its orphan witness once the grace lapses. Any other
-// shape clears the grace stamp so the next genuine orphan starts a
-// fresh window.
-func (r *ResourceDefinitionReconciler) deferOrphanWitnessCollapse(
-	ctx context.Context,
-	rd *blockstoriov1alpha1.ResourceDefinition,
-	diskful, diskless, witness []apiv1.Resource,
-	wantWitness bool,
-) (bool, error) {
-	nonWitnessDiskless := len(diskless) - len(witness)
-	orphanCollapseShape := !wantWitness && len(witness) > 0 &&
-		len(diskful) == 1 && nonWitnessDiskless == 0
-
-	if !orphanCollapseShape {
-		return wantWitness, r.clearOrphanWitnessGrace(ctx, rd)
-	}
-
-	expired, err := r.orphanWitnessGraceExpired(ctx, rd)
-	if err != nil {
-		return wantWitness, err
-	}
-
-	if !expired {
-		// Keep the witness this cycle; Reconcile's RequeueAfter
-		// re-checks once the grace lapses (or the relocate `r c`
-		// changes the shape first).
-		return true, nil
-	}
-
-	return wantWitness, nil
-}
-
-// orphanWitnessGraceExpired reports whether the Bug-338 orphan-witness
-// shape has persisted long enough to collapse the witness. On the
-// FIRST observation it stamps orphanWitnessSeenAtAnnotation with the
-// current wall-clock time and returns false (defer). On subsequent
-// observations it compares the stamp against orphanWitnessCollapseGrace
-// and returns true once the grace has lapsed.
-//
-// A missing / unparseable stamp is treated as "first observation":
-// stamp fresh and defer. This keeps a hand-edited annotation from
-// either freezing the collapse forever or collapsing instantly.
-func (r *ResourceDefinitionReconciler) orphanWitnessGraceExpired(ctx context.Context, rd *blockstoriov1alpha1.ResourceDefinition) (bool, error) {
-	raw := ""
-	if rd.Annotations != nil {
-		raw = rd.Annotations[orphanWitnessSeenAtAnnotation]
-	}
-
-	if seenAt, err := time.Parse(time.RFC3339, raw); err == nil {
-		return time.Since(seenAt) >= orphanWitnessCollapseGrace, nil
-	}
-
-	// First (or unparseable) observation — stamp now and defer.
-	if err := r.setOrphanWitnessSeenAt(ctx, rd, time.Now().UTC().Format(time.RFC3339)); err != nil {
-		return false, err
-	}
-
-	return false, nil
-}
-
-// clearOrphanWitnessGrace drops the orphanWitnessSeenAtAnnotation when
-// the RD no longer matches the orphan-collapse shape (the relocate
-// `r c` landed, or the operator otherwise changed the topology), so a
-// later genuine Bug-338 starts a fresh grace window. No-op when the
-// annotation is absent.
-func (r *ResourceDefinitionReconciler) clearOrphanWitnessGrace(ctx context.Context, rd *blockstoriov1alpha1.ResourceDefinition) error {
-	if rd.Annotations == nil || rd.Annotations[orphanWitnessSeenAtAnnotation] == "" {
-		return nil
-	}
-
-	return r.setOrphanWitnessSeenAt(ctx, rd, "")
-}
-
-// setOrphanWitnessSeenAt writes (value != "") or deletes (value == "")
-// the orphan-witness grace stamp on the RD CRD, with the same
-// conflict-retry shape as setQuorum so a racing reconcile / REST
-// upsert converges instead of being dropped by a stale snapshot.
-func (r *ResourceDefinitionReconciler) setOrphanWitnessSeenAt(ctx context.Context, rd *blockstoriov1alpha1.ResourceDefinition, value string) error {
-	for range 3 {
-		if rd.Annotations == nil {
-			rd.Annotations = map[string]string{}
-		}
-
-		if value == "" {
-			delete(rd.Annotations, orphanWitnessSeenAtAnnotation)
-		} else {
-			rd.Annotations[orphanWitnessSeenAtAnnotation] = value
-		}
-
-		err := r.Update(ctx, rd)
-		if err == nil {
-			return nil
-		}
-
-		if !apierrors.IsConflict(err) {
-			return err
-		}
-
-		if err := r.Get(ctx, client.ObjectKey{Name: rd.Name}, rd); err != nil {
 			return err
 		}
 	}

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -773,7 +773,33 @@ reset_cluster_state() {
         ' 2>/dev/null || true
     done
 
-    echo ">> reset_cluster_state: done $(date -Iseconds) (delete_all_rds rc=$rc)"
+    # 6. Wait for the satellite DaemonSet to converge before handing
+    #    control to the next scenario. state-offline-unknown and other
+    #    partition scenarios mutate the DS template (nodeAffinity
+    #    rejecting a worker label) and force-delete the Pod on that
+    #    worker; their EXIT cleanup reverts the template but does not
+    #    always wait for the DS controller to spawn the replacement
+    #    Pod into Ready. Without this barrier the next scenario's
+    #    `require_workers` preflight can race the DS reconciliation
+    #    and SKIP with a "previous-test cascade" message (e.g.
+    #    state-offline-unknown → toggle-disk in ci-lane3 alphabetical
+    #    order). 90s is generous: a fresh satellite Pod typically
+    #    reaches Ready within 10s; we mostly cover the window between
+    #    DS-template-revert and DS-controller noticing it.
+    local ds_deadline=$(( $(date +%s) + 90 ))
+    local ds_desired ds_ready
+    while (( $(date +%s) < ds_deadline )); do
+        ds_desired=$(kubectl -n "$NS" get ds blockstor-satellite \
+            -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
+        ds_ready=$(kubectl -n "$NS" get ds blockstor-satellite \
+            -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+        if [[ -n "$ds_desired" ]] && (( ds_desired > 0 )) && (( ds_desired == ds_ready )); then
+            break
+        fi
+        sleep 2
+    done
+
+    echo ">> reset_cluster_state: done $(date -Iseconds) (delete_all_rds rc=$rc, ds_ready=${ds_ready:-?}/${ds_desired:-?})"
     return $rc
 }
 

--- a/tests/e2e/tiebreaker-r-d-cleanup.sh
+++ b/tests/e2e/tiebreaker-r-d-cleanup.sh
@@ -60,9 +60,8 @@ N2=$WORKER_2
 N3=$WORKER_3
 
 # Per-step convergence budget. The witness add/remove path is event-
-# driven (RD reconciler watches Resource CRDs) plus a 5s requeue tick
-# under the auto-tiebreaker grace window, so 60s is comfortable on the
-# QEMU stand.
+# driven (RD reconciler watches Resource CRDs) plus a 5s requeue tick,
+# so 60s is comfortable on the QEMU stand.
 CONVERGE=${CONVERGE:-60}
 
 # blockstor's REST/apiserver is exposed inside the cluster on :3370
@@ -173,8 +172,9 @@ diskful_count() {
 
 # wait_witness_count <rd> <want> [timeout] — poll until exactly $want
 # TIE_BREAKER witnesses exist for $rd, or timeout. Tries one extra
-# settle iteration before returning (the controller can churn the
-# witness during the deferOrphanWitnessCollapse grace window).
+# settle iteration before returning (the controller is event-driven
+# off Resource watches, so the witness can briefly oscillate during
+# the per-cycle 5s requeue while the diskful count is observed).
 wait_witness_count() {
     local rd=$1 want=$2 timeout=${3:-$CONVERGE}
     local deadline=$(( $(date +%s) + timeout ))
@@ -291,11 +291,14 @@ fi
 
 # Stability tail: hold for 15s and re-check. The pre-fix symptom of
 # Bug 338 was a witness that oscillated between collapse and resurrect
-# under the deferOrphanWitnessCollapse grace window — a "willRemove:
-# true → willCreate: true → willRemove: true" thrash in the controller
-# logs. A single point-in-time read could catch the witness in the
-# collapsed half of the oscillation and pass; force a tail-window
-# stability check so the regression catcher actually sees the bounce.
+# — a "willRemove: true → willCreate: true → willRemove: true" thrash
+# in the controller logs. A single point-in-time read could catch the
+# witness in the collapsed half of the oscillation and pass; force a
+# tail-window stability check so the regression catcher actually sees
+# the bounce. The Bug-342 node-id-occupied invariant now closes the
+# in-flight relocate race that the prior grace-window guarded, so the
+# collapse fires on the first observation — the stability tail still
+# proves it stays collapsed across a 5s requeue cycle without bouncing.
 echo ">> stability tail: hold 15s, re-check witness count"
 deadline=$(( $(date +%s) + 15 ))
 while (( $(date +%s) < deadline )); do


### PR DESCRIPTION
## Summary
- Drop the 15s `orphanWitnessCollapseGrace` from `ResourceDefinitionReconciler.ensureTiebreaker`; the Bug-338 collapse now fires on the first observation of the orphan-witness shape (1 diskful + 1 TIE_BREAKER + 0 user-diskless).
- Strip the now-unused grace machinery: `orphanWitnessSeenAtAnnotation`, `deferOrphanWitnessCollapse`, `orphanWitnessGraceExpired`, `clearOrphanWitnessGrace`, `setOrphanWitnessSeenAt`, plus the test-only exports of the constants.
- Update the Bug-338 unit test to assert the instant collapse and delete the now-obsolete `TestEnsureTiebreakerRelocateDefersOrphanCollapse` (its premise — the grace — no longer exists).

## Why
The grace existed to keep the collapse from racing the in-flight relocate window:
```
linstor r d <one-of-two-diskful>      # leaves 1 diskful + 1 orphan TIE_BREAKER
linstor r c <tiebreaker-node>          # promotes the witness in-place via promoteDisklessReplica
```
Without the grace, the controller could delete the witness CRD just as REST's `promoteDisklessReplica` fast-path was promoting it — leaving the relocate target to land on a node whose kernel-slot id was still held by the just-freed witness.

Bug 342 closed that race architecturally at the allocator layer: `collectTakenNodeIDs` now unions live sibling `Status.DRBDNodeID` with observed `Status.Connections[].PeerDrbdNodeId`, so a fresh diskful allocated by the relocate cannot collide with a peer kernel slot that hasn't been torn down yet. With that invariant the only fallout of an instant collapse is one extra Resource CRD cycle in the narrow `r d → r c` overlap (the relocate falls through to a fresh Create instead of the in-place promote fast-path) — no oscillation, no kernel-slot reuse.

`removeWitnesses` still re-checks each row's live Flags before Delete, so a witness that already promoted to the relocate target (TIE_BREAKER stripped) is skipped.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/controller/...`
- [x] `golangci-lint run ./internal/controller/...`
- [ ] Live verification on dev stand: TieBreaker collapses within one reconcile of `linstor r d`; existing `tests/e2e/r-full-lifecycle.sh` Phase-3 relocate still converges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Witness removal now occurs immediately upon detection instead of being deferred in certain topology scenarios

* **Tests**
  * Enhanced e2e test infrastructure with improved cluster state verification, including DaemonSet readiness checks
  * Updated test coverage to reflect simplified witness collapse behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->