### PR TITLE
fix(rest): bug-hunt P3 wire-shape cleanups

### DIFF
--- a/pkg/rest/api_call_rc.go
+++ b/pkg/rest/api_call_rc.go
@@ -164,6 +164,30 @@ const warnNoSatelliteConnection = maskWarn | int64(2057)
 // (2057).
 const warnRscConnPathNotFound = maskWarn | int64(2058)
 
+// warnNetInterfaceNotFound flags a delete-of-missing on
+// `DELETE /v1/nodes/{node}/net-interfaces/{name}`. Bug-hunt v0.1.3
+// Finding 9: the pre-fix handler always returned 200 + maskInfo
+// "net-interface deleted: <name>" even when the interface was never
+// there, indistinguishable from a real drop in audit logs. Following
+// the Bug 56 / 66 family pattern, surface a warn-band envelope so
+// `grep '"ret_code":2059'` flags no-op idempotency replays. Sub-code
+// 2059 keeps the warn-band numbering monotonic alongside
+// warnRscConnPathNotFound (2058).
+const warnNetInterfaceNotFound = maskWarn | int64(2059)
+
+// warnNodeAlreadyGone flags a `DELETE /v1/nodes/{node}/lost` (node-
+// lost) replay where the named node is already absent from the
+// controller. Bug-hunt v0.1.3 Finding 9: the pre-fix handler folded
+// the NotFound into 200 + maskInfo "node lost: <name>", lying to the
+// caller that a real teardown happened. Audit-log greppers + cozystack
+// playbooks that re-run `n lost` on retry expect to distinguish a
+// successful cascade from a no-op replay. Sub-code 2060 keeps the
+// warn-band numbering monotonic alongside warnNetInterfaceNotFound
+// (2059). Separate from warnNodeNotFound (2053, used by plain
+// `DELETE /v1/nodes/{node}`) so the audit shape distinguishes the two
+// removal verbs.
+const warnNodeAlreadyGone = maskWarn | int64(2060)
+
 // apiCallRcFailSnapshotFinalizerStuck is emitted by `DELETE /v1/
 // resource-definitions/{rd}/snapshots/{snap}` (Bug 193) when the
 // Snapshot CRD's satellite-side finalizer

