### PR TITLE
fix(stand): up.sh for talosctl 1.13 CLI + dodge /24 slots that overlap k8s service CIDR

### DIFF
--- a/stand/up.sh
+++ b/stand/up.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # usage: up.sh NAME CONTROLPLANES WORKERS EXTENSIONS WORK_DIR
-# Brings up a Talos cluster on QEMU/KVM. When EXTENSIONS is set, uses Talos
-# Image Factory to obtain a kernel+initramfs with those extensions baked in
-# and boots the VMs from those artifacts.
+# Brings up a Talos cluster on QEMU/KVM via `talosctl cluster create qemu`.
+# When EXTENSIONS is set we register a Talos Image Factory schematic with
+# those extensions and pass the resulting id as `--schematic-id`, so the
+# factory ISO the cluster boots from has the DRBD/ZFS bits baked in.
 set -euo pipefail
 
 NAME=${1:?cluster name required}
@@ -84,21 +85,17 @@ else
     BOOT_DIR="$SCHEMATIC_DIR/vanilla-$TALOS_VERSION-$ARCH"
 fi
 
+# Pre-1.13 `talosctl cluster create --provisioner qemu` consumed
+# `--vmlinuz-path`/`--initrd-path` directly, so up.sh used to fetch the
+# kernel + initramfs into $BOOT_DIR. In 1.13 the deprecation shim
+# behind `--provisioner qemu` no longer wires PKI SANs correctly and
+# the bootstrap RPC fails cert verification on the controlplane IP.
+# The replacement `talosctl cluster create qemu` subcommand handles
+# boot-artifact retrieval itself via `--presets iso --schematic-id <id>`
+# (pulls an ISO from the Image Factory) so the local kernel cache is
+# no longer needed. $BOOT_DIR is still created as a sentinel for
+# cleanup logic but stays empty.
 mkdir -p "$BOOT_DIR"
-VMLINUZ="$BOOT_DIR/vmlinuz"
-INITRD="$BOOT_DIR/initramfs.xz"
-INSTALLER_IMG="$BOOT_DIR/installer.tar"
-
-if [[ ! -s "$VMLINUZ" || ! -s "$INITRD" ]]; then
-    if [[ -n "$SCHEMATIC_ID" ]]; then
-        BASE="https://factory.talos.dev/image/$SCHEMATIC_ID/$TALOS_VERSION"
-    else
-        BASE="https://github.com/siderolabs/talos/releases/download/$TALOS_VERSION"
-    fi
-    echo ">> downloading kernel/initramfs from $BASE"
-    curl -fL "$BASE/kernel-$ARCH"        -o "$VMLINUZ"
-    curl -fL "$BASE/initramfs-$ARCH.xz"  -o "$INITRD"
-fi
 
 # Per-cluster CIDR offset to avoid collisions when running parallel stands.
 HASH=$(echo -n "$NAME" | sha256sum | cut -c1-2)
@@ -115,9 +112,9 @@ echo ">> preflight cleanup for '$NAME'"
 sudo bash "$(dirname "$0")/down.sh" "$NAME" "$WORK_DIR" >/dev/null 2>&1 || true
 mkdir -p "$STATE_DIR"
 
-# Talos qemu provisioner uses --vmlinuz-path/--initrd-path only for *boot*; the
-# on-disk install uses ghcr.io/siderolabs/installer:* by default, which lacks
-# our extensions. Override machine.install.image to the same factory schematic
+# The factory ISO carries our extensions for *boot*; the on-disk
+# install uses ghcr.io/siderolabs/installer:* by default, which lacks
+# them. Override machine.install.image to the same factory schematic
 # so the installed Talos has DRBD bits, and tell it to load the modules.
 if [[ -n "$SCHEMATIC_ID" ]]; then
     INSTALL_IMG="factory.talos.dev/installer/$SCHEMATIC_ID:$TALOS_VERSION"
@@ -158,29 +155,51 @@ machine:
         skipFallback: true
 YAML
 
