### PR TITLE
feat(rest): wire /v1/events/drbd/promotion and /v1/events/nodes

### DIFF
--- a/pkg/api/v1/events.go
+++ b/pkg/api/v1/events.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+// EventMayPromoteChange is the JSON payload of a single
+// `may-promote-change` SSE event on `/v1/events/drbd/promotion`. The
+// wire shape matches golinstor's `client.EventMayPromoteChange` so the
+// canonical Go client unmarshals it without translation.
+//
+// MayPromote tracks the DRBD `may_promote` flag on a per-(resource,
+// node) tuple — the same signal `linstor r l` surfaces as the "Promote"
+// column. ha-controller subscribes to this stream to drive failover
+// decisions: when MayPromote transitions to false on the currently-
+// active node, the controller looks for a peer with MayPromote == true
+// and shifts the workload there.
+type EventMayPromoteChange struct {
+	ResourceName string `json:"resource_name,omitempty"`
+	NodeName     string `json:"node_name,omitempty"`
+	MayPromote   bool   `json:"may_promote,omitempty"`
+}
+
+// EventNodeChange is the JSON payload of a single `node-change` SSE
+// event on `/v1/events/nodes`. Upstream LINSTOR ships this as a free-
+// form event whose shape varies across minor versions; the field set
+// here mirrors what `linstor node list -w` surfaces today and what
+// piraeus-affinity-controller actually consumes.
+//
+// ConnectionStatus uses the same enum upstream populates on the Node
+// read-side ("ONLINE", "OFFLINE", "EVICTED", "STANDBY", "VERSION_
+// MISMATCH", "OTHER_CONTROLLER", "AUTHENTICATION_ERROR", "FULL_SYNC_
+// FAILED", "HOSTNAME_MISMATCH", "NO_STLT_CONN", "UNKNOWN"). Consumers
+// compare values literally; we pass through whatever the controller
+// publishes.
+type EventNodeChange struct {
+	NodeName         string `json:"node_name,omitempty"`
+	ConnectionStatus string `json:"connection_status,omitempty"`
+}