--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -110,7 +110,7 @@ func (s *Server) handleResourceList(w http.ResponseWriter, r *http.Request) {
 
 	out := make([]apiv1.ResourceWithVolumes, 0, len(resList))
 	for i := range resList {
-		out = append(out, apiv1.ResourceWithVolumes{Resource: resList[i]})
+		out = append(out, wrapResourceWithVolumes(&resList[i]))
 	}
 
 	// Bug 188 (P0): scrub deny-listed sensitive keys (passphrase,
@@ -132,6 +132,25 @@ func (s *Server) handleResourceList(w http.ResponseWriter, r *http.Request) {
 	stripInternalAnnotationsFromResourcesWithVolumes(out)
 
 	writeJSON(w, http.StatusOK, out)
+}
+
+// wrapResourceWithVolumes wraps a Resource into ResourceWithVolumes so
+// the `volumes` JSON key is always present (never `null`). Bug-hunt
+// v0.1.3 Finding 3: handleResourceList / handleResourceGet wrapped via
+// `ResourceWithVolumes{Resource: res}` leaving the outer Volumes nil,
+// which `encoding/json` serialises as `"volumes":null`. Upstream
+// LINSTOR's `Resource` schema has no `volumes` key at all, but the
+// Python CLI's `responses.py` derefs `rsc._rest_data['volumes']`
+// unconditionally and crashes on `None.iter`. Mirrors the
+// ensureVolumesForView contract used by /v1/view/resources: a non-nil
+// (possibly empty) slice survives the JSON encode as `[]`.
+func wrapResourceWithVolumes(res *apiv1.Resource) apiv1.ResourceWithVolumes {
+	out := apiv1.ResourceWithVolumes{Resource: *res, Volumes: res.Volumes}
+	if out.Volumes == nil {
+		out.Volumes = []apiv1.Volume{}
+	}
+
+	return out
 }
 
 // handleResourceGet answers `GET /v1/resource-definitions/{rd}/resources/{node}`,
@@ -185,7 +204,11 @@ func (s *Server) handleResourceGet(w http.ResponseWriter, r *http.Request) {
 	// strip applied on the cluster-wide view and per-RD list paths.
 	res.Annotations = stripInternalAnnotations(res.Annotations)
 
-	writeJSON(w, http.StatusOK, apiv1.ResourceWithVolumes{Resource: res})
+	// Bug-hunt v0.1.3 Finding 3: wrap via wrapResourceWithVolumes so the
+	// outer `volumes` JSON key serialises as `[]` instead of `null` when
+	// the Resource carries no Volumes; protects python-linstor's
+	// `rsc._rest_data['volumes']` dereference.
+	writeJSON(w, http.StatusOK, wrapResourceWithVolumes(&res))
 }
 
 // handleAutoplace selects up to `place_count` nodes that have a storage

--- a/pkg/rest/bughunt_p3_wire_shape_test.go
+++ b/pkg/rest/bughunt_p3_wire_shape_test.go
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestBughuntP3_Finding3_ResourceGetVolumesAlwaysSlice pins that
+// `GET /v1/resource-definitions/{rd}/resources/{node}` and the list
+// sibling emit `"volumes":[]` instead of `"volumes":null` when the
+// satellite hasn't written Status.Volumes yet. Bug-hunt v0.1.3
+// Finding 3: pre-fix the wrapper `ResourceWithVolumes{Resource: r}`
+// left the outer slice nil and `encoding/json` serialised it as
+// `null`, breaking python-linstor's `rsc._rest_data['volumes']`
+// dereference (same crash class as the historical KeyError:'size').
+// Per Bug 137 contract the wire key is always present (even as
+// `[]`); a fresh diskful replica with no observed Volumes is the
+// most common trigger.
+func TestBughuntP3_Finding3_ResourceGetVolumesAlwaysSlice(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Fresh diskful replica — no Volumes populated by the satellite
+	// observer yet. This is the wire shape the bug report captured.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "rd-1", NodeName: "n1"}); err != nil {
+		t.Fatalf("seed res: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Per-node GET path.
+	getResp := httpGet(t, base+"/v1/resource-definitions/rd-1/resources/n1")
+	defer func() { _ = getResp.Body.Close() }()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("get status: got %d, want 200", getResp.StatusCode)
+	}
+
+	getBytes, err := io.ReadAll(getResp.Body)
+	if err != nil {
+		t.Fatalf("get read: %v", err)
+	}
+
+	if !bytes.Contains(getBytes, []byte(`"volumes":[]`)) {
+		t.Errorf("get response missing `volumes:[]`; got: %s", getBytes)
+	}
+
+	if bytes.Contains(getBytes, []byte(`"volumes":null`)) {
+		t.Errorf("get response leaked `volumes:null`: %s", getBytes)
+	}
+
+	// Per-RD list path.
+	listResp := httpGet(t, base+"/v1/resource-definitions/rd-1/resources")
+	defer func() { _ = listResp.Body.Close() }()
+
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("list status: got %d, want 200", listResp.StatusCode)
+	}
+
+	listBytes, err := io.ReadAll(listResp.Body)
+	if err != nil {
+		t.Fatalf("list read: %v", err)
+	}
+
+	if !bytes.Contains(listBytes, []byte(`"volumes":[]`)) {
+		t.Errorf("list response missing `volumes:[]`; got: %s", listBytes)
+	}
+
+	if bytes.Contains(listBytes, []byte(`"volumes":null`)) {
+		t.Errorf("list response leaked `volumes:null`: %s", listBytes)
+	}
+}
+
+// TestBughuntP3_Finding9_NetInterfaceDeleteMissingWarnBand pins the
+// warn-band envelope on `DELETE /v1/nodes/{node}/net-interfaces/{name}`
+// when the named interface is absent. Bug-hunt v0.1.3 Finding 9:
+// pre-fix the handler returned maskInfo + "net-interface deleted: foo"
+// (indistinguishable from a real drop in audit logs). Post-fix the
+// envelope carries warnNetInterfaceNotFound + "net-interface already
+// absent: foo" so audit-log greppers + Prometheus alerting can
+// distinguish a real teardown from an idempotent replay.
+func TestBughuntP3_Finding9_NetInterfaceDeleteMissingWarnBand(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n1",
+		Type: apiv1.NodeTypeSatellite,
+		NetInterfaces: []apiv1.NetInterface{
+			{Name: "default", Address: "10.0.0.1"},
+		},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/nodes/n1/net-interfaces/never-existed")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var rc []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(rc) != 1 {
+		t.Fatalf("envelope len: got %d, want 1", len(rc))
+	}
+
+	if rc[0].RetCode != warnNetInterfaceNotFound {
+		t.Errorf("ret_code: got %d, want %d (warnNetInterfaceNotFound)", rc[0].RetCode, warnNetInterfaceNotFound)
+	}
+
+	if !strings.Contains(rc[0].Message, "already absent") {
+		t.Errorf("message: got %q, want 'already absent' substring", rc[0].Message)
+	}
+
+	// Pin that a real-delete still surfaces maskInfo (no regression).
+	realResp := httpDelete(t, base+"/v1/nodes/n1/net-interfaces/default")
+	defer func() { _ = realResp.Body.Close() }()
+
+	var realRC []apiv1.APICallRc
+	if err := json.NewDecoder(realResp.Body).Decode(&realRC); err != nil {
+		t.Fatalf("real-delete decode: %v", err)
+	}
+
+	if realRC[0].RetCode != maskInfo {
+		t.Errorf("real-delete ret_code: got %d, want maskInfo (%d)", realRC[0].RetCode, maskInfo)
+	}
+}
+
+// TestBughuntP3_Finding9_NodeLostMissingWarnBand pins the warn-band
+// envelope on `DELETE /v1/nodes/{ghost}/lost` (and the POST sibling
+// — both route through handleNodeLost). Bug-hunt v0.1.3 Finding 9:
+// pre-fix the handler folded NotFound into maskInfo + "node lost:
+// ghost" so the wire could not distinguish a real cascade from an
+// idempotent replay. Post-fix it carries warnNodeAlreadyGone.
+func TestBughuntP3_Finding9_NodeLostMissingWarnBand(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpPost(t, base+"/v1/nodes/ghost/lost", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (idempotent fold)", resp.StatusCode)
+	}
+
+	var rc []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(rc) != 1 {
+		t.Fatalf("envelope len: got %d, want 1", len(rc))
+	}
+
+	if rc[0].RetCode != warnNodeAlreadyGone {
+		t.Errorf("ret_code: got %d, want %d (warnNodeAlreadyGone)", rc[0].RetCode, warnNodeAlreadyGone)
+	}
+
+	if !strings.Contains(rc[0].Message, "already absent") {
+		t.Errorf("message: got %q, want 'already absent' substring", rc[0].Message)
+	}
+}
+
+// TestBughuntP3_Finding10_QueryMaxVolumeSizeGlobalRoute pins the
+// top-level OPTIONS /v1/query-max-volume-size endpoint. Bug-hunt
+// v0.1.3 Finding 10: upstream LINSTOR OpenAPI registers this for
+// the RG-less `linstor query-max-volume-size --place 2 --storage-
+// pool <pool>` CLI form; pre-fix the apiserver only wired the RG-
+// scoped path so the top-level form 404'd. The endpoint takes an
+// AutoSelectFilter body and returns the same `candidates` envelope
+// as the RG-scoped variant.
+//
+// We exercise both the body-bearing form and the no-body fallback
+// (an operator running `curl -X OPTIONS .../v1/query-max-volume-
+// size` with no JSON must still get a non-empty candidate list
+// instead of 400).
+func TestBughuntP3_Finding10_QueryMaxVolumeSizeGlobalRoute(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	// Seed a pool so the candidate list is non-empty — confirms the
+	// handler is wired end-to-end through computeSizeInfo.
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "n1"}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		NodeName:        "n1",
+		StoragePoolName: "zfs-thin",
+		ProviderKind:    apiv1.StoragePoolKindZFSThin,
+		FreeCapacity:    1024 * 1024,
+		TotalCapacity:   2048 * 1024,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Body-bearing form: filter pinned to the seeded pool.
+	body, _ := json.Marshal(apiv1.AutoSelectFilter{
+		PlaceCount:  1,
+		StoragePool: "zfs-thin",
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodOptions, base+"/v1/query-max-volume-size", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (top-level OPTIONS wired)", resp.StatusCode)
+	}
+
+	var got struct {
+		Candidates []struct {
+			StoragePool string `json:"storage_pool"`
+		} `json:"candidates"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(got.Candidates) == 0 {
+		t.Errorf("candidates empty; want at least one (filter pinned zfs-thin)")
+	}
+
+	for _, c := range got.Candidates {
+		if c.StoragePool != "zfs-thin" {
+			t.Errorf("candidate pool: got %q, want zfs-thin (filter constraint ignored)", c.StoragePool)
+		}
+	}
+
+	// No-body form: must NOT 400.
+	emptyReq, err := http.NewRequestWithContext(ctx, http.MethodOptions, base+"/v1/query-max-volume-size", nil)
+	if err != nil {
+		t.Fatalf("new empty req: %v", err)
+	}
+
+	emptyResp, err := http.DefaultClient.Do(emptyReq)
+	if err != nil {
+		t.Fatalf("do empty: %v", err)
+	}
+	defer func() { _ = emptyResp.Body.Close() }()
+
+	if emptyResp.StatusCode != http.StatusOK {
+		t.Errorf("empty-body status: got %d, want 200 (no-body fallback)", emptyResp.StatusCode)
+	}
+}
+
+// TestBughuntP3_Finding13_StatsNodes pins the /v1/stats/nodes
+// endpoint. Bug-hunt v0.1.3 Finding 13: pre-fix this returned 404
+// while the six sibling /v1/stats/<kind> sub-paths were wired. The
+// shape mirrors upstream's NodeStats schema: `count` total plus
+// `online` / `offline` / `evicted` sub-counts — `linstor node
+// stats` reads each key unconditionally.
+func TestBughuntP3_Finding13_StatsNodes(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	// Three nodes: one ONLINE, one OFFLINE, one ONLINE+EVICTED.
+	for _, n := range []apiv1.Node{
+		{Name: "online-1", ConnectionStatus: "ONLINE"},
+		{Name: "offline-1", ConnectionStatus: "OFFLINE"},
+		{Name: "evicted-online", ConnectionStatus: "ONLINE", Flags: []string{apiv1.NodeFlagEvicted}},
+	} {
+		if err := st.Nodes().Create(ctx, &n); err != nil {
+			t.Fatalf("seed %s: %v", n.Name, err)
+		}
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpGet(t, base+"/v1/stats/nodes")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (no longer 404)", resp.StatusCode)
+	}
+
+	var got nodeStatsEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Count != 3 {
+		t.Errorf("count: got %d, want 3", got.Count)
+	}
+
+	if got.Online != 2 {
+		t.Errorf("online: got %d, want 2 (online-1 + evicted-online)", got.Online)
+	}
+
+	if got.Offline != 1 {
+		t.Errorf("offline: got %d, want 1 (offline-1)", got.Offline)
+	}
+
+	if got.Evicted != 1 {
+		t.Errorf("evicted: got %d, want 1 (evicted-online)", got.Evicted)
+	}
+}
+
+// TestBughuntP3_Finding14_RDExternalFilesEmptyList pins the per-RD
+// external-files attach surface returning an empty `[]`. Bug-hunt
+// v0.1.3 Finding 14: pre-fix `GET /v1/resource-definitions/{rd}/
+// files` returned 404, crashing the CLI's `linstor rd list-files`
+// JSON decode. blockstor doesn't support arbitrary external files
+// (operators ship custom DRBD opts via `Aux/` props per the report's
+// note), so the empty list is the upstream-shaped truth.
+func TestBughuntP3_Finding14_RDExternalFilesEmptyList(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpGet(t, base+"/v1/resource-definitions/rd-x/files")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (no longer 404)", resp.StatusCode)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	trimmed := strings.TrimSpace(string(got))
+	if trimmed != "[]" {
+		t.Errorf("body: got %q, want %q", trimmed, "[]")
+	}
+}
+
+// TestBughuntP3_Finding15_ControllerConfigLogLevel pins that
+// GET /v1/controller/config carries the live runtime log level and
+// http.enabled. Bug-hunt v0.1.3 Finding 15: pre-fix the handler
+// returned bare `{}`, so any client reading `cfg.log.level` to
+// determine the current logger state (vs. PUTting + diffing) had no
+// signal. Post-fix log.level mirrors the runtimeLogLevel LevelVar.
+//
+// We flip the level via the existing PUT /v1/controller/config
+// surface (Bug 159) and re-GET — the round-trip must be the
+// identity for any value `set-log-level` accepts.
+func TestBughuntP3_Finding15_ControllerConfigLogLevel(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	// Flip the level via the upstream-shaped PUT.
+	putBody, _ := json.Marshal(map[string]any{
+		"log": map[string]string{"level": "DEBUG"},
+	})
+
+	putResp := httpPut(t, base+"/v1/controller/config", putBody)
+	_ = putResp.Body.Close()
+
+	if putResp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status: got %d, want 200", putResp.StatusCode)
+	}
+
+	// Re-GET and verify log.level == DEBUG + http.enabled == true.
+	getResp := httpGet(t, base+"/v1/controller/config")
+	defer func() { _ = getResp.Body.Close() }()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET status: got %d, want 200", getResp.StatusCode)
+	}
+
+	var got struct {
+		Log struct {
+			Level string `json:"level"`
+		} `json:"log"`
+		HTTP struct {
+			Enabled bool `json:"enabled"`
+		} `json:"http"`
+	}
+
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Log.Level != "DEBUG" {
+		t.Errorf("log.level: got %q, want DEBUG (PUT round-trip identity)", got.Log.Level)
+	}
+
+	if !got.HTTP.Enabled {
+		t.Errorf("http.enabled: got false, want true (apiserver wired)")
+	}
+}

