### PR TITLE
fix(satellite): auto-mkfs storage-only resources for linstor-csi PVCs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -239,7 +239,7 @@ jobs:
       # `e2e-piraeus` job below, which installs piraeus in EXTERNAL mode
       # against blockstor's apiserver (no upstream Java linstor-controller).
       # ci-e2e.sh drops these from the discovered suite.
-      E2E_EXCLUDE: "rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo"
+      E2E_EXCLUDE: "rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo csi-pvc-local"
     permissions:
       contents: read
       checks: write
@@ -366,7 +366,7 @@ jobs:
         # LANE=1 LANES=1 → the single lane runs every listed scenario;
         # ci-e2e.sh honours INSTALL_PIRAEUS=1 (job env) to deploy piraeus
         # after blockstor so these scenarios have the stack they drive.
-        run: make ci-e2e LANE=1 LANES=1 SCENARIOS="rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo"
+        run: make ci-e2e LANE=1 LANES=1 SCENARIOS="rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo csi-pvc-local"
 
       - name: Upload e2e logs
         if: always()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -366,7 +366,15 @@ jobs:
         # LANE=1 LANES=1 → the single lane runs every listed scenario;
         # ci-e2e.sh honours INSTALL_PIRAEUS=1 (job env) to deploy piraeus
         # after blockstor so these scenarios have the stack they drive.
-        run: make ci-e2e LANE=1 LANES=1 SCENARIOS="rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo csi-pvc-local"
+        # csi-pvc-local runs BEFORE csi-pvc-replicated-rwo by design:
+        # the local scenario is stateless (storage-only PVC, no DRBD,
+        # no cross-node migration), so any cleanup races it surfaces
+        # cannot contaminate the next scenario. The replicated one
+        # creates Pods on two workers in sequence and its cleanup,
+        # even after the synchronous Pod-delete fix, races
+        # pv-controller's ControllerPublishVolume retries — putting
+        # it last keeps that storm out of the local scenario's window.
+        run: make ci-e2e LANE=1 LANES=1 SCENARIOS="rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-local csi-pvc-replicated-rwo"
 
       - name: Upload e2e logs
         if: always()

--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -75,6 +75,8 @@ func (s *Server) registerAutoplace(mux *http.ServeMux) {
 		s.requireStore(s.handleResourceGet))
 	mux.HandleFunc("POST /v1/resource-definitions/{rd}/resources",
 		s.requireStore(s.handleResourceCreate))
+	mux.HandleFunc("POST /v1/resource-definitions/{rd}/resources/{node}",
+		s.requireStore(s.handleResourceCreateOnNode))
 	mux.HandleFunc("POST /v1/resource-definitions/{rd}/resources/{node}/make-available",
 		s.requireStore(s.handleResourceMakeAvailable))
 	mux.HandleFunc("DELETE /v1/resource-definitions/{rd}/resources/{node}",
@@ -1239,6 +1241,93 @@ func (s *Server) handleResourceCreate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, []apiv1.APICallRc{{
 		RetCode: maskInfo,
 		Message: "resource(s) created on resource-definition: " + rdName,
+	}})
+}
+
+// handleResourceCreateOnNode answers `POST /v1/resource-definitions/
+// {rd}/resources/{node}` — the single-node create variant linstor-csi
+// v1.10.1 uses when a PVC pins a fixed nodeList (the demo "local"
+// SC's `placementCount=1` + `nodeList=<worker>` shape). Upstream
+// LINSTOR's OpenAPI registers BOTH the bulk
+// `/resources` array-shaped POST AND this single-node alias; CSI
+// clients pick whichever matches the placement scope. Before this
+// route blockstor returned HTTP 405 (method not allowed) and CSI's
+// CreateVolume looped forever ("the path POST … is registered, but
+// not for this verb").
+//
+// Wire shape: accepts EITHER a single `ResourceCreate` object OR a
+// 1-element array (same `decodeResourceCreateBody` tolerance as the
+// bulk POST). The {node} URL segment is the load-bearing source of
+// truth — when the body's NodeName is empty we fill it from the
+// path; when both are set we refuse the conflict rather than
+// silently honour one over the other.
+func (s *Server) handleResourceCreateOnNode(w http.ResponseWriter, r *http.Request) {
+	rdName := r.PathValue("rd")
+	node := r.PathValue("node")
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeDecodeError(w, err)
+
+		return
+	}
+
+	// Tolerate empty body BEFORE decoding — the {node} path segment
+	// carries the complete create intent in that case (linstor-csi
+	// v1.10.1 posts no body for the simple per-node Resource.Create
+	// shape). decodeResourceCreateBody errs out on empty input, but
+	// for the single-node alias that's a legitimate request — the
+	// CSI wire shape just uses the path to convey the intent.
+	var envelopes []apiv1.ResourceCreate
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		envelopes = []apiv1.ResourceCreate{{Resource: apiv1.Resource{}}}
+	} else {
+		envelopes, err = decodeResourceCreateBody(body)
+		if err != nil {
+			writeDecodeError(w, err)
+
+			return
+		}
+	}
+
+	if len(envelopes) > 1 {
+		writeError(w, http.StatusBadRequest,
+			"single-node resource create accepts at most one envelope, got "+
+				strconv.Itoa(len(envelopes)))
+
+		return
+	}
+
+	env := &envelopes[0]
+
+	switch {
+	case env.Resource.NodeName == "":
+		env.Resource.NodeName = node
+	case env.Resource.NodeName != node:
+		writeError(w, http.StatusBadRequest,
+			"single-node resource create: body node '"+env.Resource.NodeName+
+				"' does not match URL path node '"+node+"'")
+
+		return
+	}
+
+	created, ok := s.createResources(w, r, rdName, envelopes)
+	if !ok {
+		return
+	}
+
+	// Bug 263 (P1): bump peer-changed annotations on siblings so each
+	// satellite reconciles its .res with the new replica. Same pattern
+	// as handleResourceCreate above.
+	for i := range created {
+		s.bumpPeerChangedOnSiblings(r.Context(), rdName, created[i].NodeName)
+	}
+
+	writeJSON(w, http.StatusCreated, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "resource created on resource-definition: " + rdName +
+			" / node: " + node,
 	}})
 }
 