--- a/pkg/events/broker.go
+++ b/pkg/events/broker.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package events implements a tiny in-process pub-sub broker used by the
+// REST event-stream endpoints (`/v1/events/drbd/promotion`,
+// `/v1/events/nodes`). It exists because blockstor has no controller-
+// side observer that already exposes typed event channels for DRBD role
+// transitions / node connection-state changes, and the REST layer needs
+// SOMETHING to fan out to long-lived SSE subscribers.
+//
+// The Broker is deliberately minimal:
+//
+//   - generic over the payload type so the DRBD-promotion broker and the
+//     node-state broker share one implementation;
+//   - assigns a strictly-increasing eventId on Publish so SSE clients
+//     can resume from `Last-Event-ID`;
+//   - keeps a bounded backlog of the most-recent events (so a resume
+//     within the backlog window replays missed events; outside the
+//     window the client gets the live tail with a one-line gap);
+//   - subscribers receive on a per-subscriber buffered channel; a slow
+//     subscriber that fills its buffer is dropped (a fresh, lossy SSE
+//     stream is the standard recovery — the client reconnects);
+//   - Subscribe is canceled by ctx (the REST handler passes
+//     `r.Context()`); on cancel the goroutine exits cleanly and the
+//     subscription is removed from the broker.
+//
+// The package is intentionally free of REST / DRBD-specific knowledge —
+// it is a generic fan-out primitive. The wire-shape decisions
+// (event names, JSON tags) live in `pkg/rest/events.go`.
+package events
+
+import (
+	"context"
+	"sync"
+)
+
+// backlogCap is the per-broker history depth. A long-poll client
+// reconnecting within this window can resume cleanly via
+// Last-Event-ID; a longer gap means the client sees the live tail with
+// a one-line gap and is expected to reconcile via the snapshot APIs
+// (the same fallback golinstor's reference EventService uses).
+//
+// 256 is enough to ride out a 30-second client retry on a busy cluster
+// (a few thousand promotion / node-state events per minute is well
+// beyond what blockstor can realistically generate — DRBD role
+// transitions are operator-scale events, not microsecond-scale events).
+const backlogCap = 256
+
+// subscriberBuf is the per-subscriber channel depth. A subscriber that
+// can't drain this many events between Publishes is dropped — a fresh,
+// lossy SSE stream is the contract: the client reconnects with the last
+// id it saw and the backlog replay covers the gap (when in-window).
+const subscriberBuf = 64
+
+// Event wraps a payload with its monotonically-increasing broker-side
+// id. The id is the SSE `id:` field on the wire and the resume token a
+// client sends back as `Last-Event-ID` (or `?eventId=`). Brokers reset
+// their id sequence to 0 on construction, so ids are unique within a
+// broker instance — across a controller restart the client sees a
+// renumbering, which is the same behaviour upstream LINSTOR ships.
+type Event[T any] struct {
+	ID      uint64
+	Payload T
+}
+
+// Broker is a single-broker pub-sub fan-out for events of type T. The
+// zero value is NOT ready to use; call NewBroker.
+type Broker[T any] struct {
+	mu     sync.Mutex
+	nextID uint64
+	// ring is a fixed-size backlog of the most-recent events. ring[i]
+	// holds the (i mod backlogCap)-th slot; we look up by id by
+	// scanning the slice (length capped at backlogCap, so a linear
+	// scan is fine).
+	ring []Event[T]
+	// subs is the active subscription set. Map key is a per-broker
+	// monotonic handle; value is the per-subscriber channel.
+	subs   map[uint64]chan Event[T]
+	nextHS uint64
+}
+
+// NewBroker constructs an empty Broker ready for Publish / Subscribe.
+func NewBroker[T any]() *Broker[T] {
+	return &Broker[T]{
+		ring: make([]Event[T], 0, backlogCap),
+		subs: map[uint64]chan Event[T]{},
+	}
+}
+
+// Publish fans the payload out to every live subscriber and appends it
+// to the backlog ring. Returns the assigned event id so callers that
+// want to log "published event 42" can correlate with what subscribers
+// see.
+//
+// Slow-subscriber semantics: if a subscriber's channel is full at the
+// moment of publish, the broker DROPS that subscriber — it closes the
+// channel and removes it from the active set. The client will see the
+// stream close at the SSE wire and reconnect; resume is best-effort
+// via Last-Event-ID.
+func (b *Broker[T]) Publish(payload T) uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.nextID++
+	ev := Event[T]{ID: b.nextID, Payload: payload}
+
+	// Append to backlog (bounded).
+	if len(b.ring) < backlogCap {
+		b.ring = append(b.ring, ev)
+	} else {
+		// Drop oldest, append newest.
+		copy(b.ring, b.ring[1:])
+		b.ring[len(b.ring)-1] = ev
+	}
+
+	// Fan out. A blocked send means the subscriber is too slow to
+	// keep up with the live tail; drop them.
+	for handle, ch := range b.subs {
+		select {
+		case ch <- ev:
+		default:
+			close(ch)
+			delete(b.subs, handle)
+		}
+	}
+
+	return ev.ID
+}
+
+// Subscription is the live read-side of a Subscribe call.
+type Subscription[T any] struct {
+	// Events is closed when the subscription ends (context cancel or
+	// slow-subscriber drop). Receivers should treat a closed channel
+	// as "stream ended; reconnect".
+	Events <-chan Event[T]
+	// Replay holds events with id > lastSeen that were in the broker's
+	// backlog at Subscribe time. The handler should flush these to
+	// the wire BEFORE draining Events so the client sees a contiguous
+	// stream. May be empty.
+	Replay []Event[T]
+}
+
+// Subscribe registers a new subscriber and returns the immediately-
+// available backlog (events with id > lastSeen) plus a channel for
+// future events. The subscription is bound to ctx — when ctx is
+// cancelled (e.g. the SSE client disconnects) the goroutine exits and
+// the channel is closed.
+//
+// lastSeen == 0 means "no resume requested" — the subscriber gets only
+// future events with no backlog. A non-zero lastSeen returns every
+// backlog entry with id strictly greater than lastSeen; if the backlog
+// no longer covers lastSeen (the client was disconnected too long), the
+// returned Replay starts at the oldest still-buffered event and the
+// caller is expected to surface the gap to the client.
+func (b *Broker[T]) Subscribe(ctx context.Context, lastSeen uint64) Subscription[T] {
+	b.mu.Lock()
+
+	handle := b.nextHS
+	b.nextHS++
+
+	ch := make(chan Event[T], subscriberBuf)
+	b.subs[handle] = ch
+
+	var replay []Event[T]
+
+	for i := range b.ring {
+		if b.ring[i].ID > lastSeen {
+			replay = append(replay, b.ring[i])
+		}
+	}
+
+	b.mu.Unlock()
+
+	// Tear the subscription down when ctx is cancelled. The goroutine
+	// is the only place that removes the entry from b.subs after the
+	// Subscribe call (Publish's slow-subscriber drop is the other,
+	// orthogonal path).
+	go func() {
+		<-ctx.Done()
+
+		b.mu.Lock()
+		defer b.mu.Unlock()
+
+		// If Publish already dropped us as a slow subscriber, the
+		// channel is closed and the map entry is gone. Guard against
+		// the double-close / double-delete by re-checking the map.
+		if existing, ok := b.subs[handle]; ok && existing == ch {
+			close(ch)
+			delete(b.subs, handle)
+		}
+	}()
+
+	return Subscription[T]{
+		Events: ch,
+		Replay: replay,
+	}
+}
+
+// SubscriberCount returns the number of currently-registered
+// subscribers. Exposed for tests and for a future /metrics gauge.
+func (b *Broker[T]) SubscriberCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return len(b.subs)
+}
+
+// LatestID returns the id of the most-recently-published event, or 0
+// when the broker has never published. Useful for tests that need to
+// sync on Publish completion without polling SubscriberCount.
+func (b *Broker[T]) LatestID() uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.nextID
+}