--- a/pkg/rest/controller_props.go
+++ b/pkg/rest/controller_props.go
@@ -20,6 +20,7 @@ package rest
 
 import (
 	"context"
+	"log/slog"
 	"maps"
 	"net/http"
 
@@ -66,13 +67,86 @@ func (s *Server) registerControllerProperties(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /v1/controller/config", handlePutControllerConfig)
 }
 
-// handleControllerConfig returns an empty ControllerConfig object.
-// blockstor's config lives in k8s (Deployment env, ConfigMaps, the
-// ControllerConfig CRD's typed fields) — there's no JVM-style flat
-// config file to expose. The empty `{}` satisfies golinstor's decoder
-// without leaking anything implementation-specific.
+// handleControllerConfig returns the populated ControllerConfig
+// subset blockstor supports. Bug-hunt v0.1.3 Finding 15: pre-fix
+// this returned bare `{}`, breaking `linstor c v` config display and
+// any client that does `cfg.log.level` to read the current logger
+// state without a PUT round-trip.
+//
+// Populated sub-objects:
+//
+//   - `log.level`: derived from the runtime slog level (PUT
+//     /v1/controller/config flips this same LevelVar — Bug 159).
+//   - `http.enabled`: literal true; the apiserver only exists when
+//     HTTP is wired, so reaching this handler proves it.
+//
+// Other ControllerConfig sub-objects (debug, db, https, ldap) stay
+// empty in this PR — blockstor doesn't run the JVM-style flat
+// config layer, so there's nothing meaningful to expose there.
+// Wider population lands when individual surfaces (e.g. mTLS for
+// https) become user-tunable.
 func handleControllerConfig(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, struct{}{})
+	writeJSON(w, http.StatusOK, controllerConfigEnvelope{
+		Log: controllerConfigLog{
+			Level: currentRuntimeLogLevelName(),
+		},
+		HTTP: controllerConfigHTTP{
+			Enabled: true,
+		},
+	})
+}
+
+// controllerConfigEnvelope mirrors the upstream ControllerConfig
+// JSON shape (subset). Bug-hunt v0.1.3 Finding 15. Only the
+// sub-objects blockstor can meaningfully populate are non-empty;
+// the rest stay zero-valued and serialise as `omitempty`-absent so
+// the wire shape stays compact.
+type controllerConfigEnvelope struct {
+	Log  controllerConfigLog  `json:"log"`
+	HTTP controllerConfigHTTP `json:"http"`
+}
+
+// controllerConfigLog mirrors the upstream log sub-object. We expose
+// the runtime level only; the upstream `directory` / `rest_access_log`
+// / `rest_access_log_mode` fields are JVM-specific and stay absent.
+type controllerConfigLog struct {
+	Level string `json:"level"`
+}
+
+// controllerConfigHTTP mirrors the upstream http sub-object. We
+// expose `enabled` only — the apiserver's listen-address / port
+// come from the K8s Service surface, not from the JVM-config file
+// upstream is mirroring.
+type controllerConfigHTTP struct {
+	Enabled bool `json:"enabled"`
+}
+
+// currentRuntimeLogLevelName reverse-maps the runtimeLogLevel
+// LevelVar to the upstream-CLI level vocabulary used by
+// parseLogLevel (TRACE / DEBUG / INFO / WARN / ERROR). Mirrors the
+// `set-log-level` PUT path so a GET → PUT round-trip is the
+// identity for any value the operator can set.
+//
+// The mapping is exact at the parseLogLevel boundaries (LevelDebug
+// → DEBUG, LevelInfo → INFO, ...) and uses the closest-bucket rule
+// for intermediate values — the LevelVar's Level() always returns
+// the value we Set() on the PUT path, so the only off-mapping case
+// is the initial default LevelInfo (slog's zero value), which maps
+// cleanly to INFO.
+func currentRuntimeLogLevelName() string {
+	level := runtimeLogLevel.Level()
+	switch {
+	case level <= slog.LevelDebug-traceBelowDebug:
+		return logLevelTrace
+	case level <= slog.LevelDebug:
+		return logLevelDebug
+	case level <= slog.LevelInfo:
+		return logLevelInfo
+	case level <= slog.LevelWarn:
+		return logLevelWarn
+	default:
+		return logLevelError
+	}
 }
 
 // handleControllerPropsGet returns ControllerConfig.Spec.ExtraProps