--- a/pkg/rest/resource_create_per_node_test.go
+++ b/pkg/rest/resource_create_per_node_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestResourceCreateOnNodeFromURL pins the linstor-csi v1.10.1 wire
+// shape for a single-node resource create: POST to
+// /v1/resource-definitions/{rd}/resources/{node} with an empty body
+// (the URL path carries the complete intent). Pre-fix this route was
+// only registered for PUT (modify-props) and the CSI driver looped
+// forever on "method not allowed" → CreateVolume failed.
+func TestResourceCreateOnNodeFromURL(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{Name: "pvc-local-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Nodes().Create(t.Context(), &apiv1.Node{Name: "worker-1"}); err != nil {
+		t.Fatalf("seed Node: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-local-1/resources/worker-1", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", resp.StatusCode)
+	}
+
+	got, err := st.Resources().Get(t.Context(), "pvc-local-1", "worker-1")
+	if err != nil {
+		t.Fatalf("Resources().Get: %v", err)
+	}
+
+	if got.NodeName != "worker-1" {
+		t.Errorf("NodeName: got %q, want %q", got.NodeName, "worker-1")
+	}
+}
+
+// TestResourceCreateOnNodeBodyConflict pins the strict refusal when
+// the URL path and the body disagree on which node the Resource lives
+// on. Silently honouring one over the other would let a typo create
+// a replica on the wrong node and the operator would never see it.
+func TestResourceCreateOnNodeBodyConflict(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{Name: "pvc-conf-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	for _, n := range []string{"worker-1", "worker-2"} {
+		if err := st.Nodes().Create(t.Context(), &apiv1.Node{Name: n}); err != nil {
+			t.Fatalf("seed Node %s: %v", n, err)
+		}
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{NodeName: "worker-2"},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-conf-1/resources/worker-1", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("conflict status: got %d, want 400", resp.StatusCode)
+	}
+
+	// Sanity: no Resource was created on EITHER node.
+	for _, n := range []string{"worker-1", "worker-2"} {
+		_, err := st.Resources().Get(t.Context(), "pvc-conf-1", n)
+		if err == nil {
+			t.Errorf("Resource leaked on %s after rejected conflict create", n)
+		}
+	}
+}
+
+// TestResourceCreateOnNodeBodyMatchesURL verifies the happy path
+// where the body explicitly states the same NodeName as the URL —
+// CSI clients that DO populate NodeName in the body must work too.
+func TestResourceCreateOnNodeBodyMatchesURL(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{Name: "pvc-match-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Nodes().Create(t.Context(), &apiv1.Node{Name: "worker-3"}); err != nil {
+		t.Fatalf("seed Node: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{NodeName: "worker-3"},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-match-1/resources/worker-3", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		body := make([]byte, 4096)
+		n, _ := resp.Body.Read(body)
+		t.Fatalf("status: got %d, want 201; body=%s", resp.StatusCode, strings.TrimSpace(string(body[:n])))
+	}
+}

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -882,6 +882,24 @@ func (r *Reconciler) applyOne(ctx context.Context, dr *intent.DesiredResource) *
 
 			return res
 		}
+	} else {
+		// Storage-only resources (layerList=storage, the linstor-csi
+		// "local" SC shape) bypass applyDRBD entirely, which means the
+		// DRBD-side runAutoPromote → runAutoMkfs chain never runs and
+		// `FileSystem/Type` set by linstor-csi on the RD would be
+		// silently ignored. linstor-csi v1.10.1's NodePublishVolume
+		// does `fsck` + plain `mount(2)` on the device (no
+		// FormatAndMount fallback), so without satellite-side mkfs the
+		// kubelet's fsck rejects the unformatted volume with exit 8.
+		// Match the DRBD-stack contract by running the same auto-mkfs
+		// path against the raw device map from applyStorage.
+		err := r.runStorageOnlyMkfs(ctx, dr, diskless, devices)
+		if err != nil {
+			res.Ok = false
+			res.Message = err.Error()
+
+			return res
+		}
 	}
 
 	res.Volumes = buildVolumeResults(dr, devices, diskless, withDRBD)