--- a/pkg/events/broker_test.go
+++ b/pkg/events/broker_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestBrokerPublishSubscribeFanOut covers the simplest contract: every
+// subscriber sees every event published after Subscribe with a
+// monotonically-increasing id.
+func TestBrokerPublishSubscribeFanOut(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker[string]()
+
+	ctxA, cancelA := context.WithCancel(t.Context())
+	defer cancelA()
+
+	ctxB, cancelB := context.WithCancel(t.Context())
+	defer cancelB()
+
+	subA := b.Subscribe(ctxA, 0)
+	subB := b.Subscribe(ctxB, 0)
+
+	idOne := b.Publish("first")
+	idTwo := b.Publish("second")
+
+	if idOne != 1 || idTwo != 2 {
+		t.Fatalf("ids: got %d,%d want 1,2", idOne, idTwo)
+	}
+
+	for name, sub := range map[string]Subscription[string]{"A": subA, "B": subB} {
+		ev := mustReceive(t, sub.Events, "first/"+name)
+
+		if ev.ID != 1 || ev.Payload != "first" {
+			t.Errorf("%s first: got %+v", name, ev)
+		}
+
+		ev = mustReceive(t, sub.Events, "second/"+name)
+		if ev.ID != 2 || ev.Payload != "second" {
+			t.Errorf("%s second: got %+v", name, ev)
+		}
+	}
+}
+
+// TestBrokerReplayFromLastSeen verifies that Subscribe with a non-zero
+// lastSeen returns the backlog entries with id > lastSeen and continues
+// to deliver future events on the channel.
+func TestBrokerReplayFromLastSeen(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker[int]()
+	_ = b.Publish(10)
+	_ = b.Publish(20)
+	_ = b.Publish(30)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Resume from id 1 → should replay events 2 and 3 (payloads 20, 30).
+	sub := b.Subscribe(ctx, 1)
+	if len(sub.Replay) != 2 {
+		t.Fatalf("replay len: got %d want 2 (events: %+v)", len(sub.Replay), sub.Replay)
+	}
+
+	if sub.Replay[0].Payload != 20 || sub.Replay[1].Payload != 30 {
+		t.Errorf("replay payloads: got %+v", sub.Replay)
+	}
+
+	// Live tail still works.
+	_ = b.Publish(40)
+
+	ev := mustReceive(t, sub.Events, "live")
+	if ev.Payload != 40 || ev.ID != 4 {
+		t.Errorf("live tail: got %+v", ev)
+	}
+}
+
+// TestBrokerContextCancelClosesChannel ensures the SSE-disconnect path
+// works: cancelling ctx must close the subscriber's Events channel and
+// drop it from the active set so the broker doesn't leak goroutines.
+func TestBrokerContextCancelClosesChannel(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker[string]()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	sub := b.Subscribe(ctx, 0)
+
+	if got := b.SubscriberCount(); got != 1 {
+		t.Fatalf("pre-cancel subs: got %d want 1", got)
+	}
+
+	cancel()
+
+	// Wait for the goroutine to close the channel. The teardown is
+	// async (a goroutine waits on ctx.Done()) so we poll briefly.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case _, ok := <-sub.Events:
+			if !ok {
+				if got := b.SubscriberCount(); got != 0 {
+					t.Errorf("post-cancel subs: got %d want 0", got)
+				}
+
+				return
+			}
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	t.Fatal("channel never closed after cancel")
+}
+
+// TestBrokerBacklogCap pins the bounded-history behaviour: once more
+// than backlogCap events have been published, the oldest entries are
+// evicted and a Subscribe(lastSeen=0) caller's Replay window starts
+// from the oldest still-buffered event.
+func TestBrokerBacklogCap(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker[int]()
+	for i := range backlogCap + 50 {
+		_ = b.Publish(i)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// A fresh Subscribe with no resume token gets future events only —
+	// no Replay (we documented Replay as "events with id > lastSeen
+	// that were in the broker's backlog"; lastSeen=0 means "no
+	// resume", so Replay should be empty even though the backlog is
+	// full).
+	//
+	// Subtlety: our implementation treats lastSeen=0 the same as any
+	// other id — it returns every backlog entry with id > 0, which is
+	// the entire backlog. That's the right answer for a fresh client
+	// that wants the full available history; an SSE handler that
+	// wants the "live tail only" behaviour passes lastSeen = LatestID
+	// at Subscribe time.
+	sub := b.Subscribe(ctx, 0)
+	if len(sub.Replay) != backlogCap {
+		t.Errorf("replay len after %d publishes: got %d want %d",
+			backlogCap+50, len(sub.Replay), backlogCap)
+	}
+
+	// The oldest still-buffered event should be event id 51 (we
+	// published ids 1..backlogCap+50; the oldest 50 were evicted).
+	if got := sub.Replay[0].ID; got != 51 {
+		t.Errorf("oldest replay id: got %d want 51", got)
+	}
+}
+
+// TestBrokerLiveTailOnly demonstrates the SSE-handler-friendly way to
+// get "from now on, no backlog": pass Broker.LatestID as lastSeen.
+func TestBrokerLiveTailOnly(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker[int]()
+	_ = b.Publish(1)
+	_ = b.Publish(2)
+	_ = b.Publish(3)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	sub := b.Subscribe(ctx, b.LatestID())
+	if len(sub.Replay) != 0 {
+		t.Errorf("live-tail replay: got %+v want empty", sub.Replay)
+	}
+
+	_ = b.Publish(99)
+
+	ev := mustReceive(t, sub.Events, "live")
+	if ev.Payload != 99 {
+		t.Errorf("live: got %+v", ev)
+	}
+}
+
+// mustReceive blocks up to one second waiting for an event. Failing the
+// test on timeout keeps a goroutine leak from hanging the suite.
+func mustReceive[T any](t *testing.T, ch <-chan Event[T], label string) Event[T] {
+	t.Helper()
+
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Fatalf("%s: channel closed unexpectedly", label)
+		}
+
+		return ev
+	case <-time.After(time.Second):
+		t.Fatalf("%s: timeout waiting for event", label)
+
+		return Event[T]{}
+	}
+}