--- a/pkg/rest/controller_props_test.go
+++ b/pkg/rest/controller_props_test.go
@@ -126,13 +126,14 @@ func TestControllerPropertiesDelete(t *testing.T) {
 	}
 }
 
-// TestControllerConfigEmptyObject pins the GET /v1/controller/config
-// stub: golinstor's `Controller.GetConfig()` parses the response into
-// a ControllerConfig struct (all fields `omitempty`) so an empty `{}`
-// is the minimal-but-correct response. blockstor doesn't run a JVM
-// config layer; the endpoint exists only because the CLI calls it
-// at startup and breaks on 404.
-func TestControllerConfigEmptyObject(t *testing.T) {
+// TestControllerConfigPopulated pins GET /v1/controller/config:
+// pre-fix it returned bare `{}`. Bug-hunt v0.1.3 Finding 15 wires
+// `log.level` (from the runtime slog LevelVar) and `http.enabled`
+// (always true — the apiserver only exists when HTTP is wired) so
+// `linstor c v` and any client that reads `cfg.log.level` without
+// a PUT round-trip see meaningful values. Sub-objects we don't yet
+// populate (debug / db / https / ldap) stay absent.
+func TestControllerConfigPopulated(t *testing.T) {
 	base, stop := startServerWithStore(t, store.NewInMemory())
 	defer stop()
 
@@ -143,13 +144,25 @@ func TestControllerConfigEmptyObject(t *testing.T) {
 		t.Fatalf("status: got %d, want 200", resp.StatusCode)
 	}
 
-	var got map[string]any
+	var got struct {
+		Log struct {
+			Level string `json:"level"`
+		} `json:"log"`
+		HTTP struct {
+			Enabled bool `json:"enabled"`
+		} `json:"http"`
+	}
+
 	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 
-	if len(got) != 0 {
-		t.Errorf("expected empty object; got %v", got)
+	if got.Log.Level == "" {
+		t.Errorf("log.level: got empty, want a non-empty level string")
+	}
+
+	if !got.HTTP.Enabled {
+		t.Errorf("http.enabled: got false, want true (apiserver wired)")
 	}
 }
 

--- a/pkg/rest/external_files.go
+++ b/pkg/rest/external_files.go
@@ -29,9 +29,19 @@ import (
 //
 // LIST → []. GET on a single path → 404. Wider implementation lands
 // when a real per-cluster need shows up.
+//
+// Bug-hunt v0.1.3 Finding 14: the per-RD attach surface
+// `/v1/resource-definitions/{rd}/files` is also wired here as an
+// empty `[]`. blockstor doesn't ship arbitrary files to satellites
+// (cozystack handles host config via Talos extensions), so the
+// list is genuinely empty for every RD — `[]` is the truthful
+// upstream-shape answer rather than a 404 that crashes the CLI's
+// `linstor rd list-files <rd>` json decode.
 func (s *Server) registerExternalFiles(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/files", handleExternalFilesList)
 	mux.HandleFunc("GET /v1/files/{path...}", handleExternalFileGet)
+	mux.HandleFunc("GET /v1/resource-definitions/{rd}/files",
+		handleRDExternalFilesList)
 }
 
 func handleExternalFilesList(w http.ResponseWriter, _ *http.Request) {
@@ -40,4 +50,14 @@ func handleExternalFilesList(w http.ResponseWriter, _ *http.Request) {
 
 func handleExternalFileGet(w http.ResponseWriter, _ *http.Request) {
 	writeError(w, http.StatusNotFound, "external file not found")
+}
+
+// handleRDExternalFilesList answers the per-RD attach surface with an
+// empty list. Bug-hunt v0.1.3 Finding 14: blockstor doesn't support
+// arbitrary external files (operators ship custom DRBD opts via
+// `Aux/` props, see the report's note). The empty list is the
+// upstream-shaped non-error response — same approach as
+// handleExternalFilesList for the global registry.
+func handleRDExternalFilesList(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, []map[string]string{})
 }

--- a/pkg/rest/node_lifecycle.go
+++ b/pkg/rest/node_lifecycle.go
@@ -439,7 +439,22 @@ func (s *Server) handleNodeLost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = s.Store.Nodes().Delete(r.Context(), name)
-	if err != nil && !errors.Is(err, store.ErrNotFound) {
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// Bug-hunt v0.1.3 Finding 9: surface a warn-band envelope
+			// so audit-log greppers + `*_lost_total` Prometheus
+			// alerts can distinguish a real `n lost` teardown from
+			// an idempotent retry against an already-absent node.
+			// Mirrors the Bug 56 / 66 family pattern every other
+			// delete-of-missing handler in this package uses.
+			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+				RetCode: warnNodeAlreadyGone,
+				Message: "node already absent: " + name,
+			}})
+
+			return
+		}
+
 		writeStoreError(w, err)
 
 		return

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -197,15 +197,30 @@ func (s *Server) handleNetInterfaceUpdate(w http.ResponseWriter, r *http.Request
 // so a sibling `handleNetInterfaceCreate` adding a different
 // interface concurrently won't be silently dropped on the
 // wholesale-Spec-replace path the old `Update` used.
+//
+// Bug-hunt v0.1.3 Finding 9: when the named interface was never
+// present on the node, surface a warn-band ApiCallRc envelope
+// (warnNetInterfaceNotFound) instead of the success-band maskInfo
+// shape so audit-log greppers can distinguish a real drop from an
+// idempotent no-op. Mirrors the Bug 56 / 66 pattern every other
+// delete-of-missing handler in this package uses.
 func (s *Server) handleNetInterfaceDelete(w http.ResponseWriter, r *http.Request) {
 	nodeName := r.PathValue("node")
 	name := r.PathValue("name")
 
+	found := false
+
 	err := s.Store.Nodes().PatchNetInterfaces(r.Context(), nodeName, func(current []apiv1.NetInterface) ([]apiv1.NetInterface, error) {
+		// Reset on every retry — Bug 201's Patch closure may re-run
+		// against a freshly-fetched state, so a state-dependent flag
+		// has to be (re)computed inside the closure to stay correct.
+		found = false
 		out := current[:0]
 
 		for i := range current {
 			if current[i].Name == name {
+				found = true
+
 				continue
 			}
 
@@ -216,6 +231,15 @@ func (s *Server) handleNetInterfaceDelete(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		writeStoreError(w, err)
+
+		return
+	}
+
+	if !found {
+		writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+			RetCode: warnNetInterfaceNotFound,
+			Message: "net-interface already absent: " + name,
+		}})
 
 		return
 	}

--- a/pkg/rest/resource_group_extras.go
+++ b/pkg/rest/resource_group_extras.go
@@ -59,6 +59,14 @@ func (s *Server) registerResourceGroupExtras(mux *http.ServeMux) {
 
 	mux.HandleFunc("GET /v1/resource-groups/{rg}/query-max-volume-size",
 		s.requireStore(s.handleQueryMaxVolumeSize))
+	// Bug-hunt v0.1.3 Finding 10: upstream LINSTOR OpenAPI registers
+	// an RG-less variant under OPTIONS /v1/query-max-volume-size (yes,
+	// OPTIONS with a body — upstream quirk so the verb stays read-only
+	// while still accepting an AutoSelectFilter for ad-hoc queries).
+	// `linstor query-max-volume-size --place 2 --storage-pool zfs-thin`
+	// (no RG argument) routes through this URL; pre-fix it 404'd.
+	mux.HandleFunc("OPTIONS /v1/query-max-volume-size",
+		s.requireStore(s.handleQueryMaxVolumeSizeGlobal))
 	mux.HandleFunc("POST /v1/resource-groups/{rg}/adjust",
 		s.requireStore(s.handleRGAdjust))
 
@@ -394,6 +402,83 @@ func (s *Server) handleQueryMaxVolumeSize(w http.ResponseWriter, r *http.Request
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleQueryMaxVolumeSizeGlobal answers the top-level (no-RG)
+// `linstor query-max-volume-size` form. Bug-hunt v0.1.3 Finding 10:
+// upstream LINSTOR registers this under OPTIONS /v1/query-max-volume-
+// size (an upstream quirk — the verb is OPTIONS so it stays
+// nominally read-only while still accepting a body that carries an
+// AutoSelectFilter; HTTP technically allows it). The body is the
+// same AutoSelectFilter the RG-scoped variant computes against, so
+// we route it through computeSizeInfo and reshape into the same
+// `candidates` envelope handleQueryMaxVolumeSize uses.
+//
+// Empty / malformed body collapses to the zero filter (any pool,
+// place_count=1), matching upstream's behaviour for an operator
+// who runs `linstor query-max-volume-size` with no flags.
+func (s *Server) handleQueryMaxVolumeSizeGlobal(w http.ResponseWriter, r *http.Request) {
+	filter, ok := decodeQueryMaxVolumeSizeBody(w, r)
+	if !ok {
+		return
+	}
+
+	info, err := s.computeSizeInfo(r.Context(), &filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	pools := filterPoolNames(&filter)
+	if len(pools) == 0 {
+		pools = clusterPoolNames(r.Context(), s)
+	}
+
+	candidates := make([]maxVolumeSizeCandidate, 0, len(pools))
+
+	for _, p := range pools {
+		candidates = append(candidates, maxVolumeSizeCandidate{
+			MaxVolumeSizeKib: info.SpaceInfo.MaxVlmSizeInKib,
+			StoragePool:      p,
+			NodeNames:        poolNodeNamesFor(r.Context(), s, p),
+			AllThin:          false,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, maxVolumeSizeResponse{
+		DefaultMaxOversubscriptionRatio: 1.0,
+		Candidates:                      candidates,
+	})
+}
+
+// decodeQueryMaxVolumeSizeBody decodes the body of the top-level
+// OPTIONS /v1/query-max-volume-size into an AutoSelectFilter. An
+// empty / absent body collapses to the zero filter (no constraints)
+// so a hand-rolled `curl -X OPTIONS .../v1/query-max-volume-size`
+// with no body returns the cluster-wide candidate list rather than
+// 400 (the canonical decodeJSON helper rejects an empty body via the
+// Bug 158 envelope, which is the right call for create/modify paths
+// but wrong for this OPTIONS-with-optional-body endpoint).
+//
+// Returns (filter, true) on success; (_, false) after writing the
+// canonical Bug 158/161 envelope when the body is present but
+// malformed.
+func decodeQueryMaxVolumeSizeBody(w http.ResponseWriter, r *http.Request) (apiv1.AutoSelectFilter, bool) {
+	var filter apiv1.AutoSelectFilter
+
+	// Peek at Content-Length so an absent / empty body skips the
+	// decoder altogether — the canonical decodeJSON treats empty as
+	// 400 + envelope per Bug 158, but this endpoint must permit it.
+	if r.ContentLength == 0 {
+		return filter, true
+	}
+
+	if !decodeJSON(w, r, &filter) {
+		return apiv1.AutoSelectFilter{}, false
+	}
+
+	return filter, true
 }
 
 // handleRGAdjust answers `linstor rg adjust`. Upstream LINSTOR

--- a/pkg/rest/stats.go
+++ b/pkg/rest/stats.go
@@ -20,6 +20,9 @@ package rest
 
 import (
 	"net/http"
+	"slices"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
 )
 
 // registerStats wires the cluster-wide counter endpoint family.
@@ -58,6 +61,13 @@ func (s *Server) registerStats(mux *http.ServeMux) {
 		s.requireStore(s.handleStatsVolumes))
 	mux.HandleFunc("GET /v1/stats/snapshots",
 		s.requireStore(s.handleStatsSnapshots))
+	// Bug-hunt v0.1.3 Finding 13: upstream OpenAPI line 397 declares
+	// /v1/stats/nodes as a per-status histogram surface — `linstor
+	// node stats` and the prometheus-exporter scrape it on a tick.
+	// Pre-fix the apiserver only wired the other six sub-paths so
+	// node stats returned 404.
+	mux.HandleFunc("GET /v1/stats/nodes",
+		s.requireStore(s.handleStatsNodes))
 }
 
 // countEnvelope is the upstream `*Stats` schema shape: a single
@@ -68,6 +78,65 @@ func (s *Server) registerStats(mux *http.ServeMux) {
 type countEnvelope struct {
 	Count int64 `json:"count"`
 }
+
+// nodeStatsEnvelope is the upstream `NodeStats` shape: one `count`
+// total plus per-status sub-counts (online / offline / evicted).
+// Bug-hunt v0.1.3 Finding 13. The field set mirrors what
+// `linstor node stats` and the prometheus-exporter both read from
+// upstream. ConnectionStatus is the satellite-heartbeat-stamped
+// wire field every Node carries; "ONLINE" / "OFFLINE" are the two
+// terminal values, anything else (CONNECTING, UNKNOWN, blank) is
+// treated as not-online by the same convention the Bug 111 gate
+// uses (checkNodeLostAllowed) so the counts stay consistent across
+// surfaces. Evicted is counted independently of online/offline —
+// an EVICTED node may still be ONLINE during the drain phase.
+type nodeStatsEnvelope struct {
+	Count   int64 `json:"count"`
+	Online  int64 `json:"online"`
+	Offline int64 `json:"offline"`
+	Evicted int64 `json:"evicted"`
+}
+
+// handleStatsNodes emits the node-status histogram. Bug-hunt v0.1.3
+// Finding 13: pre-fix `/v1/stats/nodes` 404'd while the six sibling
+// `/v1/stats/<kind>` sub-paths were wired. The four-field shape
+// (count / online / offline / evicted) matches upstream's NodeStats
+// schema (the `linstor node stats` Python CLI dereferences each key
+// unconditionally — anything missing crashes the render).
+func (s *Server) handleStatsNodes(w http.ResponseWriter, r *http.Request) {
+	nodes, err := s.Store.Nodes().List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+
+		return
+	}
+
+	out := nodeStatsEnvelope{Count: int64(len(nodes))}
+
+	for i := range nodes {
+		if nodes[i].ConnectionStatus == nodeConnectionStatusOnline {
+			out.Online++
+		} else {
+			// Treat CONNECTING / UNKNOWN / blank as offline — matches
+			// the Bug 111 gate's "anything not ONLINE is not online"
+			// rule so the histogram stays consistent with the gate.
+			out.Offline++
+		}
+
+		if slices.Contains(nodes[i].Flags, apiv1.NodeFlagEvicted) {
+			out.Evicted++
+		}
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// nodeConnectionStatusOnline is the wire-canonical "satellite is
+// healthy" value of Node.ConnectionStatus. Hoisted to a constant so
+// the stats histogram and any future gate read from one source of
+// truth — typo'ing this string would silently flip every node to
+// "offline" in the histogram.
+const nodeConnectionStatusOnline = "ONLINE"
 
 // handleStatsResourceDefinitions emits the count of resource
 // definitions. Bug 195. List+len is the cheapest implementation —

--- a/tests/contract/testdata/smoke/06-controller-config.json
+++ b/tests/contract/testdata/smoke/06-controller-config.json
@@ -1,7 +1,14 @@
 {
-  "name": "controller config empty object",
+  "name": "controller config populated",
   "method": "GET",
   "path": "/v1/controller/config",
   "expectedStatus": 200,
-  "expectedBody": {}
+  "expectedBody": {
+    "log": {
+      "level": "INFO"
+    },
+    "http": {
+      "enabled": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Bug-hunt v0.1.3 report `2026-05-30-bughunt-v0.1.3.md` flagged seven P3 wire-shape / cosmetic findings. This PR ships six of them; Finding 11 is deferred (rationale below).

Each fix carries a unit test in `pkg/rest/bughunt_p3_wire_shape_test.go` pattern-matching the existing per-finding test layout.

## Findings shipped

- **Finding 3** — `Resource` GET emitted `"volumes":null`. `handleResourceList` / `handleResourceGet` now initialise `ResourceWithVolumes.Volumes` to a non-nil empty slice via `wrapResourceWithVolumes`, so the wire key is always `[]` per the Bug 137 contract. Pre-fix the nil slice serialised as `null`, crashing python-linstor's `rsc._rest_data['volumes']` deref (same class as the historical `KeyError:'size'`).
- **Finding 9** — Phantom-success on `DELETE /v1/nodes/{node}/net-interfaces/{name}` and on `DELETE|POST /v1/nodes/{ghost}/lost`. Both now surface warn-band envelopes (`warnNetInterfaceNotFound = maskWarn | 2059`, `warnNodeAlreadyGone = maskWarn | 2060`) when the target is absent, so audit-log greppers and `*_lost_total` Prometheus alerts distinguish a real teardown from an idempotent replay. Mirrors the Bug 56 / 66 / 198 family pattern.
- **Finding 10** — Top-level `OPTIONS /v1/query-max-volume-size` was 404. Wired the global handler that takes an `AutoSelectFilter` body (empty body collapses to the zero filter, matching upstream's quirk of using OPTIONS with a body). Routes through the same `computeSizeInfo` the RG-scoped variant uses and returns the same `candidates` envelope.
- **Finding 13** — `/v1/stats/nodes` was 404. Wired the per-status histogram (`count` / `online` / `offline` / `evicted`) matching upstream's `NodeStats` schema. `evicted` is counted independently of `online`/`offline` so an EVICTED node during drain still contributes to `online`.
- **Finding 14** — `/v1/resource-definitions/{rd}/files` was 404. Wired as `[]` — blockstor doesn't ship arbitrary external files (operators use `Aux/` props per the report), so the empty list is the upstream-shaped truth.
- **Finding 15** — `/v1/controller/config` returned bare `{}`. Now populates `log.level` (mirrors the runtime `slog.LevelVar` so a `set-log-level` PUT round-trip is the identity) and `http.enabled` (always `true` — the apiserver only exists when HTTP is wired). Other sub-objects (debug / db / https / ldap) stay empty in this PR; they need wider design before being populated.

## Deferred

- **Finding 11** — Wire extensions `Node.unsupported_layers`, `Node.unsupported_providers`, `VolumeState.current_gi`, `DrbdConnection.replication_state`. Accept-as-documented for all four:
  - `VolumeState.current_gi` and `DrbdConnection.replication_state` are documented blockstor extensions the user-facing `r l` CLI rendering depends on (see `blockstor_currentgi_design.md` in memory). Keep call is unambiguous.
  - `Node.unsupported_layers` / `Node.unsupported_providers`: the report's recommendation was to drop these, but the codebase pins them on the wire via `TestNodeListExposesUnsupportedSets` (F2/audit row #1) — `linstor advise` reads them to avoid suggesting unreachable configurations. Removing them without a coordinated F2 invariant rewrite would break that contract. Document the keep choice here; revisit when the F2 audit is itself revisited.

## Test plan

- [x] `go test ./pkg/rest/... ./pkg/api/...` — all pass, including 7 new `TestBughuntP3_*` cases.
- [x] `go test ./...` — full repo green, contract test `TestSmokeTraceReplay` updated to reflect the populated `/v1/controller/config` shape.
- [x] `golangci-lint run ./pkg/rest/... ./pkg/api/...` — 0 issues.