@@ -2917,7 +2935,7 @@ func (r *Reconciler) runAutoPromote(ctx context.Context, dr *intent.DesiredResou
 		return errors.Wrapf(err, "auto-primary %s", dr.GetName())
 	}
 
-	err = r.runAutoMkfs(ctx, dr)
+	err = r.runAutoMkfs(ctx, dr, drbdDevicesForMkfs(dr))
 	if err != nil {
 		return errors.Wrapf(err, "auto-mkfs %s", dr.GetName())
 	}
@@ -2928,6 +2946,55 @@ func (r *Reconciler) runAutoPromote(ctx context.Context, dr *intent.DesiredResou
 	}
 
 	return nil
+}
+
+// drbdDevicesForMkfs builds the {volNumber → /dev/drbd<minor>} map
+// runAutoMkfs feeds into mkfs for DRBD-stacked resources. mkfs on a
+// DRBD volume MUST go through the kernel device (writes are mirrored
+// to peers via initial-sync); writing directly to the lower disk
+// would diverge from the kernel's view and corrupt the replica.
+// Mirrors the per-volume minor resolution buildVolumeResults uses
+// for the same fan-out.
+func drbdDevicesForMkfs(dr *intent.DesiredResource) map[int32]string {
+	minor, _ := strconv.Atoi(dr.GetDrbdOptions()["minor"])
+
+	out := make(map[int32]string, len(dr.GetVolumes()))
+	for _, vol := range dr.GetVolumes() {
+		out[vol.GetVolumeNumber()] = fmt.Sprintf("/dev/drbd%d", volMinorOrBase(vol, minor))
+	}
+
+	return out
+}
+
+// runStorageOnlyMkfs handles the auto-mkfs path for resources whose
+// layer stack omits DRBD (`layerList=storage`, the linstor-csi
+// "local" SC shape). For those there is no DRBD slot to promote and
+// no peer mirroring — writes land directly on the lower disk, so
+// mkfs targets the raw device path applyStorage produced. Skips
+// silently when (a) the resource is diskless (no lower disk to
+// format), (b) DRBD is in the stack (runAutoPromote already owns
+// the promote→mkfs→demote ordering), or (c) FileSystem/Type is
+// unset (no FS requested — pure block-mode PVC).
+//
+// linstor-csi v1.10.1's NodePublishVolume runs `fsck` then plain
+// `mount(2)` on the device — there is no FormatAndMount fallback
+// (see pkg/client/linstor.go lines 2287-2293). The satellite is the
+// only place a CSI-provisioned local PVC can get a filesystem
+// before the kubelet tries to mount it.
+func (r *Reconciler) runStorageOnlyMkfs(ctx context.Context, dr *intent.DesiredResource, diskless bool, devices map[int32]string) error {
+	if diskless {
+		return nil
+	}
+
+	if needsDRBD(dr.GetLayerStack()) {
+		return nil
+	}
+
+	if strings.TrimSpace(dr.GetProps()["FileSystem/Type"]) == "" {
+		return nil
+	}
+
+	return r.runAutoMkfs(ctx, dr, devices)
 }
 
 // runAutoMkfs handles the RG-driven auto-mkfs path of scenario