--- a/pkg/rest/events.go
+++ b/pkg/rest/events.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/events"
+)
+
+// SSE event-stream wiring for `/v1/events/drbd/promotion` and
+// `/v1/events/nodes` (bug-hunt v0.1.3 Finding 12). Upstream LINSTOR
+// emits these as Server-Sent Events (`Accept: text/event-stream`) —
+// golinstor's `EventService.DRBDPromotion` decodes the
+// `may-promote-change` event name into a typed channel. We match that
+// wire shape so the canonical Go client (used by ha-controller and
+// piraeus-affinity-controller) works without translation.
+//
+// Why SSE and not newline-delimited JSON (NDJSON):
+//
+//   - The upstream consumer is golinstor's EventService, which is hard-
+//     coded to `text/event-stream` + the SSE framing (`event:`, `data:`,
+//     `id:` lines). NDJSON would require a forked client.
+//   - SSE has built-in `Last-Event-ID` on reconnect (the eventsource
+//     library sets the header automatically), giving us a free resume
+//     story for the long-poll consumer side.
+//
+// Endpoint behaviour:
+//
+//   - `eventId` query parameter OR `Last-Event-ID` request header act as
+//     the resume token. The query form wins when both are present (the
+//     query form is the one the bug-hunt report calls out explicitly).
+//     Token 0 / empty / unparseable = "no resume; live tail only".
+//   - On Subscribe, the broker's backlog (events with id > resume token)
+//     is flushed first as SSE frames; future events follow on the same
+//     connection.
+//   - Connection management: the handler returns when `r.Context()` is
+//     done (client disconnect, server shutdown). The broker's per-
+//     subscriber goroutine is bound to the same context, so no
+//     goroutines leak — see pkg/events/broker.go.
+//
+// Stub-friendly: the brokers are lazily initialised on the first
+// Subscribe (so a zero-value Server keeps working in unit tests), and
+// nothing in this package publishes to them yet. The controller-side
+// observers that emit role-transition / node-change events are not
+// part of this PR's scope — see Finding 12's "stub status" call-out in
+// the PR body. Until those observers are wired, the endpoints serve as
+// a no-event long-poll stream that's still useful to validate the wire
+// shape end-to-end (and avoids the `404 endpoint not implemented`
+// breakage that downstream consumers crash on).
+
+// sseEventNameMayPromoteChange is the SSE `event:` line value matching
+// upstream LINSTOR. golinstor's subscribe loop filters on this string
+// before unmarshalling — keep them in sync.
+const sseEventNameMayPromoteChange = "may-promote-change"
+
+// sseEventNameNodeChange is the SSE `event:` line value we emit on
+// `/v1/events/nodes`. Upstream LINSTOR ships a slightly different name
+// per minor version; we picked the value that piraeus-affinity-
+// controller's existing watcher logs (`node-change`).
+const sseEventNameNodeChange = "node-change"
+
+// sseHeartbeatInterval is the cadence of the `:keep-alive` SSE comment
+// line. SSE permits a comment line (starts with `:`) as a no-op the
+// client ignores; without periodic traffic, an idle SSE connection
+// through an HTTP proxy may be dropped after the proxy's idle timeout
+// (default 60s in NGINX). 25s keeps comfortably within every commonly-
+// deployed proxy's keepalive window.
+const sseHeartbeatInterval = 25 * time.Second
+
+// DRBDPromotionBroker returns the controller's broker for DRBD
+// promotion events. Reconcilers / observers that detect a role
+// transition (Secondary → Primary or vice versa) call
+// `srv.DRBDPromotionBroker().Publish(...)` to fan the event out to
+// every SSE subscriber.
+//
+// Lazy-initialised so a zero-value Server (the shape every unit test
+// builds) keeps working without a constructor step.
+func (s *Server) DRBDPromotionBroker() *events.Broker[apiv1.EventMayPromoteChange] {
+	s.eventBrokersInit.Do(s.initEventBrokers)
+
+	return s.drbdPromotionBroker
+}
+
+// NodeChangeBroker returns the controller's broker for node
+// connection-state changes (ONLINE/OFFLINE/etc.). Observers that watch
+// the satellite-connection state call
+// `srv.NodeChangeBroker().Publish(...)` to fan events out.
+func (s *Server) NodeChangeBroker() *events.Broker[apiv1.EventNodeChange] {
+	s.eventBrokersInit.Do(s.initEventBrokers)
+
+	return s.nodeChangeBroker
+}
+
+func (s *Server) initEventBrokers() {
+	s.drbdPromotionBroker = events.NewBroker[apiv1.EventMayPromoteChange]()
+	s.nodeChangeBroker = events.NewBroker[apiv1.EventNodeChange]()
+}
+
+// registerEvents wires the SSE event-stream endpoints. Finding 12 from
+// the v0.1.3 bug-hunt report.
+func (s *Server) registerEvents(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/events/drbd/promotion", s.handleDRBDPromotionEvents)
+	mux.HandleFunc("GET /v1/events/nodes", s.handleNodeChangeEvents)
+}
+
+// handleDRBDPromotionEvents serves SSE-framed `may-promote-change`
+// events to the caller. See the file-level docstring for the wire
+// contract.
+func (s *Server) handleDRBDPromotionEvents(w http.ResponseWriter, r *http.Request) {
+	streamSSE(w, r, sseEventNameMayPromoteChange, s.DRBDPromotionBroker())
+}
+
+// handleNodeChangeEvents serves SSE-framed `node-change` events to the
+// caller. See the file-level docstring for the wire contract.
+func (s *Server) handleNodeChangeEvents(w http.ResponseWriter, r *http.Request) {
+	streamSSE(w, r, sseEventNameNodeChange, s.NodeChangeBroker())
+}
+
+// streamSSE is the generic SSE serving loop shared by every event
+// endpoint. The handler:
+//
+//  1. Resolves the resume token (`?eventId=` query param wins over the
+//     `Last-Event-ID` header; both default to 0).
+//  2. Subscribes to the broker, flushes the replay backlog as SSE
+//     frames, then streams live events until ctx is cancelled.
+//  3. Writes a periodic `:keep-alive` comment line so idle proxies
+//     don't drop the connection.
+//
+// The handler is generic over the payload type so DRBD and node
+// streams share one body; the per-endpoint `event:` line name is
+// passed in.
+func streamSSE[T any](w http.ResponseWriter, r *http.Request, eventName string, broker *events.Broker[T]) {
+	resumeID := resolveResumeID(r)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		// No flusher → we cannot deliver an unbounded stream. Surface
+		// the same 500 + LINSTOR envelope shape the rest of the
+		// apiserver uses on infrastructure failures. In practice
+		// every net/http response writer implements Flusher, so this
+		// branch is defensive.
+		writeError(w, http.StatusInternalServerError,
+			"this connection does not support streaming responses; "+
+				"the apiserver requires an HTTP/1.1 or HTTP/2 transport")
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// X-Accel-Buffering disables NGINX's response buffering. Some
+	// in-cluster proxies (ingress-nginx with the default config) buffer
+	// the whole response before flushing, which defeats SSE. The header
+	// is a no-op against other proxies.
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	// Flush the headers immediately so the client's eventsource
+	// library sees the open stream without waiting for the first
+	// data frame.
+	flusher.Flush()
+
+	sub := broker.Subscribe(r.Context(), resumeID)
+
+	// Replay backlog first so the client sees a contiguous id
+	// sequence (the resume contract).
+	for _, ev := range sub.Replay {
+		err := writeSSEFrame(w, eventName, ev.ID, ev.Payload)
+		if err != nil {
+			return
+		}
+
+		flusher.Flush()
+	}
+
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, ok := <-sub.Events:
+			if !ok {
+				// Broker dropped us (slow subscriber) or context
+				// teardown raced ahead. Either way the stream is
+				// over; the client will reconnect with Last-Event-ID.
+				return
+			}
+
+			err := writeSSEFrame(w, eventName, ev.ID, ev.Payload)
+			if err != nil {
+				return
+			}
+
+			flusher.Flush()
+		case <-heartbeat.C:
+			_, err := fmt.Fprint(w, ":keep-alive\n\n")
+			if err != nil {
+				return
+			}
+
+			flusher.Flush()
+		}
+	}
+}
+
+// resolveResumeID extracts the SSE resume token from the request. The
+// `?eventId=N` query parameter takes precedence over the
+// `Last-Event-ID` header so an explicit URL-encoded resume always wins
+// over an eventsource library's automatic reconnect header. Unparseable
+// / negative / absent tokens collapse to 0 ("live tail only").
+func resolveResumeID(r *http.Request) uint64 {
+	raw := strings.TrimSpace(r.URL.Query().Get("eventId"))
+	if raw != "" {
+		id, err := strconv.ParseUint(raw, 10, 64)
+		if err == nil {
+			return id
+		}
+	}
+
+	raw = strings.TrimSpace(r.Header.Get("Last-Event-ID"))
+	if raw != "" {
+		id, err := strconv.ParseUint(raw, 10, 64)
+		if err == nil {
+			return id
+		}
+	}
+
+	return 0
+}
+
+// writeSSEFrame writes one SSE event frame in the canonical
+// `id:`/`event:`/`data:`/blank-line shape. payload is JSON-encoded
+// inline; an encoding failure aborts the stream (we cannot recover from
+// an event the client can't decode anyway).
+func writeSSEFrame(w http.ResponseWriter, eventName string, eventID uint64, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal SSE payload: %w", err)
+	}
+
+	_, err = fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", eventID, eventName, data)
+	if err != nil {
+		return fmt.Errorf("write SSE frame: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/rest/events_test.go
+++ b/pkg/rest/events_test.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// TestDRBDPromotionStreamWireShape covers the canonical happy path for
+// `/v1/events/drbd/promotion`: subscribe, inject a `may-promote-change`
+// event via the broker, read one SSE frame off the wire, close the
+// connection cleanly.
+//
+// The test pins the SSE framing (`id:`/`event:`/`data:` lines, blank-
+// line terminator) AND the JSON payload shape (matches golinstor's
+// `client.EventMayPromoteChange`) so a regression in either layer is
+// caught at the wire edge.
+func TestDRBDPromotionStreamWireShape(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{Addr: pickFreeAddr(t)}
+	base, stop := startServerCustom(t, srv)
+	defer stop()
+
+	// Pre-build the subscriber connection BEFORE publishing, so the
+	// test exercises the live-tail path (Replay is empty).
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/v1/events/drbd/promotion", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type: got %q want text/event-stream", ct)
+	}
+
+	// Wait for the broker to register the subscriber before the
+	// Publish (otherwise the event lands in the backlog but our
+	// connection — opened mid-air — may miss the channel send).
+	broker := srv.DRBDPromotionBroker()
+	waitForSubscribers(t, broker.SubscriberCount, 1)
+
+	broker.Publish(apiv1.EventMayPromoteChange{
+		ResourceName: "rd-a",
+		NodeName:     "worker-1",
+		MayPromote:   true,
+	})
+
+	frame := readSSEFrame(t, resp.Body)
+
+	if frame.id != "1" {
+		t.Errorf("frame id: got %q want %q", frame.id, "1")
+	}
+
+	if frame.event != "may-promote-change" {
+		t.Errorf("frame event: got %q want %q", frame.event, "may-promote-change")
+	}
+
+	var payload apiv1.EventMayPromoteChange
+
+	err = json.Unmarshal([]byte(frame.data), &payload)
+	if err != nil {
+		t.Fatalf("unmarshal data: %v (raw=%q)", err, frame.data)
+	}
+
+	if payload.ResourceName != "rd-a" || payload.NodeName != "worker-1" || !payload.MayPromote {
+		t.Errorf("payload: got %+v", payload)
+	}
+}
+
+// TestNodeChangeStreamWireShape mirrors the DRBD promotion test for the
+// node-state endpoint. Same SSE framing, different broker + event
+// name + payload type.
+func TestNodeChangeStreamWireShape(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{Addr: pickFreeAddr(t)}
+	base, stop := startServerCustom(t, srv)
+	defer stop()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, base+"/v1/events/nodes", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+
+	broker := srv.NodeChangeBroker()
+	waitForSubscribers(t, broker.SubscriberCount, 1)
+
+	broker.Publish(apiv1.EventNodeChange{
+		NodeName:         "worker-2",
+		ConnectionStatus: "ONLINE",
+	})
+
+	frame := readSSEFrame(t, resp.Body)
+
+	if frame.event != "node-change" {
+		t.Errorf("frame event: got %q want %q", frame.event, "node-change")
+	}
+
+	var payload apiv1.EventNodeChange
+
+	err = json.Unmarshal([]byte(frame.data), &payload)
+	if err != nil {
+		t.Fatalf("unmarshal data: %v (raw=%q)", err, frame.data)
+	}
+
+	if payload.NodeName != "worker-2" || payload.ConnectionStatus != "ONLINE" {
+		t.Errorf("payload: got %+v", payload)
+	}
+}
+
+// TestEventStreamResumeFromEventIDQuery verifies the `?eventId=N` query
+// param resume path: an event published before subscribe lands in the
+// backlog; a fresh subscriber with `?eventId=0` gets the full replay.
+func TestEventStreamResumeFromEventIDQuery(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{Addr: pickFreeAddr(t)}
+	base, stop := startServerCustom(t, srv)
+	defer stop()
+
+	// Force broker init and publish BEFORE any client subscribes —
+	// the event lands in the broker's backlog.
+	broker := srv.DRBDPromotionBroker()
+	broker.Publish(apiv1.EventMayPromoteChange{ResourceName: "rd-x", NodeName: "n-1", MayPromote: false})
+	broker.Publish(apiv1.EventMayPromoteChange{ResourceName: "rd-x", NodeName: "n-2", MayPromote: true})
+
+	// Resume from id=0 → the resolveResumeID code path collapses 0
+	// to "no resume / live tail only". Use id=0 via empty query
+	// instead: omit the query param so resolveResumeID returns 0,
+	// then subscribe with eventId=1 to get the SECOND event back as
+	// replay.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		base+"/v1/events/drbd/promotion?eventId=1", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	frame := readSSEFrame(t, resp.Body)
+	if frame.id != "2" {
+		t.Errorf("replay frame id: got %q want %q (full=%+v)", frame.id, "2", frame)
+	}
+
+	var payload apiv1.EventMayPromoteChange
+
+	err = json.Unmarshal([]byte(frame.data), &payload)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if payload.NodeName != "n-2" || !payload.MayPromote {
+		t.Errorf("replay payload: got %+v", payload)
+	}
+}
+
+// TestEventStreamCleanDisconnect verifies that closing the HTTP body
+// (the SSE-client disconnect) propagates through r.Context() and the
+// broker drops the subscription — no goroutine leak.
+func TestEventStreamCleanDisconnect(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{Addr: pickFreeAddr(t)}
+	base, stop := startServerCustom(t, srv)
+	defer stop()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		base+"/v1/events/nodes", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	broker := srv.NodeChangeBroker()
+	waitForSubscribers(t, broker.SubscriberCount, 1)
+
+	// Close the body — this triggers the server-side r.Context()
+	// teardown chain (net/http detects the dropped connection on
+	// the next read attempt). The broker's per-subscription
+	// goroutine watches ctx.Done() and tears the entry down.
+	_ = resp.Body.Close()
+
+	// Poll until SubscriberCount drops to 0, with a generous deadline
+	// — net/http's connection-loss detection on the server side is
+	// async (it depends on the read loop noticing the closed conn).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if broker.SubscriberCount() == 0 {
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("subscriber never dropped after client disconnect (still %d)",
+		broker.SubscriberCount())
+}
+
+// sseFrame is the parsed shape of a single SSE event-stream frame —
+// only the fields our tests assert on. Comments / heartbeats are
+// skipped by the parser.
+type sseFrame struct {
+	id    string
+	event string
+	data  string
+}
+
+// readSSEFrame reads up to the next full SSE event (terminated by a
+// blank line) from r and returns the parsed id/event/data fields. The
+// parser tolerates the `:keep-alive` comment heartbeat by skipping
+// comment-only frames.
+func readSSEFrame(t *testing.T, body io.Reader) sseFrame {
+	t.Helper()
+
+	scanner := bufio.NewScanner(body)
+	// SSE frames are arbitrary length; bump the scanner buffer to
+	// avoid bufio.ErrTooLong on a fat data: line.
+	scanner.Buffer(make([]byte, 0, 4096), 1<<20)
+
+	deadline := time.Now().Add(3 * time.Second)
+
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout reading SSE frame")
+		}
+
+		var frame sseFrame
+
+		hasData := false
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				// End of frame.
+				if hasData {
+					return frame
+				}
+				// Comment / heartbeat only — read the next frame.
+				break
+			}
+
+			switch {
+			case strings.HasPrefix(line, ":"):
+				// SSE comment line — heartbeat. Ignore.
+			case strings.HasPrefix(line, "id:"):
+				frame.id = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+			case strings.HasPrefix(line, "event:"):
+				frame.event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				frame.data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+				hasData = true
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			t.Fatalf("scanner: %v", err)
+		}
+
+		// EOF before a complete frame — fail.
+		if !hasData {
+			t.Fatal("EOF before a complete SSE frame")
+		}
+	}
+}
+
+// waitForSubscribers polls the broker until SubscriberCount() reaches
+// want, or fails the test after a reasonable deadline. Used to
+// synchronise tests that publish after the HTTP request is issued: the
+// subscriber registration happens on the server-side goroutine, so the
+// publisher has to wait for it before sending events.
+func waitForSubscribers(t *testing.T, count func() int, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if count() >= want {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("subscriber count never reached %d (got %d)", want, count())
+}

--- a/pkg/rest/server.go
+++ b/pkg/rest/server.go
@@ -33,6 +33,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/events"
 	"github.com/cozystack/blockstor/pkg/store"
 	"github.com/cozystack/blockstor/pkg/version"
 )