+# Build the `--disks` list: first disk is the boot disk (20 GiB), the
+# rest are EXTRA_DISKS data disks at EXTRA_DISK_SIZE_GB each. The new
+# subcommand expects a single comma-separated `<driver>:<size>` list
+# instead of the old `--disk`/`--extra-disks`/`--extra-disks-size`
+# triple.
+# Backward compat: legacy `EXTRA_DISK_SIZE_MB` (MiB, e.g. 16384 = 16 GiB)
+# wins if set so stand/ci-e2e.sh keeps working unchanged.
+if [[ -n "${EXTRA_DISK_SIZE_MB:-}" ]]; then
+    EXTRA_DISK_SIZE_GB=$(( EXTRA_DISK_SIZE_MB / 1024 ))
+fi
+EXTRA_DISK_SIZE_GB=${EXTRA_DISK_SIZE_GB:-16}
+DISKS="virtio:20GiB"
+for _ in $(seq 1 ${EXTRA_DISKS:-2}); do
+    DISKS="$DISKS,virtio:${EXTRA_DISK_SIZE_GB}GiB"
+done
+
 echo ">> creating cluster '$NAME' (CP=$CONTROLPLANES, workers=$WORKERS, net=$NET_CIDR)"
-# talos qemu provisioner needs root for CNI bridge / netfilter; run via sudo -E
-# and fix ownership afterwards so the user can read configs.
-sudo -E "$TALOSCTL" cluster create \
+# 1.13 `cluster create qemu` subcommand: presets ISO + factory
+# schematic id give us a DRBD/ZFS-extension boot. Flag renames vs
+# the legacy `cluster create --provisioner qemu` path:
+#   --provisioner qemu        → (now the subcommand)
+#   --vmlinuz-path/--initrd-path → --presets iso (factory ISO download)
+#   --talosconfig             → --talosconfig-destination
+#   --memory                  → --memory-controlplanes
+#   --cpus                    → --cpus-controlplanes
+#   --disk + --extra-disks*   → --disks "<driver>:<size>,..."
+# `--wait` is implicit on the new subcommand. Run via `sudo -E`
+# because the qemu provisioner still needs root for CNI / netfilter.
+sudo -E "$TALOSCTL" cluster create qemu \
     --name "$NAME" \
-    --provisioner qemu \
     --state "$STATE_DIR" \
+    --presets iso \
+    --schematic-id "$SCHEMATIC_ID" \
+    --talos-version "$TALOS_VERSION" \
+    --talosconfig-destination "$TALOSCONFIG" \
     --controlplanes "$CONTROLPLANES" \
     --workers "$WORKERS" \
     --cidr "$NET_CIDR" \
-    --vmlinuz-path "$VMLINUZ" \
-    --initrd-path "$INITRD" \
-    --talosconfig "$TALOSCONFIG" \
     --kubernetes-version "${KUBERNETES_VERSION:-v1.34.1}" \
     --config-patch "@$PATCH_FILE" \
-    --memory 4096 \
+    --memory-controlplanes 4096 \
     --memory-workers 4096 \
-    --cpus 2 \
-    --cpus-workers 2 \
-    --disk 20480 \
-    --extra-disks ${EXTRA_DISKS:-2} \
-    --extra-disks-size ${EXTRA_DISK_SIZE_MB:-16384} \
-    --wait
+    --cpus-controlplanes 2.0 \
+    --cpus-workers 2.0 \
+    --disks "$DISKS"
 
 # `chown -R` does not follow a top-level symlink, so when WORK_DIR is
 # a symlink (the dev stand redirects `.work/<name>` →

--- a/stand/up.sh
+++ b/stand/up.sh
@@ -98,8 +98,20 @@ fi
 mkdir -p "$BOOT_DIR"
 
 # Per-cluster CIDR offset to avoid collisions when running parallel stands.
+# Talos's default Kubernetes service CIDR is 10.96.0.0/12 (covers
+# 10.96.0.0 – 10.111.255.255). If our slot lands inside that range,
+# the controlplane's own bridge IP overlaps with the service-IP pool,
+# Talos's `address-overlap` diagnostic fires, and apid refuses to put
+# the IP into its API server cert SANs — so bootstrap fails with
+# `cannot validate certificate for 10.X.0.2 because it doesn't
+# contain any IP SANs`. Skip slots 96..111 to dodge the collision.
 HASH=$(echo -n "$NAME" | sha256sum | cut -c1-2)