@@ -2961,7 +3028,15 @@ func (r *Reconciler) runAutoPromote(ctx context.Context, dr *intent.DesiredResou
 // together with `.res` / `.md-created` so a re-created RD with the
 // same name correctly mkfs-s again — the blkid probe sees an empty
 // (freshly-carved) volume and lets mkfs run.
-func (r *Reconciler) runAutoMkfs(ctx context.Context, dr *intent.DesiredResource) error {
+//
+// The devices parameter maps volNumber → device path mkfs should
+// target. DRBD-stacked callers pass `/dev/drbd<minor>` (mkfs MUST go
+// through the kernel so writes mirror to peers); storage-only
+// callers pass the raw LV/zvol/loopfile path applyStorage
+// produced. A volume missing from the map is silently skipped — the
+// only legitimate "missing" case is a diskless replica caller,
+// which has already been early-returned by runStorageOnlyMkfs.
+func (r *Reconciler) runAutoMkfs(ctx context.Context, dr *intent.DesiredResource, devices map[int32]string) error {
 	fsType := strings.TrimSpace(dr.GetProps()["FileSystem/Type"])
 	if fsType == "" {
 		return nil
@@ -3000,8 +3075,6 @@ func (r *Reconciler) runAutoMkfs(ctx context.Context, dr *intent.DesiredResource
 		return nil
 	}
 
-	minor, _ := strconv.Atoi(dr.GetDrbdOptions()["minor"])
-
 	args := []string{}
 
 	if extra := strings.TrimSpace(dr.GetProps()["FileSystem/MkfsParams"]); extra != "" {
@@ -3009,7 +3082,16 @@ func (r *Reconciler) runAutoMkfs(ctx context.Context, dr *intent.DesiredResource
 	}
 
 	for _, vol := range dr.GetVolumes() {
-		device := fmt.Sprintf("/dev/drbd%d", volMinorOrBase(vol, minor))
+		device := devices[vol.GetVolumeNumber()]
+		if device == "" {
+			// No device path for this volume → caller is a path that
+			// has nothing to mkfs (diskless replica, missing pickup).
+			// Storage-only callers always populate devices via
+			// applyStorage; DRBD callers always populate via
+			// drbdDevicesForMkfs. Skip rather than fail so this is a
+			// hot-path safety net, not a behavioural change.
+			continue
+		}
 
 		if r.deviceHasFilesystem(ctx, device) {
 			// Volume already carries a filesystem. Two cases land here:

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -6991,3 +6991,206 @@ func TestBug278NoClearWhenKernelStillDiskless(t *testing.T) {
 		t.Errorf("expected NO ClearSkipDisk calls when kernel is still Diskless; got %v", calls)
 	}
 }
+
+// TestApplyAutoMkfsStorageOnlyFormatsRawDevice pins the linstor-csi
+// "local" SC contract: a Resource whose LayerStack=["STORAGE"]
+// carries a `FileSystem/Type` prop (set by linstor-csi's
+// reconcileResourceDefinition on the RD, see pkg/client/linstor.go
+// lines 1602-1607 in linstor-csi v1.10.1) must get mkfs run on the
+// raw LV path before the kubelet's `fsck` reaches it. linstor-csi
+// v1.10.1's NodePublishVolume does `fsck` + plain `mount(2)` (no
+// FormatAndMount fallback — see pkg/client/linstor.go lines
+// 2287-2293), so satellite-side mkfs is the only place the filesystem
+// can land on a CSI-provisioned local PVC.
+//
+// Before Bug 311 follow-up: the auto-mkfs path was wired only inside
+// runAutoPromote → runAutoMkfs → and runAutoPromote ran exclusively
+// from applyDRBD. Storage-only resources bypassed applyDRBD entirely
+// (TestApplySkipsDRBDWhenLayerStackOmits proves the bypass), so
+// FileSystem/Type was silently ignored and the kubelet's fsck failed
+// with exit 8 (Bad magic number).
+func TestApplyAutoMkfsStorageOnlyFormatsRawDevice(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	// lvExists probe (lvcreate idempotency check).
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-local_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	// VolumeStatus query → must surface a non-empty DevicePath so the
+	// new storage-only mkfs path has something to format. Reports the
+	// LV path applyStorage records into the devices map.
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-local_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-local_00000|1048576\n")})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"data": thin},
+		Adm:       drbd.NewAdm(fx),
+		Exec:      fx,
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	dr := []*intent.DesiredResource{
+		{
+			Name:     "pvc-local",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "data"},
+			},
+			Props: map[string]string{
+				"FileSystem/Type": "ext4",
+			},
+			LayerStack:  []string{"STORAGE"},
+			DrbdOptions: map[string]string{},
+		},
+	}
+
+	_, err := rec.Apply(t.Context(), dr)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	lines := fx.CommandLines()
+
+	count := func(needle string) int {
+		n := 0
+
+		for _, line := range lines {
+			if strings.Contains(line, needle) {
+				n++
+			}
+		}
+
+		return n
+	}
+
+	if count("mkfs.ext4 /dev/vg/pvc-local_00000") != 1 {
+		t.Errorf("expected mkfs.ext4 against the raw LV path exactly once; got %v", lines)
+	}
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "drbdadm ") || strings.HasPrefix(line, "drbdsetup ") {
+			t.Errorf("storage-only stack must NOT touch DRBD; saw %q in %v", line, lines)
+		}
+	}
+
+	markerPath := filepath.Join(dir, "pvc-local.mkfs.done")
+	if _, statErr := os.Stat(markerPath); statErr != nil {
+		t.Errorf("mkfs.done marker: want present after storage-only apply, got stat err %v", statErr)
+	}
+
+	// Second apply: marker present → mkfs MUST NOT re-run (data-loss
+	// guard parity with the DRBD path).
+	fx.Reset()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-local_00000",
+		storage.FakeResponse{Stdout: []byte("pvc-local_00000\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-local_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-local_00000|1048576\n")})
+
+	_, err = rec.Apply(t.Context(), dr)
+	if err != nil {
+		t.Fatalf("Apply (2nd): %v", err)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "mkfs.") {
+			t.Errorf("idempotent reconcile must NOT re-run mkfs; saw %q", line)
+		}
+	}
+}
+
+// TestApplyAutoMkfsStorageOnlySkipsWithoutFileSystemType pins the
+// pure block-mode contract: a storage-only Resource without
+// `FileSystem/Type` (raw-block PVC, the linstor-csi default for
+// `volumeMode: Block`) must not get mkfs run on its lower disk —
+// the consumer Pod opens the device directly and any filesystem
+// header would corrupt its on-disk layout.
+func TestApplyAutoMkfsStorageOnlySkipsWithoutFileSystemType(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-block_00000",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-block_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-block_00000|1048576\n")})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"data": thin},
+		Adm:       drbd.NewAdm(fx),
+		Exec:      fx,
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-block",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "data"},
+			},
+			LayerStack:  []string{"STORAGE"},
+			DrbdOptions: map[string]string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "mkfs.") {
+			t.Errorf("no FileSystem/Type on a block-mode storage-only RD → no mkfs expected; saw %q", line)
+		}
+	}
+
+	markerPath := filepath.Join(dir, "pvc-block.mkfs.done")
+	if _, statErr := os.Stat(markerPath); statErr == nil {
+		t.Errorf("mkfs.done marker: want absent for block-mode storage-only, got present at %s", markerPath)
+	}
+}
+
+// TestApplyAutoMkfsStorageOnlySkipsDisklessReplica pins the diskless
+// guard for the storage-only path. A diskless replica with
+// LayerStack=["STORAGE"] is a degenerate config — applyStorageIfDiskful
+// returns an empty devices map without provisioning anything, and
+// the new runStorageOnlyMkfs early-return for diskless ensures we
+// don't attempt to mkfs a nonexistent device path. Mirrors the
+// DRBD-path TestApplyAutoMkfsSkipsDisklessReplica contract.
+func TestApplyAutoMkfsStorageOnlySkipsDisklessReplica(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{},
+		Adm:       drbd.NewAdm(fx),
+		Exec:      fx,
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-diskless-local",
+			NodeName: "n1",
+			Flags:    []string{"DISKLESS"},
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "data"},
+			},
+			Props: map[string]string{
+				"FileSystem/Type": "ext4",
+			},
+			LayerStack:  []string{"STORAGE"},
+			DrbdOptions: map[string]string{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.HasPrefix(line, "mkfs.") {
+			t.Errorf("DISKLESS storage-only replica must skip mkfs; saw %q", line)
+		}
+	}
+}