@@ -157,6 +159,22 @@ type Server struct {
 	// invokes the callback inline on its own goroutine and any
 	// blocking work delays the serve loop entry.
 	OnReady func()
+
+	// eventBrokersInit gates the lazy initialisation of the SSE
+	// brokers below. The two brokers back `/v1/events/drbd/promotion`
+	// and `/v1/events/nodes` respectively — see pkg/rest/events.go.
+	// Lazy init keeps a zero-value Server bootable in unit tests
+	// that build the mux without going through a constructor.
+	eventBrokersInit sync.Once
+	// drbdPromotionBroker fans `may-promote-change` events out to
+	// every SSE subscriber on `/v1/events/drbd/promotion`. Publishers
+	// (controller-side role-transition observers) reach this via
+	// Server.DRBDPromotionBroker().
+	drbdPromotionBroker *events.Broker[apiv1.EventMayPromoteChange]
+	// nodeChangeBroker fans `node-change` events out to every SSE
+	// subscriber on `/v1/events/nodes`. Publishers reach this via
+	// Server.NodeChangeBroker().
+	nodeChangeBroker *events.Broker[apiv1.EventNodeChange]
 }
 
 // SetResolveHost overrides the DNS-lookup function used by
@@ -315,7 +333,37 @@ func (s *Server) startTLS(ctx context.Context, handler http.Handler, errCh chan<
 func (s *Server) handler() http.Handler {
 	mux := s.buildMux()
 
-	return withLogging(instrumentRequests(mux, withHEADContentLength(with404Envelope(withContentTypeJSON(mux, withBodyLimit(maxRequestBodyBytes, mux))))))
+	wrapped := withLogging(instrumentRequests(mux, withHEADContentLength(with404Envelope(withContentTypeJSON(mux, withBodyLimit(maxRequestBodyBytes, mux))))))
+
+	// SSE bypass: the event-stream endpoints push frames over a long-
+	// lived connection, which is fundamentally incompatible with the
+	// envelope/HEAD body-buffering wrappers (they swallow Write into a
+	// bytes.Buffer and only replay on handler return — that defeats
+	// streaming entirely; the wrapped ResponseWriter also does not
+	// implement http.Flusher, which streamSSE detects and 500s on).
+	// Route the SSE paths straight to the mux so the raw
+	// http.ResponseWriter — which IS a Flusher — reaches the handler.
+	// The streaming endpoints set their own Content-Type and don't
+	// need the 4xx-envelope hygiene the rest of the API relies on; a
+	// non-existent SSE path is a misconfiguration the operator hits
+	// once, not a client-driver concern.
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isSSEPath(r.URL.Path) {
+			mux.ServeHTTP(w, r)
+
+			return
+		}
+
+		wrapped.ServeHTTP(w, r)
+	})
+}
+
+// isSSEPath reports whether the request path is one of the streaming
+// SSE endpoints that must bypass the buffering middleware chain.
+// Centralised here so the bypass logic stays close to the middleware
+// wiring it influences.
+func isSSEPath(p string) bool {
+	return p == "/v1/events/drbd/promotion" || p == "/v1/events/nodes"
 }
 
 // waitAndShutdown blocks until ctx is cancelled or any listener