-SLOT=$((16#$HASH % 200 + 5))
+RAW_SLOT=$((16#$HASH % 200 + 5))
+if [[ $RAW_SLOT -ge 96 && $RAW_SLOT -le 111 ]]; then
+    SLOT=$(( RAW_SLOT - 16 ))
+else
+    SLOT=$RAW_SLOT
+fi
 NET_CIDR="10.${SLOT}.0.0/24"
 
 STATE_DIR="$WORK_DIR/talos-state"


### PR DESCRIPTION
## Summary

Two interlocked fixes to `stand/up.sh` validated end-to-end on `linstor-dev-1`:

### 1. Rewrite for the `talosctl cluster create qemu` subcommand

The legacy `talosctl cluster create --provisioner qemu ...` invocation is now a deprecation shim in 1.13 and will be removed in 1.14. Switched to the dedicated `cluster create qemu` subcommand: presets ISO + factory `--schematic-id`, `--talosconfig-destination` instead of `--talosconfig`, `--memory-controlplanes` / `--cpus-controlplanes` instead of `--memory` / `--cpus`, and the single `--disks "<driver>:<size>,..."` list instead of `--disk` + `--extra-disks` + `--extra-disks-size`. The local kernel+initramfs download in `$BOOT_DIR` is no longer needed — the new subcommand pulls the ISO itself from the Image Factory. Legacy `EXTRA_DISK_SIZE_MB` env (used by `stand/ci-e2e.sh`) is converted to GiB for backward compatibility.

### 2. Skip `/24` slots that overlap the Kubernetes service CIDR

Talos's default Kubernetes service CIDR is `10.96.0.0/12` (covers `10.96.0.0`–`10.111.255.255`). The slot allocator maps a hashed cluster name onto `10.<slot>.0.0/24` with slot ∈ [5, 204], so any name whose first SHA-256 byte mod-200 lands in [96, 111] puts the bridge gateway inside the service-IP pool. When that happens Talos's `address-overlap` diagnostic fires and `apid` refuses to add the controlplane IP to its API server cert SANs — so `talosctl` bootstrap dies with `cannot validate certificate for 10.X.0.2 because it doesn't contain any IP SANs` and the cluster wedges in maintenance mode. Hit empirically on `NAME=v013` (slot 101 = `10.101.0.0/24`). Fix shifts offending slots down by 16.

## Validation

Full DRBD smoke on `linstor-dev-1` against blockstor `v0.1.3`:

- `make up NAME=smoke` (slot 9 → `10.9.0.0/24`) — 4 nodes Ready
- `make blockstor && make pools TYPE=both && make piraeus` — controller + 3 apiserver + 3 satellite + linstor-csi + piraeus-operator all Running
- `replicated` StorageClass (3 DRBD replicas on ZFS-thin): PVC bound, writer pod on `worker-2` wrote `DRBD_v013_OK`, delete writer → reader pod pinned to `worker-1` read back the same marker (cross-node DRBD replication verified)
- `local` StorageClass (storage-only, no DRBD): PVC bound, pod Ready, ext4 auto-mkfs OK (validates PR #37); RD shows `layerStack: [STORAGE]` (DRBD-less)
- Namespace cascade delete: 0 orphan RDs / Resources / PVs (validates PR #36 collapse-grace)

## Test plan

- [x] `make up NAME=smoke` succeeds end-to-end on a fresh Oracle host
- [x] `stand/ci-e2e.sh` keeps working via the legacy `EXTRA_DISK_SIZE_MB` env (backward-compatible conversion)
- [x] Live DRBD cross-node write/read smoke passes against v0.1.3 GHCR-published images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster provisioning to use the latest Talos 1.13+ command flow
  * Revised CIDR slot allocation to prevent service CIDR conflicts
  * Simplified disk configuration handling with updated flag mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->