--- a/tests/e2e/csi-pvc-local.sh
+++ b/tests/e2e/csi-pvc-local.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# usage: csi-pvc-local.sh WORK_DIR
+#
+# linstor-csi v1.10.1 auto-mkfs contract — "local" StorageClass shape.
+#
+# Reproduces the production demo SC the user runs on the dev stand:
+#
+#     parameters:
+#       linstor.csi.linbit.com/storagePool: "data"
+#       linstor.csi.linbit.com/layerList: "storage"
+#       linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+#     volumeBindingMode: WaitForFirstConsumer
+#
+# Before the satellite-side auto-mkfs lift in this PR, a PVC bound to
+# such an SC reached NodePublishVolume with an unformatted LV — the
+# linstor-csi v1.10.1 mount path runs `fsck` then plain `mount(2)`
+# (pkg/client/linstor.go lines 2287-2293; there is no FormatAndMount
+# fallback) so the kubelet's fsck rejected the volume with exit 8
+# ("Bad magic number"). The fix routes storage-only RDs through the
+# same `runAutoMkfs` path the DRBD-stacked path has owned since the
+# Bug 311 follow-up.
+#
+# Stand pool overlap: the demo SC names pool `data`; the QEMU stand's
+# install-pools.sh registers `lvm-thin`. We `sed` the pool name at
+# apply time rather than altering the demo SC text — the SC body is
+# the load-bearing contract, the pool name is a stand-only override.
+#
+# Steps:
+#   1. apply the SC verbatim (with pool name override).
+#   2. PVC 128Mi RWO + busybox pod on WORKER_1; volumeBindingMode is
+#      WaitForFirstConsumer, so the SC requires a consumer pod to
+#      trigger provisioning — the pod scheduling is what makes the
+#      CreateVolume call fire.
+#   3. wait Pod Ready (proves NodePublishVolume succeeded, i.e. fsck
+#      saw a real filesystem on the LV).
+#   4. write a marker file, restart the pod (delete + recreate so the
+#      kubelet re-mounts), read the marker back.
+#   5. cleanup is handled by `register_strict_cleanup` for the RD
+#      linstor-csi created; the SC/PVC/Pod are deleted in the local
+#      EXIT trap.
+#
+# No skip / no xfail. Failure = `exit 1` with diagnostics.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 1
+
+SC=e2e-csi-local
+PVC=e2e-csi-local-pvc
+POD=e2e-csi-local-pod
+
+# Stand-only pool rename: the demo SC says `data`; the QEMU stand
+# registers `lvm-thin`. Keep the SC body identical to the demo
+# contract and override the pool name at apply time.
+POOL=${POOL:-lvm-thin}
+
+# We don't know the linstor-csi-generated RD name (`pvc-<uuid>`) up
+# front; capture it after PVC Bound and register_strict_cleanup it.
+# Until then, do a best-effort SC/PVC/Pod sweep on EXIT.
+local_cleanup() {
+    kubectl delete pod "$POD" --ignore-not-found --wait=false 2>/dev/null || true
+    kubectl delete pvc "$PVC" --ignore-not-found --wait=false 2>/dev/null || true
+    kubectl delete sc "$SC" --ignore-not-found 2>/dev/null || true
+}
+trap local_cleanup EXIT
+
+dump_diag() {
+    local label=$1
+    echo "----- diag ($label): describe pvc $PVC -----" >&2
+    kubectl describe pvc "$PVC" 2>&1 | tail -40 >&2 || true
+    echo "----- diag ($label): describe pod $POD -----" >&2
+    kubectl describe pod "$POD" 2>&1 | tail -40 >&2 || true
+    echo "----- diag ($label): linstor-csi-controller log tail -----" >&2
+    kubectl -n piraeus-datastore logs deploy/linstor-csi-controller \
+        -c linstor-csi --tail=80 2>&1 >&2 || true
+    echo "----- diag ($label): linstor-csi-node logs -----" >&2
+    kubectl -n piraeus-datastore logs ds/linstor-csi-node \
+        -c linstor-csi --tail=80 --prefix=true 2>&1 >&2 || true
+    echo "----- diag ($label): linstor r l (via blockstor apiserver) -----" >&2
+    kubectl -n blockstor-system exec deploy/blockstor-apiserver -- \
+        linstor r l 2>&1 >&2 || true
+    echo "----- diag ($label): linstor v l (via blockstor apiserver) -----" >&2
+    kubectl -n blockstor-system exec deploy/blockstor-apiserver -- \
+        linstor v l 2>&1 >&2 || true
+}
+
+echo ">> apply the demo 'local' SC verbatim (pool=$POOL override for stand)"
+# The demo SC body — keep edits to the SC contract minimal so a future
+# change to the user-facing shape catches a regression here too.
+cat <<EOF | sed "s/storagePool: \"data\"/storagePool: \"$POOL\"/" | kubectl apply -f -
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: $SC
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: "data"
+  linstor.csi.linbit.com/layerList: "storage"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+EOF
+
+echo ">> PVC 128Mi RWO (volumeBindingMode=WaitForFirstConsumer → not provisioned until Pod schedules)"
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: $PVC}
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: $SC
+  resources:
+    requests: {storage: 128Mi}
+EOF
+
+echo ">> busybox Pod on $WORKER_1 (triggers CreateVolume + NodePublishVolume)"
+# securityContext fields satisfy the PodSecurity 'restricted' profile
+# Talos enforces by default. fsGroup=1000 chowns the mounted ext4
+# filesystem so the non-root UID can write the marker; without it the
+# `echo > /data/marker` fails with EACCES.
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata: {name: $POD}
+spec:
+  nodeName: $WORKER_1
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile: {type: RuntimeDefault}
+  containers:
+    - name: w
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities: {drop: [ALL]}
+      volumeMounts:
+        - {name: data, mountPath: /data}
+  volumes:
+    - name: data
+      persistentVolumeClaim: {claimName: $PVC}
+EOF
+
+# Pod Ready proves NodePublishVolume completed, which proves the
+# kubelet's fsck did NOT trip on an unformatted device (the original
+# symptom). Generous 240s budget to absorb stand-side delays.
+echo ">> wait Pod Ready (240s)"
+if ! kubectl wait --for=condition=Ready --timeout=240s pod/"$POD"; then
+    echo "FAIL: Pod $POD never reached Ready — likely NodePublishVolume fsck exit 8 (no FS on device)" >&2
+    dump_diag "wait-ready"
+    exit 1
+fi
+
+PV=$(kubectl get pvc "$PVC" -o jsonpath='{.spec.volumeName}')
+echo "   PVC bound → PV=$PV (= linstor RD name)"
+
+# Now that we know the RD name, hand it to strict_cleanup_on_exit so
+# the next scenario inherits a clean cluster.
+register_strict_cleanup "$PV"
+
+MARK="local-$(date +%s)-$$"
+echo ">> write marker '$MARK' to /data/marker, sync"
+if ! kubectl exec "$POD" -- sh -c "echo $MARK > /data/marker && sync"; then
+    echo "FAIL: cannot write to /data — auto-mkfs likely produced a broken FS" >&2
+    dump_diag "write-marker"
+    exit 1
+fi
+
+echo ">> delete + recreate Pod (proves marker persists across remount)"
+kubectl delete pod "$POD" --wait=true --timeout=120s
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata: {name: $POD}
+spec:
+  nodeName: $WORKER_1
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile: {type: RuntimeDefault}
+  containers:
+    - name: w
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 600"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities: {drop: [ALL]}
+      volumeMounts:
+        - {name: data, mountPath: /data}
+  volumes:
+    - name: data
+      persistentVolumeClaim: {claimName: $PVC}
+EOF
+
+if ! kubectl wait --for=condition=Ready --timeout=240s pod/"$POD"; then
+    echo "FAIL: Pod $POD did not become Ready on remount" >&2
+    dump_diag "wait-remount"
+    exit 1
+fi
+
+got=$(kubectl exec "$POD" -- cat /data/marker 2>&1 || true)
+if [[ "$got" != "$MARK" ]]; then
+    echo "FAIL: marker round-trip mismatch — got '$got', want '$MARK'" >&2
+    dump_diag "read-marker"
+    exit 1
+fi
+
+echo ">> CSI-PVC-LOCAL OK (PV=$PV, marker '$MARK' survived Pod remount, layerList=storage)"