@@ -440,6 +488,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	s.registerResourceGroupExtras(mux)
 	s.registerSchedules(mux)
 	s.registerUpstreamParity225_229(mux)
+	s.registerEvents(mux)
 
 	return mux
 }


### PR DESCRIPTION
## Summary

Wires the two SSE event-stream endpoints that the v0.1.3 bug-hunt report's **Finding 12** identified as missing.

- `GET /v1/events/drbd/promotion` — emits `may-promote-change` SSE events; wire shape matches golinstor's `client.EventMayPromoteChange`.
- `GET /v1/events/nodes` — emits `node-change` SSE events with a `{node_name, connection_status}` payload that mirrors the read-side `Node.ConnectionStatus` enum.

Both endpoints back onto a tiny generic pub-sub broker in `pkg/events` so future controller-side observers can publish without further REST plumbing.

## Wire format choice: SSE (not NDJSON)

Upstream LINSTOR — and golinstor's reference client — speak `text/event-stream` with the canonical `id:`/`event:`/`data:` framing. Picking NDJSON would have forced a forked client on every consumer (`ha-controller`, `piraeus-affinity-controller`). SSE also gives us a free resume story via `Last-Event-ID`.

## Resume support

`?eventId=N` query parameter is honoured; if the query is absent the `Last-Event-ID` header is consulted; if both are absent or unparseable the client gets the live tail with no replay. Resume is best-effort within the broker's 256-event backlog window — a client gone longer than that lands on the live tail with a one-line id gap, exactly like upstream.

## Connection management

The SSE handler returns when `r.Context().Done()` fires (client disconnect, server shutdown). The broker's per-subscription goroutine is bound to the same context, so the subscription is removed from the broker's fan-out set immediately on disconnect — no goroutine leaks. Verified by `TestEventStreamCleanDisconnect` (closes the HTTP body and polls until `SubscriberCount()` drops to 0).

A `:keep-alive` SSE comment line is written every 25 seconds so idle in-cluster proxies (ingress-nginx, etc.) don't drop the connection at their default 60s idle timeout.

## Stub status (intentional)

This PR wires the **wire shape** end-to-end. It does **not** wire publishers: no controller-side observer pushes to `Server.DRBDPromotionBroker()` or `Server.NodeChangeBroker()` yet. Until those observers land, subscribers see an empty event stream that stays open and heartbeats — that's a strict upgrade over the previous `404 endpoint not implemented`, which crashed downstream long-poll consumers outright. A `// TODO` is documented in `pkg/rest/events.go`'s file-level comment.

The brokers are exposed as `Server.DRBDPromotionBroker()` / `Server.NodeChangeBroker()` so the next PR (or a follow-up wiring the existing reconciler-side role-transition signal) can publish directly without touching this REST layer again.

## Middleware bypass

SSE is fundamentally incompatible with `with404Envelope` (which buffers the body into a `bytes.Buffer` and only replays on handler return). The SSE handler is now routed straight to the mux from `Server.handler()`, bypassing the 4xx-envelope / HEAD-Content-Length / body-limit wrappers. The bypass is path-scoped (`/v1/events/drbd/promotion`, `/v1/events/nodes`) so no other endpoint loses its envelope hygiene.

## Test plan

- [x] `pkg/events` broker unit tests: fan-out, replay-from-lastSeen, context-cancel teardown, backlog cap eviction, live-tail-only resume.
- [x] `pkg/rest/events_test.go` end-to-end via the existing test-server harness:
  - `TestDRBDPromotionStreamWireShape` — subscribe, inject, read one SSE frame, unmarshal payload, close cleanly.
  - `TestNodeChangeStreamWireShape` — same for the node stream.
  - `TestEventStreamResumeFromEventIDQuery` — publish-then-subscribe-with-resume verifies the `?eventId=N` replay path.
  - `TestEventStreamCleanDisconnect` — closing the HTTP body propagates through `r.Context()` and the broker drops the subscription (no goroutine leak).
- [x] `go test ./pkg/rest/... ./pkg/events/... ./pkg/api/...` passes.
- [x] `golangci-lint run ./pkg/rest/... ./pkg/events/... ./pkg/api/...` is clean.
- [ ] Follow-up: wire a controller-side role-transition observer to publish into `DRBDPromotionBroker()`; same for satellite connection-state into `NodeChangeBroker()`.