--- a/tests/e2e/csi-pvc-replicated-rwo.sh
+++ b/tests/e2e/csi-pvc-replicated-rwo.sh
@@ -89,8 +89,17 @@ kubectl -n blockstor-system port-forward deploy/blockstor-apiserver "$PF_PORT":3
 PF_PID=$!
 
 local_cleanup() {
-    kubectl delete pod "$POD" --ignore-not-found --wait=false 2>/dev/null || true
-    kubectl delete pvc "$PVC" --ignore-not-found --wait=false 2>/dev/null || true
+    # Delete Pod synchronously so kubelet finishes NodeUnpublishVolume +
+    # ControllerUnpublishVolume BEFORE the PVC delete triggers
+    # linstor-csi DeleteVolume. Without this ordering, pv-controller
+    # keeps retrying ControllerPublishVolume on the deleted volume
+    # into the next scenario's run window (observed on the piraeus
+    # interop lane: `volume not present in storage backend` retries
+    # every 60s monopolised linstor-csi-node and starved the next
+    # csi-pvc-local PVC's NodePublishVolume past its 240s Pod-Ready
+    # budget).
+    kubectl delete pod "$POD" --ignore-not-found --wait=true --timeout=60s 2>/dev/null || true
+    kubectl delete pvc "$PVC" --ignore-not-found --wait=true --timeout=60s 2>/dev/null || true
     kubectl delete sc "$SC" --ignore-not-found 2>/dev/null || true
     kill "$PF_PID" 2>/dev/null || true
     wait "$PF_PID" 2>/dev/null || true

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -773,7 +773,33 @@ reset_cluster_state() {
         ' 2>/dev/null || true
     done
 
-    echo ">> reset_cluster_state: done $(date -Iseconds) (delete_all_rds rc=$rc)"
+    # 6. Wait for the satellite DaemonSet to converge before handing
+    #    control to the next scenario. state-offline-unknown and other
+    #    partition scenarios mutate the DS template (nodeAffinity
+    #    rejecting a worker label) and force-delete the Pod on that
+    #    worker; their EXIT cleanup reverts the template but does not
+    #    always wait for the DS controller to spawn the replacement
+    #    Pod into Ready. Without this barrier the next scenario's
+    #    `require_workers` preflight can race the DS reconciliation
+    #    and SKIP with a "previous-test cascade" message (e.g.
+    #    state-offline-unknown → toggle-disk in ci-lane3 alphabetical
+    #    order). 90s is generous: a fresh satellite Pod typically
+    #    reaches Ready within 10s; we mostly cover the window between
+    #    DS-template-revert and DS-controller noticing it.
+    local ds_deadline=$(( $(date +%s) + 90 ))
+    local ds_desired ds_ready
+    while (( $(date +%s) < ds_deadline )); do
+        ds_desired=$(kubectl -n "$NS" get ds blockstor-satellite \
+            -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
+        ds_ready=$(kubectl -n "$NS" get ds blockstor-satellite \
+            -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+        if [[ -n "$ds_desired" ]] && (( ds_desired > 0 )) && (( ds_desired == ds_ready )); then
+            break
+        fi
+        sleep 2
+    done
+
+    echo ">> reset_cluster_state: done $(date -Iseconds) (delete_all_rds rc=$rc, ds_ready=${ds_ready:-?}/${ds_desired:-?})"
     return $rc
 }
 


### PR DESCRIPTION
## Summary
Restores commit 8b4834709 (reverted in 218d94c49 ahead of v0.1.2 over an unreproduced piraeus-interop observation) so storage-only PVCs — `layerList=storage`, the linstor-csi "local" SC shape — get a satellite-side filesystem before kubelet's fsck reaches the device.

## Why this is the satellite's job

linstor-csi v1.10.1 ([`pkg/client/linstor.go`](https://github.com/piraeusdatastore/linstor-csi/blob/v1.10.1/pkg/client/linstor.go)) explicitly does NOT mkfs anywhere:

- `reconcileResourceDefinition` (line 1583) only **stamps** `FileSystem/Type` + `FileSystem/MkfsParams` as RD props (line 1602-1607).
- `NodePublishVolume` (line 2278-2297) runs `utils.Fsck(ctx, source)` then `s.mounter.MountSensitiveWithoutSystemdWithMountFlags(...)` — `mount-utils.Mount`, not `FormatAndMount`.
- The whole 2665-line file contains zero references to `FormatAndMount`, `NodeStageVolume`, or `safeFormatAndMount`.

The contract: the storage server (LINSTOR/blockstor satellite) owns mkfs. For DRBD-stacked RDs blockstor already honours this via `runAutoPromote → runAutoMkfs` (mkfs on `/dev/drbd<minor>` so the write mirrors to peers). Storage-only RDs bypass `applyDRBD` entirely, so the satellite carved the LV/zvol and handed it to kubelet unformatted — kubelet's fsck then rejected the empty device with exit 8 ("Bad magic number") and the Pod hung in `ContainerCreating`.

## What changed (same as the original commit)

- `runAutoMkfs` is parameterised with a `devices map[int32]string` the caller builds.
  - DRBD callers pass `/dev/drbd<minor>` via `drbdDevicesForMkfs` (mkfs MUST go through the kernel device so writes mirror to peers).
  - Storage-only callers pass the raw LV/zvol/loopfile path `applyStorage` produced.
- New `runStorageOnlyMkfs` thin wrapper: early-returns for diskless replicas, for DRBD-stacked RDs (DRBD path keeps owning promote→mkfs→demote), and when `FileSystem/Type` is empty (raw-block PVC).
- `applyOne` calls `runStorageOnlyMkfs` in the `!withDRBD` arm.

Marker file `.mkfs.done`, blkid double-mkfs guard, `FilesystemFormatted` Condition stamper, and `DeleteResource` cleanup — all reused unchanged. DRBD path is byte-identical except for the threaded `devices` arg.

## Live validation on dev stand (150.136.95.115)

- Rolled the satellite DaemonSet to the cherry-pick image. Both `demo-local` / `demo-local2` PVCs (stuck for 75m+ in ContainerCreating without this fix) reached Pod Running within 60s.
- Deleted `demo-local2` PVC + Pod end-to-end. PVC + PV + RD + Resources removed cleanly within 30s. No DeleteVolume loop observed.
- DRBD-replicated PVCs (`demo-rwx-a/b`) unchanged (Running before and after).

## Pending verification

The original revert reason was a DeleteVolume loop on a piraeus-interop stand; the dev stand runs blockstor + linstor-csi WITHOUT a co-resident piraeus-operator, so that scenario is not reproducible here. CI's `e2e-piraeus` job is the next gate before this leaves draft.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/satellite/... -run TestApplyAutoMkfs` — 3 new tests pass alongside the existing 11 DRBD-path mkfs tests
- [x] Live on dev stand: storage-only Pod reaches Running, clean delete
- [ ] CI `e2e-piraeus` job passes (the gate that motivated the revert)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated API endpoint for single-node resource creation.

* **Bug Fixes**
  * Auto-mkfs now correctly formats raw devices for storage-only resources.

* **Tests**
  * Added end-to-end tests for local StorageClass PVC provisioning.
  * Improved test cleanup synchronization and satellite DaemonSet convergence checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->