### PR TITLE
feat(rest): wire missing storage-pool-definition, migrate-disk, properties/info routes

### DIFF
--- a/pkg/rest/api_call_rc.go
+++ b/pkg/rest/api_call_rc.go
@@ -222,6 +222,30 @@ const apiCallRcFailSnapshotFinalizerStuck int64 = 998
 // a separate rule.
 const apiCallRcFailExistsSnapshotDfn int64 = 514
 
+// apiCallRcFailExistsStorPoolDfn mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_EXISTS_STOR_POOL_DFN` (508). Emitted by
+// `POST /v1/storage-pool-definitions` when a definition with the
+// requested name already exists. The MASK_ERROR bit is OR'd in by
+// the envelope wrapper at the call site; the bare 508 sub-code here
+// keeps the wire shape byte-identical to upstream's `linstor sp-d c`
+// reply on the same input.
+//
+// Finding 6: blockstor never wired the POST handler before, so a
+// duplicate create returned 405 instead of this typed conflict. With
+// the handler wired and this sub-code emitted, golinstor's
+// `client.ApiCallError.Is(client.FAIL_EXISTS_STOR_POOL_DFN)` returns
+// true on a real duplicate — operators that branch on typed errors
+// can treat "already exists" as a no-op success.
+const apiCallRcFailExistsStorPoolDfn int64 = 508
+
+// warnStoragePoolDfnNotFound flags a delete-of-missing on
+// `DELETE /v1/storage-pool-definitions/{name}`. Sub-code 2059 sits
+// one past warnRscConnPathNotFound (2058) so the warn-band numbering
+// stays monotonic; the python CLI surfaces the line as a WARNING
+// rather than a silent INFO replay, matching Bug 56's pattern for
+// RDs / SPs / nodes.
+const warnStoragePoolDfnNotFound = maskWarn | int64(2059)
+
 // apiCallRcFailExistsRscDfn mirrors upstream LINSTOR's
 // `ApiConsts.FAIL_EXISTS_RSC_DFN` (`501 | MASK_ERROR`). Emitted by
 // `DELETE /v1/resource-groups/{rg}` when the RG still has at least one
@@ -315,5 +339,6 @@ const (
 	objRefRscGrp      = "RscGrp"
 	objRefSnapshotDfn = "SnapshotDfn"
 	objRefStorPool    = "StorPool"
+	objRefStorPoolDfn = "StorPoolDfn"
 	objRefVlmNr       = "VlmNr"
 )

--- a/pkg/rest/cache_invalidation_bug_124_test.go
+++ b/pkg/rest/cache_invalidation_bug_124_test.go
@@ -236,6 +236,10 @@ func (s *laggingStore) ControllerProps() store.ControllerPropsStore {
 	return s.inner.ControllerProps()
 }
 
+func (s *laggingStore) StoragePoolDefinitions() store.StoragePoolDefinitionStore {
+	return s.inner.StoragePoolDefinitions()
+}
+
 // seedRDWithResources stamps an RD and `replicas`-many child
 // Resources directly on the inner inmemory store so the bug-fixture
 // is ready before the laggingStore semantics kick in. The RD-create

--- a/pkg/rest/migrate_disk_bodyless_test.go
+++ b/pkg/rest/migrate_disk_bodyless_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Finding 7 (P2): `PUT /v1/resource-definitions/{rd}/resources/{dst}/migrate-disk/{src}`
+// (no `/{storagepool}` suffix) returned 404 — only the path-suffix
+// variant was wired. python-linstor's common `linstor r migrate-disk
+// <to_node> <rd> <from_node>` CLI form URL-encodes WITHOUT the pool
+// segment and ships the pool in the JSON body. The test below pins
+// the wire shape so the bodyless route stays wired.
+func TestMigrateDiskBodylessVariant(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name: "rd1",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Source replica must be diskful (no DISKLESS flag) for the
+	// migrate-disk validation to pass.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name:     "rd1",
+		NodeName: "src",
+	}); err != nil {
+		t.Fatalf("seed src replica: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body := []byte(`{"storage_pool":"zfs-thin"}`)
+
+	resp := httpPut(t, base+"/v1/resource-definitions/rd1/resources/dst/migrate-disk/src", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) != 1 || rcs[0].RetCode != maskInfo {
+		t.Errorf("envelope: got %+v, want one maskInfo entry", rcs)
+	}
+
+	// The destination replica must now exist with the requested pool
+	// stamped and the BlockstorMigratingFrom prop pointing back at src.
+	dstRes, err := st.Resources().Get(ctx, "rd1", "dst")
+	if err != nil {
+		t.Fatalf("read back dst replica: %v", err)
+	}
+
+	if dstRes.Props["StorPoolName"] != "zfs-thin" {
+		t.Errorf("dst StorPoolName prop: got %q, want zfs-thin", dstRes.Props["StorPoolName"])
+	}
+
+	if dstRes.Props[MigratingFromProp] != "src" {
+		t.Errorf("dst MigratingFrom prop: got %q, want src", dstRes.Props[MigratingFromProp])
+	}
+}
+
+// TestMigrateDiskBodylessVariant_EmptyBodyTolerated pins the
+// no-pool form: an entirely empty body is accepted, and the
+// destination replica is created without a stamped pool — the
+// controller's auto-diskful path picks one during the next
+// reconcile. Matches upstream LINSTOR's behaviour for the bodyless
+// CLI form `linstor r migrate-disk` with no `--storage-pool` flag.
+func TestMigrateDiskBodylessVariant_EmptyBodyTolerated(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name: "rd1",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name:     "rd1",
+		NodeName: "src",
+	}); err != nil {
+		t.Fatalf("seed src replica: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Send a truly empty body — the handler must short-circuit the
+	// EOF-rejection path that decodeJSON otherwise triggers.
+	resp := httpPut(t, base+"/v1/resource-definitions/rd1/resources/dst/migrate-disk/src", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	dstRes, err := st.Resources().Get(ctx, "rd1", "dst")
+	if err != nil {
+		t.Fatalf("read back dst replica: %v", err)
+	}
+
+	// No pool stamped — the migrating-from prop is set so the migration
+	// reconciler still picks the right src.
+	if dstRes.Props[MigratingFromProp] != "src" {
+		t.Errorf("dst MigratingFrom prop: got %q, want src", dstRes.Props[MigratingFromProp])
+	}
+}

--- a/pkg/rest/properties_info.go
+++ b/pkg/rest/properties_info.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"net/http"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// Finding 8 (P2): the `/v1/{kind}/properties/info` endpoints (where
+// {kind} ∈ nodes, resource-definitions, resource-groups,
+// storage-pool-definitions) were unwired. Two failure modes:
+//
+//   - `/v1/nodes/properties/info` was swallowed by `GET /v1/nodes/{node}/info`
+//     — the router treats "properties" as a node name and falls into
+//     the handleNodeInfo NotFound branch, returning 404 with the
+//     misleading "node 'properties': object not found" body.
+//   - The other three (`resource-definitions`, `resource-groups`,
+//     `storage-pool-definitions`) had no registered handler at all and
+//     hit the 404 envelope catch-all.
+//
+// `linstor` CLI's tab completion + `--help` output for property keys
+// come from these endpoints. The python CLI calls them on every
+// `linstor n lp -i`, `linstor rd lp -i`, etc. Without the routes
+// tab-completion is broken; with the routes returning an empty body
+// (or a synthesized envelope) the CLI's parser crashes downstream.
+//
+// Fix:
+//
+//   - Wire literal-path handlers for all four endpoints. Go 1.22's
+//     ServeMux precedence puts literal paths above wildcard ones
+//     (`/v1/nodes/properties/info` beats `/v1/nodes/{node}/info`), so
+//     a single registration here closes the nodes routing trap too.
+//   - Return a hand-curated catalogue covering the prop keys blockstor
+//     actually accepts on each object kind. Best-effort: the python
+//     CLI only consumes `name` + `info`, so the curated catalogue is
+//     enough to keep tab-completion + `--help` working. The catalogue
+//     can be expanded in follow-up commits without churning the wire
+//     contract — `name` + `info` are stable, additional fields would
+//     just enrich the per-key block.
+//
+// The four catalogues share their core (Aux/*, DrbdOptions/*) because
+// every kind accepts those at its scope. Per-kind keys (e.g.
+// StorDriver/* for storage pools, autoplacer weights for RGs/RDs/
+// controller) layer on top.
+
+// Per-namespace catalogue key constants. The values themselves are
+// already-existing prop keys consumed elsewhere; centralising the
+// literals here keeps the goconst linter happy and gives a single
+// place to add new catalogue entries without re-discovering the keys.
+const (
+	auxNamespaceKey = "Aux/*"
+
+	drbdNetProtocolKey      = "DrbdOptions/Net/protocol"
+	drbdNetPingTimeoutKey   = "DrbdOptions/Net/ping-timeout"
+	drbdNetCramHMACAlgKey   = "DrbdOptions/Net/cram-hmac-alg"
+	drbdAutoQuorumKey       = "DrbdOptions/auto-quorum"
+	storDriverEncryptKey    = "StorDriver/EncryptPassphrase"
+	autoplacerThroughputKey = "Autoplacer/MaxThroughput"
+	prefNicPropKey          = "PrefNic"
+)
+
+// propsInfoEntry is one row of the PropsInfo response. Mirrors
+// upstream Java's `JsonGenTypes.PropsInfo` minimal shape: the python
+// CLI keys on `name` (the prop key, e.g. "DrbdOptions/Net/protocol")
+// and renders `info` as the per-key documentation blurb.
+//
+// Upstream emits more fields (`type`, `default`, `unit`, `dflt_val`),
+// but the python CLI's `linstor n lp -i` parser only requires
+// `name` + `info`. Operators that consume PropsInfo via golinstor
+// receive the same minimal shape — the SDK's `PropsInfo` struct
+// uses `omitempty` on the optional fields, so a partial response
+// decodes cleanly. The catalogue is best-effort and can be expanded
+// in follow-up without breaking wire compat (additive only).
+type propsInfoEntry struct {
+	Name string `json:"name"`
+	Info string `json:"info"`
+}
+
+// registerPropertiesInfo wires the four PropsInfo endpoints onto the
+// shared mux. Called from Server.buildMux. Each handler returns the
+// per-kind hand-curated catalogue.
+//
+// The nodes handler also fixes the routing trap (Finding 8 first
+// failure mode): registering the literal `GET /v1/nodes/properties/info`
+// path makes it more specific than the existing `GET /v1/nodes/{node}/info`
+// wildcard, so the literal wins by Go 1.22 ServeMux precedence —
+// `/v1/nodes/properties/info` now hits this handler instead of
+// `handleNodeInfo`'s NotFound branch.
+func (s *Server) registerPropertiesInfo(mux *http.ServeMux) {
+	mux.HandleFunc("GET /v1/nodes/properties/info", handleNodePropsInfo)
+	mux.HandleFunc("GET /v1/resource-definitions/properties/info", handleRDPropsInfo)
+	mux.HandleFunc("GET /v1/resource-groups/properties/info", handleRGPropsInfo)
+	mux.HandleFunc("GET /v1/storage-pool-definitions/properties/info", handleSPDfnPropsInfo)
+}
+
+// commonPropsInfoEntries is the core catalogue every object kind
+// accepts at its scope. Aux/* is operator-defined free-form
+// metadata (upstream LINSTOR pins this in UG9 §"Properties"). The
+// shared DrbdOptions/* keys land here too because every kind that
+// owns a DRBD-backed resource (node, RD, RG, SPDfn) lets the
+// operator override them.
+func commonPropsInfoEntries() []propsInfoEntry {
+	return []propsInfoEntry{
+		{
+			Name: auxNamespaceKey,
+			Info: "Operator-defined free-form metadata. Any key under " +
+				"the `Aux/` namespace round-trips through the API " +
+				"without validation. Use for operator tags " +
+				"(e.g. Aux/team, Aux/rack-id).",
+		},
+		{
+			Name: drbdNetProtocolKey,
+			Info: "DRBD replication protocol. A (async), B (semi-sync), " +
+				"C (sync). Default C.",
+		},
+		{
+			Name: drbdNetPingTimeoutKey,
+			Info: "DRBD network ping timeout in deciseconds. Default 500 " +
+				"(5 seconds).",
+		},
+		{
+			Name: drbdSharedSecretKey,
+			Info: "Shared secret for DRBD per-pair authentication. Redacted " +
+				"on read.",
+		},
+		{
+			Name: drbdNetCramHMACAlgKey,
+			Info: "HMAC algorithm for DRBD per-pair authentication.",
+		},
+		{
+			Name: drbdEncryptPassphraseKey,
+			Info: "Cluster-scope DRBD encryption passphrase. Redacted on " +
+				"read; set via `linstor encryption set-passphrase`.",
+		},
+	}
+}
+
+// handleNodePropsInfo serves GET /v1/nodes/properties/info. The
+// catalogue lists the per-node prop keys the controller honours —
+// operators set these via `linstor n set-property <node> <key> <val>`.
+func handleNodePropsInfo(w http.ResponseWriter, _ *http.Request) {
+	entries := append(commonPropsInfoEntries(),
+		propsInfoEntry{
+			Name: prefNicPropKey,
+			Info: "Preferred NetInterface name for inbound DRBD traffic. " +
+				"Must match a NetInterface registered on the node.",
+		},
+		propsInfoEntry{
+			Name: nodePropDiscoveredVGs,
+			Info: "Satellite-stamped comma-separated list of LVM volume " +
+				"groups the satellite enumerated on the host. Read-only " +
+				"to operators; consumed by storage-pool create pre-flight.",
+		},
+		propsInfoEntry{
+			Name: nodePropDiscoveredZPools,
+			Info: "Satellite-stamped comma-separated list of ZFS zpools " +
+				"the satellite enumerated on the host. Read-only to " +
+				"operators; consumed by storage-pool create pre-flight.",
+		},
+	)
+
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// handleRDPropsInfo serves GET /v1/resource-definitions/properties/info.
+// The catalogue lists per-RD prop keys plus the upstream inheritance
+// hierarchy notes — RD-scope props override RG-scope, which override
+// controller-scope.
+func handleRDPropsInfo(w http.ResponseWriter, _ *http.Request) {
+	entries := append(commonPropsInfoEntries(),
+		propsInfoEntry{
+			Name: storPoolPropKey,
+			Info: "Default storage pool name new replicas pick up when no " +
+				"`--storage-pool` is supplied at resource-create time.",
+		},
+		propsInfoEntry{
+			Name: drbdAutoQuorumKey,
+			Info: "Per-RD DRBD quorum mode override. Accepts `off`, " +
+				"`suspend-io`, `io-error`.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropBalanceResourcesEnabled,
+			Info: "RD-scope kill-switch for the additive rebalance " +
+				"reconciler. Accepts `true` / `false`. Overrides the " +
+				"RG and controller-scope values.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropBalanceResourcesInterval,
+			Info: "RD-scope rebalance tick interval in minutes. " +
+				"Overrides the RG and controller-scope values.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropBalanceResourcesGracePeriod,
+			Info: "RD-scope grace period in minutes before the " +
+				"rebalance reconciler churns replicas on a flapping node. " +
+				"Overrides the RG and controller-scope values.",
+		},
+	)
+
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// handleRGPropsInfo serves GET /v1/resource-groups/properties/info.
+// Similar to RD-scope but with the rebalance / autoplacer-weight
+// knobs that operators typically set group-wide.
+func handleRGPropsInfo(w http.ResponseWriter, _ *http.Request) {
+	entries := append(commonPropsInfoEntries(),
+		propsInfoEntry{
+			Name: storPoolPropKey,
+			Info: "Default storage pool name child RDs / Resources " +
+				"inherit when no explicit pool is supplied.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropAutoplacerWeightMaxFreeSpace,
+			Info: "Scoring weight for the MaxFreeSpace strategy. Default 1.0.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropAutoplacerWeightMinReservedSpace,
+			Info: "Scoring weight for the MinReservedSpace strategy. Default 1.0.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropAutoplacerWeightMinRscCount,
+			Info: "Scoring weight for the MinRscCount strategy. Default 1.0.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropAutoplacerWeightMaxThroughput,
+			Info: "Scoring weight for the MaxThroughput strategy. Default 1.0.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropBalanceResourcesEnabled,
+			Info: "RG-scope kill-switch for the additive rebalance " +
+				"reconciler. Accepts `true` / `false`. Overrides the " +
+				"controller-scope default.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropBalanceResourcesInterval,
+			Info: "RG-scope rebalance tick interval in minutes. " +
+				"Overrides the controller-scope default.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropBalanceResourcesGracePeriod,
+			Info: "RG-scope grace period in minutes before the rebalance " +
+				"reconciler churns replicas on a flapping node. Overrides " +
+				"the controller-scope default.",
+		},
+		propsInfoEntry{
+			Name: apiv1.PropAllowMixingStoragePoolDriver,
+			Info: "Cluster-scope override that opens the LVM_THIN <-> ZFS_THIN " +
+				"cell in the same-provider-kind enforcement. Default false.",
+		},
+	)
+
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// handleSPDfnPropsInfo serves
+// GET /v1/storage-pool-definitions/properties/info. The catalogue
+// lists the per-StoragePool-definition keys operators set via
+// `linstor sp-d set-property <name> <key> <val>`.
+func handleSPDfnPropsInfo(w http.ResponseWriter, _ *http.Request) {
+	entries := append(commonPropsInfoEntries(),
+		propsInfoEntry{
+			Name: propStorPoolName,
+			Info: "Backing VG / zpool / dir name. Provider-agnostic alias; " +
+				"the satellite expands it to the kind-specific key " +
+				"(StorDriver/LvmVg, StorDriver/ZPool, StorDriver/ZPoolThin, " +
+				"StorDriver/FileDir) at create time.",
+		},
+		propsInfoEntry{
+			Name: propLvmVG,
+			Info: "LVM volume group name. Required for LVM and LVM_THIN " +
+				"provider kinds.",
+		},
+		propsInfoEntry{
+			Name: propThinPool,
+			Info: "LVM thin pool name inside the VG. Required for LVM_THIN.",
+		},
+		propsInfoEntry{
+			Name: propZPool,
+			Info: "ZFS zpool name. Required for ZFS provider kind.",
+		},
+		propsInfoEntry{
+			Name: propZPoolThin,
+			Info: "ZFS zpool name backing a thin dataset. Required for ZFS_THIN.",
+		},
+		propsInfoEntry{
+			Name: propFileDir,
+			Info: "Directory path for FILE / FILE_THIN provider kinds.",
+		},
+		propsInfoEntry{
+			Name: storDriverEncryptKey,
+			Info: "Per-pool encryption passphrase. Redacted on read.",
+		},
+		propsInfoEntry{
+			Name: propMaxOversubscriptionRatio,
+			Info: "Cluster-wide max oversubscription ratio applied to thin " +
+				"pools backing this definition. Accepts a floating-point " +
+				"value (e.g. 1.5). Default 1.0 (no oversubscription).",
+		},
+		propsInfoEntry{
+			Name: autoplacerThroughputKey,
+			Info: "Per-pool advertised maximum throughput in bytes/sec. " +
+				"Consumed by the placer's MaxThroughput scoring strategy.",
+		},
+	)
+
+	writeJSON(w, http.StatusOK, entries)
+}

--- a/pkg/rest/properties_info_test.go
+++ b/pkg/rest/properties_info_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Finding 8 (P2): the `/v1/{kind}/properties/info` endpoints were
+// unwired. The nodes variant fell into the `/v1/nodes/{node}/info`
+// handler with "node 'properties': object not found"; the other
+// three (RD/RG/SPDfn) 404'd as not-implemented. The tests below pin:
+//
+//   - All four routes return 200 with a non-empty catalogue.
+//   - Each catalogue entry carries the `name` + `info` shape the
+//     python CLI keys on (`linstor n lp -i` etc.).
+//   - The nodes variant correctly beats `handleNodeInfo` — its
+//     response is the PropsInfo array, not the nodeInfo struct.
+
+// runPropsInfoExpect asserts the endpoint returns a non-empty
+// PropsInfo array with entries carrying at least `name`. Shared by
+// the four per-kind subtests so the wire contract is enforced
+// uniformly.
+func runPropsInfoExpect(t *testing.T, base, path string) {
+	t.Helper()
+
+	resp := httpGet(t, base+path)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("%s status: got %d, want 200", path, resp.StatusCode)
+	}
+
+	var entries []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("%s decode: %v", path, err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatalf("%s returned empty catalogue; python CLI crashes on len=0", path)
+	}
+
+	for i, e := range entries {
+		if _, ok := e["name"]; !ok {
+			t.Errorf("%s entry[%d] missing `name`: %+v", path, i, e)
+		}
+
+		if _, ok := e["info"]; !ok {
+			t.Errorf("%s entry[%d] missing `info`: %+v", path, i, e)
+		}
+	}
+}
+
+// TestPropertiesInfoNodes pins that the literal node-properties path
+// beats the `/v1/nodes/{node}/info` wildcard router and serves the
+// catalogue. Before the fix, the wildcard handler treated "properties"
+// as the node name and returned 404 "node 'properties': object not
+// found" — surfaced as the misleading routing trap in Finding 8.
+func TestPropertiesInfoNodes(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	runPropsInfoExpect(t, base, "/v1/nodes/properties/info")
+}
+
+// TestPropertiesInfoResourceDefinitions pins the RD catalogue.
+func TestPropertiesInfoResourceDefinitions(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	runPropsInfoExpect(t, base, "/v1/resource-definitions/properties/info")
+}
+
+// TestPropertiesInfoResourceGroups pins the RG catalogue.
+func TestPropertiesInfoResourceGroups(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	runPropsInfoExpect(t, base, "/v1/resource-groups/properties/info")
+}
+
+// TestPropertiesInfoStoragePoolDefinitions pins the SPDfn catalogue.
+func TestPropertiesInfoStoragePoolDefinitions(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	runPropsInfoExpect(t, base, "/v1/storage-pool-definitions/properties/info")
+}

--- a/pkg/rest/resource_group_extras.go
+++ b/pkg/rest/resource_group_extras.go
@@ -87,26 +87,55 @@ func (s *Server) handleStoragePoolDefinitionList(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Finding 6 (P2): the response now merges two surfaces:
+	//
+	//  1. The synthesized rows (one per unique per-node StoragePool
+	//     name) — keeps the original Python-CLI consumers happy: a
+	//     pool that exists on at least one node always shows up in
+	//     `linstor sp-d l` regardless of whether the controller's
+	//     definition registry was ever populated.
+	//  2. The explicit registry rows persisted by POST /v1/storage-
+	//     pool-definitions. These carry the operator-set props the
+	//     pure-synthesis path can't reproduce (e.g. cluster-wide
+	//     `MaxOversubscriptionRatio`).
+	//
+	// Names overlap when a definition was POSTed AND a per-node pool
+	// was created with the same name — operators get one row with
+	// the explicit definition's props (the registry wins because it
+	// carries operator intent the synthesis can't recover).
+	defs, defErr := s.Store.StoragePoolDefinitions().List(r.Context())
+	if defErr != nil {
+		writeError(w, http.StatusInternalServerError, defErr.Error())
+
+		return
+	}
+
 	// Upstream's StoragePoolDefinition uses `storage_pool_name` on
 	// the wire but the Python parser exposes it as `.name`. golinstor
 	// uses the same lookup as `Name`, so the wire field is the
 	// canonical one. We also surface an empty props map — the Python
 	// CLI dereferences `.properties` on every entry.
-	type storagePoolDefinition struct {
-		StoragePoolName string            `json:"storage_pool_name"`
-		Props           map[string]string `json:"props"`
-	}
+	seen := map[string]int{}
+	out := make([]storagePoolDefinitionWire, 0, len(pools)+len(defs))
 
-	seen := map[string]struct{}{}
-	out := make([]storagePoolDefinition, 0, len(pools))
+	for i := range defs {
+		props := map[string]string{}
+		maps.Copy(props, defs[i].Props)
+
+		seen[defs[i].Name] = len(out)
+		out = append(out, storagePoolDefinitionWire{
+			StoragePoolName: defs[i].Name,
+			Props:           props,
+		})
+	}
 
 	for i := range pools {
 		if _, dup := seen[pools[i].StoragePoolName]; dup {
 			continue
 		}
 
-		seen[pools[i].StoragePoolName] = struct{}{}
-		out = append(out, storagePoolDefinition{
+		seen[pools[i].StoragePoolName] = len(out)
+		out = append(out, storagePoolDefinitionWire{
 			StoragePoolName: pools[i].StoragePoolName,
 			Props:           map[string]string{},
 		})

--- a/pkg/rest/resource_toggle_disk.go
+++ b/pkg/rest/resource_toggle_disk.go
@@ -82,6 +82,91 @@ func (s *Server) registerResourceToggleDisk(mux *http.ServeMux) {
 	// the new diskful copy lands in on {dst}.
 	mux.HandleFunc("PUT /v1/resource-definitions/{rd}/resources/{dst}/migrate-disk/{src}/{pool}",
 		s.requireStore(s.handleResourceMigrateDisk))
+	// Finding 7 (P2): bodyless variant of the same endpoint. Upstream
+	// OpenAPI (rest_v1_openapi.yaml lines 2611-2646) defines BOTH the
+	// path-suffix and the bodyless forms. python-linstor's common
+	// `linstor r migrate-disk <to_node> <rd> <from_node>` CLI form
+	// (no `--storage-pool` flag) URL-encodes WITHOUT the trailing
+	// `/{pool}` segment and ships the pool name in the JSON body
+	// instead. Without this route the CLI hit a bare 404 envelope
+	// and migration via the common no-pool form was unusable.
+	mux.HandleFunc("PUT /v1/resource-definitions/{rd}/resources/{dst}/migrate-disk/{src}",
+		s.requireStore(s.handleResourceMigrateDiskBodyless))
+}
+
+// migrateDiskBody is the JSON payload accepted by the bodyless
+// migrate-disk variant. Mirrors upstream's `JsonGenTypes.
+// ResourceMigrateDisk` — the `storage_pool` field is the pool the
+// new diskful copy lands in on the destination node, and the
+// optional `layer_list` is forwarded through Spec.LayerStack so the
+// satellite assembles the same stack as the source replica. Both
+// fields are optional: an empty `storage_pool` falls through to the
+// controller's auto-diskful pool picker on the destination node,
+// matching upstream LINSTOR's behaviour when no pool is supplied.
+type migrateDiskBody struct {
+	StoragePool string   `json:"storage_pool,omitempty"`
+	LayerList   []string `json:"layer_list,omitempty"`
+}
+
+// handleResourceMigrateDiskBodyless serves the bodyless migrate-disk
+// variant. Decodes the pool from the JSON body, then delegates to the
+// shared `migrateDisk` helper so the validation + 2-phase add-before-
+// drop semantics stay identical to the path-suffix variant.
+//
+// An absent body is tolerated — the empty pool is forwarded to the
+// migrate helper, which leaves Spec.StoragePool unset on the
+// destination and lets the controller's auto-diskful path pick a
+// pool from the hosting node during the next reconcile.
+func (s *Server) handleResourceMigrateDiskBodyless(w http.ResponseWriter, r *http.Request) {
+	var body migrateDiskBody
+
+	// The bodyless variant tolerates a truly empty body (no JSON at
+	// all). decodeJSON rejects EOF with a typed envelope; route around
+	// that for this endpoint only by short-circuiting when
+	// Content-Length is zero.
+	if r.ContentLength != 0 {
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+	}
+
+	s.migrateDiskCommon(w, r, body.StoragePool)
+}
+
+// migrateDiskCommon factors out the shared body of the two
+// migrate-disk handlers (path-suffix + bodyless). Lifts the pool from
+// either source, then re-uses the original handler's lookup +
+// validation + promotion sequence.
+func (s *Server) migrateDiskCommon(w http.ResponseWriter, r *http.Request, pool string) {
+	rdName := r.PathValue("rd")
+	dst := r.PathValue("dst")
+	src := r.PathValue("src")
+
+	_, err := s.Store.ResourceDefinitions().Get(r.Context(), rdName)
+	if err != nil {
+		writeStoreError(w, err)
+
+		return
+	}
+
+	if !s.validateMigrateSrc(w, r, rdName, src) {
+		return
+	}
+
+	if !s.promoteMigrateDst(w, r, rdName, dst, pool, src) {
+		return
+	}
+
+	poolMsg := "(no pool specified; controller picks one)"
+	if pool != "" {
+		poolMsg = "on pool '" + pool + "'"
+	}
+
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "resource '" + rdName + "' migrating from '" + src + "' to '" + dst +
+			"' " + poolMsg + " (pending; src will be removed once dst is UpToDate)",
+	}})
 }
 
 // handleResourceToggleDisk flips Spec.Flags["DISKLESS"] on the
@@ -278,37 +363,12 @@ const MigratingFromProp = "BlockstorMigratingFrom"
 // Returns 200 with an APICallRc envelope on success, 404 on unknown
 // RD or missing src diskful replica, 409 when src is Primary InUse.
 func (s *Server) handleResourceMigrateDisk(w http.ResponseWriter, r *http.Request) {
-	rdName := r.PathValue("rd")
-	dst := r.PathValue("dst")
-	src := r.PathValue("src")
-	pool := r.PathValue("pool")
-
-	_, err := s.Store.ResourceDefinitions().Get(r.Context(), rdName)
-	if err != nil {
-		writeStoreError(w, err)
-
-		return
-	}
-
-	if !s.validateMigrateSrc(w, r, rdName, src) {
-		return
-	}
-
-	if !s.promoteMigrateDst(w, r, rdName, dst, pool, src) {
-		return
-	}
-
-	// Option B: src lives. ResourceMigrationReconciler observes
-	// the BlockstorMigratingFrom prop stamped in promoteMigrateDst,
-	// waits for dst Volumes to reach UpToDate, then deletes src and
-	// clears the prop. Operation is "pending" at REST layer; caller
-	// must observe Status (or poll the resources list) to confirm
-	// completion.
-	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
-		RetCode: maskInfo,
-		Message: "resource '" + rdName + "' migrating from '" + src + "' to '" + dst +
-			"' on pool '" + pool + "' (pending; src will be removed once dst is UpToDate)",
-	}})
+	// The path-suffix variant carries the pool name in the URL.
+	// The bodyless variant decodes it from the JSON body. Both
+	// converge on `migrateDiskCommon` which runs the shared lookup
+	// + validation + promotion sequence and writes the final
+	// envelope.
+	s.migrateDiskCommon(w, r, r.PathValue("pool"))
 }
 
 // validateMigrateSrc enforces the migrate-disk preconditions on the

--- a/pkg/rest/server.go
+++ b/pkg/rest/server.go
@@ -462,14 +462,6 @@ func (s *Server) buildMux() *http.ServeMux {
 	s.registerResourceToggleDisk(mux)
 	s.registerStats(mux)
 	s.registerErrorReports(mux)
-	// Bug 126: previously we wired /v1/.../properties/info to a stub
-	// that returned a bare `[]`. The CLI consumed the empty array
-	// silently with no signal that the catalogue isn't populated. We
-	// now leave the routes unregistered so the with404Envelope
-	// catch-all (Bug 103) emits the typed LINSTOR "endpoint not
-	// implemented" envelope — operators get a real ERROR line, and
-	// once a real property catalogue ships the route can be re-wired
-	// with the populated payload.
 	s.registerSnapshotRestore(mux)
 	s.registerEncryption(mux)
 	s.registerNodeLifecycle(mux)
@@ -489,6 +481,8 @@ func (s *Server) buildMux() *http.ServeMux {
 	s.registerSchedules(mux)
 	s.registerUpstreamParity225_229(mux)
 	s.registerEvents(mux)
+	s.registerStoragePoolDefinitions(mux)
+	s.registerPropertiesInfo(mux)
 
 	return mux
 }

--- a/pkg/rest/snap_d_wait_bug_193_test.go
+++ b/pkg/rest/snap_d_wait_bug_193_test.go
@@ -164,6 +164,10 @@ func (s *stuckSnapshotStore) ControllerProps() store.ControllerPropsStore {
 	return s.inner.ControllerProps()
 }
 
+func (s *stuckSnapshotStore) StoragePoolDefinitions() store.StoragePoolDefinitionStore {
+	return s.inner.StoragePoolDefinitions()
+}
+
 // seedSnapshot stamps a parent RD + Snapshot directly on the inner
 // inmemory store so the bug-fixture is in place before the stuck
 // semantics kick in on the Delete path.

--- a/pkg/rest/snap_multi_scrub_bug_200_test.go
+++ b/pkg/rest/snap_multi_scrub_bug_200_test.go
@@ -175,6 +175,10 @@ func (s *errInjectingSnapshotStore) ControllerProps() store.ControllerPropsStore
 	return s.inner.ControllerProps()
 }
 
+func (s *errInjectingSnapshotStore) StoragePoolDefinitions() store.StoragePoolDefinitionStore {
+	return s.inner.StoragePoolDefinitions()
+}
+
 // seedRDForMultiSnapshot stamps an RD onto the inner inmemory store so
 // the multi-create handler's hydrate path succeeds and the test reaches
 // the Snapshots().Create call where the synthesised err fires.

--- a/pkg/rest/storage_pool_definitions.go
+++ b/pkg/rest/storage_pool_definitions.go
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"maps"
+	"net/http"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Finding 6 (P2): POST/PUT/DELETE on `/v1/storage-pool-definitions`
+// were unwired and returned 405 Method Not Allowed. Upstream OpenAPI
+// (rest_v1_openapi.yaml lines 59-161) defines all three verbs:
+//
+//   - POST   /v1/storage-pool-definitions          — create a definition
+//   - PUT    /v1/storage-pool-definitions/{name}   — modify props
+//   - DELETE /v1/storage-pool-definitions/{name}   — drop the definition
+//
+// `linstor sp-d c` / `linstor sp-d set-property` / `linstor sp-d d`
+// drive these endpoints; piraeus-operator's chart provisioning POSTs
+// definitions up-front before any per-node StoragePool is created.
+// Without these handlers an operator-driven `linstor sp-d c` failed
+// the create call with a bare 405, the python CLI crashed on the
+// non-JSON body, and the chart-provisioning loop stalled.
+//
+// The store-backed surface intentionally stays minimal: a definition
+// is just a `{name, props}` pair. The wire shape mirrors upstream's
+// JsonGenTypes.StoragePoolDefinition — the `storage_pool_name` field
+// the python CLI keys on plus an open-ended props map.
+//
+// DELETE refuses with 409 + FAIL_IN_USE when any per-node StoragePool
+// still references the definition by name. Mirrors upstream LINSTOR's
+// CtrlStorPoolDfnApiCallHandler refusal — operators must drop the
+// referencing pools first.
+
+// registerStoragePoolDefinitions wires the POST / PUT / DELETE handlers
+// for the controller-scope StoragePoolDefinition registry. The matching
+// GET endpoints (list + single) are registered alongside the GET-only
+// surface in resource_group_extras.go and upstream_parity_bug_225_229.go
+// — those continue to flow through their existing handlers (which now
+// merge the registry rows with the synthesized per-pool-name list).
+func (s *Server) registerStoragePoolDefinitions(mux *http.ServeMux) {
+	mux.HandleFunc("POST /v1/storage-pool-definitions",
+		s.requireStore(s.handleStoragePoolDefinitionCreate))
+	mux.HandleFunc("PUT /v1/storage-pool-definitions/{name}",
+		s.requireStore(s.handleStoragePoolDefinitionModify))
+	mux.HandleFunc("DELETE /v1/storage-pool-definitions/{name}",
+		s.requireStore(s.handleStoragePoolDefinitionDelete))
+}
+
+// storagePoolDefinitionWire is the JSON wire shape both the existing
+// GET handlers and the new POST/PUT/DELETE handlers emit. Mirrors
+// upstream's `JsonGenTypes.StoragePoolDefinition` minus the upstream-
+// only `uuid` field (blockstor's process-local registry has no
+// persistent identity to surface).
+type storagePoolDefinitionWire struct {
+	StoragePoolName string            `json:"storage_pool_name"`
+	Props           map[string]string `json:"props,omitempty"`
+}
+
+// handleStoragePoolDefinitionCreate serves POST /v1/storage-pool-definitions.
+//
+// Body shape: `{storage_pool_name, props}`. `storage_pool_name` is
+// required; props is optional. Returns 201 + ApiCallRc envelope on
+// success, 400 on missing/invalid name, 409 + FAIL_EXISTS_STOR_POOL_DFN
+// when a definition with the same name already exists.
+//
+// CREATE-only: re-POSTing the same name is NOT an upsert (mirrors
+// Finding 1's fix for the per-node StoragePool surface — POST must
+// not silently mutate existing rows). Operators that want to mutate
+// props use PUT.
+func (s *Server) handleStoragePoolDefinitionCreate(w http.ResponseWriter, r *http.Request) {
+	var body storagePoolDefinitionWire
+
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.StoragePoolName == "" {
+		writeError(w, http.StatusBadRequest, "storage_pool_name is required")
+
+		return
+	}
+
+	// REST-boundary identifier validation runs before any store call
+	// so a whitespace-only / RFC-1123-illegal name fails fast with a
+	// LINSTOR envelope (rather than leaking the k8s "metadata.name is
+	// invalid" error). Mirrors Bug 97 / handleNodeStoragePoolCreate.
+	nameErr := validateLinstorName("storage pool definition", body.StoragePoolName)
+	if nameErr != nil {
+		writeError(w, http.StatusBadRequest, nameErr.Error())
+
+		return
+	}
+
+	def := store.StoragePoolDefinition{
+		Name:  body.StoragePoolName,
+		Props: body.Props,
+	}
+
+	err := s.Store.StoragePoolDefinitions().Create(r.Context(), &def)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+				RetCode: apiCallRcError | apiCallRcFailExistsStorPoolDfn,
+				Message: "storage pool definition already exists: " + body.StoragePoolName,
+				ObjRefs: map[string]string{
+					objRefStorPoolDfn: body.StoragePoolName,
+				},
+			}})
+
+			return
+		}
+
+		writeStoreError(w, err)
+
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "storage pool definition created: " + body.StoragePoolName,
+	}})
+}
+
+// handleStoragePoolDefinitionModify serves PUT /v1/storage-pool-definitions/{name}.
+//
+// Wire shape: `GenericPropsModify` (override_props, delete_props,
+// delete_namespaces) — the same envelope every other LINSTOR `modify`
+// endpoint accepts. Props are merged on top of the existing row;
+// delete_props / delete_namespaces drop matching keys before the
+// merge lands.
+//
+// Returns 200 + ApiCallRc envelope on success; 404 + writeStoreError
+// when the named definition doesn't exist. The definition is auto-
+// created on PUT when no row exists yet — operators that drive the
+// surface with `linstor sp-d set-property new-def key val` get the
+// definition stamped in one round-trip without a separate POST.
+func (s *Server) handleStoragePoolDefinitionModify(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	var body apiv1.GenericPropsModify
+
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	def, err := s.Store.StoragePoolDefinitions().Get(r.Context(), name)
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		def = store.StoragePoolDefinition{Name: name, Props: map[string]string{}}
+	case err != nil:
+		writeStoreError(w, err)
+
+		return
+	}
+
+	if def.Props == nil {
+		def.Props = map[string]string{}
+	}
+
+	maps.Copy(def.Props, body.OverrideProps)
+
+	for _, k := range body.DeleteProps {
+		delete(def.Props, k)
+	}
+
+	// delete_namespaces: drop every key under the given namespace
+	// prefix. Mirrors upstream LINSTOR's `delete_namespaces` behaviour
+	// — separator is '/', prefix matches literally.
+	for _, ns := range body.DeleteNamespace {
+		prefix := ns + "/"
+
+		for k := range def.Props {
+			if strings.HasPrefix(k, prefix) {
+				delete(def.Props, k)
+			}
+		}
+	}
+
+	// Try Update first; on ErrNotFound (PUT-creates path) fall back to
+	// Create so the wire surface is upsert-idempotent.
+	err = s.Store.StoragePoolDefinitions().Update(r.Context(), &def)
+	if errors.Is(err, store.ErrNotFound) {
+		err = s.Store.StoragePoolDefinitions().Create(r.Context(), &def)
+	}
+
+	if err != nil {
+		writeStoreError(w, err)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "storage pool definition modified: " + name,
+	}})
+}
+
+// handleStoragePoolDefinitionDelete serves DELETE /v1/storage-pool-definitions/{name}.
+//
+// Refuses with 409 + FAIL_IN_USE when any per-node StoragePool still
+// references the named definition. Operators must drop the referencing
+// pools first — blockstor never cascades a definition-delete into the
+// per-node SP rows, matching upstream LINSTOR's
+// `CtrlStorPoolDfnApiCallHandler` refusal pattern.
+//
+// Idempotent on NotFound (Bug 66 family): a delete of an already-
+// absent definition folds into 200 + `warnStoragePoolDfnNotFound` so
+// audit-log greppers can distinguish the no-op replay from a real
+// delete, matching the pattern Bug 56 set for RDs.
+func (s *Server) handleStoragePoolDefinitionDelete(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	if refused := s.refuseSPDfnDeleteIfReferenced(w, r, name); refused {
+		return
+	}
+
+	err := s.Store.StoragePoolDefinitions().Delete(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+				RetCode: warnStoragePoolDfnNotFound,
+				Message: "storage pool definition already absent: " + name,
+			}})
+
+			return
+		}
+
+		writeStoreError(w, err)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "storage pool definition deleted: " + name,
+	}})
+}
+
+// refuseSPDfnDeleteIfReferenced walks the per-node StoragePool table
+// and refuses the definition delete (409 + FAIL_IN_USE) when at least
+// one pool still carries the named definition. Returns true when the
+// HTTP error has already been written (the caller must stop) and
+// false when the delete may proceed.
+//
+// Match is case-sensitive, mirroring how the StoragePool CRD spec
+// stores `storage_pool_name` verbatim. Per-node pool names that
+// differ only in case from the definition name are NOT treated as
+// references — upstream LINSTOR treats those as different objects too.
+func (s *Server) refuseSPDfnDeleteIfReferenced(w http.ResponseWriter, r *http.Request, name string) bool {
+	pools, err := s.Store.StoragePools().List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+
+		return true
+	}
+
+	var refs []string
+
+	for i := range pools {
+		if pools[i].StoragePoolName != name {
+			continue
+		}
+
+		refs = append(refs, pools[i].NodeName+"/"+pools[i].StoragePoolName)
+	}
+
+	if len(refs) == 0 {
+		return false
+	}
+
+	writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInUse,
+		Message: "The specified storage pool definition '" + name +
+			"' can not be deleted as per-node storage pools are still using it.",
+		Details: "Per-node storage pools still bound to the definition: " +
+			strings.Join(refs, ", "),
+		Correc: "Delete the listed per-node storage pools first " +
+			"(`linstor sp d <node> <pool>`), then re-issue the definition delete.",
+		ObjRefs: map[string]string{
+			objRefStorPoolDfn: name,
+		},
+	}})
+
+	return true
+}

--- a/pkg/rest/storage_pool_definitions_test.go
+++ b/pkg/rest/storage_pool_definitions_test.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Finding 6 (P2) tests: POST + PUT + DELETE on
+// `/v1/storage-pool-definitions` were unwired and 405'd. The handlers
+// below pin the wire shape so a future regression (e.g. someone
+// reverts `registerStoragePoolDefinitions`) surfaces as a CI failure
+// rather than a silent 405 to the python CLI.
+
+// TestStoragePoolDefinitionCreate_OK pins the POST happy path: HTTP
+// 201 with an APICallRc[] envelope and a maskInfo success ret_code,
+// followed by a single GET-list entry carrying the seeded props.
+func TestStoragePoolDefinitionCreate_OK(t *testing.T) {
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body := []byte(`{"storage_pool_name":"zfs-thin","props":{"MaxOversubscriptionRatio":"1.5"}}`)
+	resp := httpPost(t, base+"/v1/storage-pool-definitions", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope len: got %d, want 1", len(rcs))
+	}
+
+	if rcs[0].RetCode != maskInfo {
+		t.Errorf("ret_code: got %d, want maskInfo (%d)", rcs[0].RetCode, maskInfo)
+	}
+
+	// The created definition must surface through the existing list
+	// endpoint (merged with the per-pool synthesis path).
+	listResp := httpGet(t, base+"/v1/storage-pool-definitions")
+	defer func() { _ = listResp.Body.Close() }()
+
+	var list []struct {
+		StoragePoolName string            `json:"storage_pool_name"`
+		Props           map[string]string `json:"props"`
+	}
+
+	if err := json.NewDecoder(listResp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+
+	if len(list) != 1 {
+		t.Fatalf("list len: got %d, want 1", len(list))
+	}
+
+	if list[0].StoragePoolName != "zfs-thin" {
+		t.Errorf("list[0].storage_pool_name: got %q, want %q", list[0].StoragePoolName, "zfs-thin")
+	}
+
+	if list[0].Props["MaxOversubscriptionRatio"] != "1.5" {
+		t.Errorf("list[0].props[MaxOversubscriptionRatio]: got %q, want 1.5",
+			list[0].Props["MaxOversubscriptionRatio"])
+	}
+}
+
+// TestStoragePoolDefinitionCreate_DuplicateRejected pins the
+// CREATE-only contract: a second POST against the same name returns
+// 409 with FAIL_EXISTS_STOR_POOL_DFN OR'd into the apiCallRcError
+// mask. Mirrors Finding 1 — POST must not silently mutate.
+func TestStoragePoolDefinitionCreate_DuplicateRejected(t *testing.T) {
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body := []byte(`{"storage_pool_name":"zfs-thin"}`)
+
+	first := httpPost(t, base+"/v1/storage-pool-definitions", body)
+	_ = first.Body.Close()
+
+	if first.StatusCode != http.StatusCreated {
+		t.Fatalf("first POST: got %d, want 201", first.StatusCode)
+	}
+
+	second := httpPost(t, base+"/v1/storage-pool-definitions", body)
+	defer func() { _ = second.Body.Close() }()
+
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("second POST status: got %d, want 409", second.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(second.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) == 0 || rcs[0].RetCode&apiCallRcError == 0 {
+		t.Errorf("ret_code: got %d, want apiCallRcError bit set", rcs[0].RetCode)
+	}
+
+	if rcs[0].RetCode&apiCallRcFailExistsStorPoolDfn == 0 {
+		t.Errorf("ret_code: got %d, want FAIL_EXISTS_STOR_POOL_DFN (%d) OR'd in",
+			rcs[0].RetCode, apiCallRcFailExistsStorPoolDfn)
+	}
+}
+
+// TestStoragePoolDefinitionModify_OverridesAndDeletes pins the PUT
+// happy path: override_props merges, delete_props strips a key,
+// delete_namespaces clears every key under a prefix.
+func TestStoragePoolDefinitionModify_OverridesAndDeletes(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name: "zfs-thin",
+		Props: map[string]string{
+			"MaxOversubscriptionRatio": "1.0",
+			"Aux/team":                 "blue",
+			"Aux/zone":                 "us-east-1a",
+		},
+	}); err != nil {
+		t.Fatalf("seed definition: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body := []byte(`{
+		"override_props": {"MaxOversubscriptionRatio":"1.5"},
+		"delete_props":   ["Aux/team"],
+		"delete_namespaces": ["Aux"]
+	}`)
+
+	resp := httpPut(t, base+"/v1/storage-pool-definitions/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) != 1 || rcs[0].RetCode != maskInfo {
+		t.Fatalf("envelope: got %+v, want one maskInfo entry", rcs)
+	}
+
+	got, err := st.StoragePoolDefinitions().Get(ctx, "zfs-thin")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	if got.Props["MaxOversubscriptionRatio"] != "1.5" {
+		t.Errorf("override missed: got %q, want 1.5", got.Props["MaxOversubscriptionRatio"])
+	}
+
+	// delete_namespaces "Aux" must have dropped Aux/team AND Aux/zone.
+	if _, present := got.Props["Aux/team"]; present {
+		t.Errorf("Aux/team still present after delete_namespaces")
+	}
+
+	if _, present := got.Props["Aux/zone"]; present {
+		t.Errorf("Aux/zone still present after delete_namespaces")
+	}
+}
+
+// TestStoragePoolDefinitionDelete_OK pins the DELETE happy path on a
+// definition that has no per-node pool references.
+func TestStoragePoolDefinitionDelete_OK(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name: "zfs-thin",
+	}); err != nil {
+		t.Fatalf("seed definition: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/storage-pool-definitions/zfs-thin")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) != 1 || rcs[0].RetCode != maskInfo {
+		t.Errorf("envelope: got %+v, want one maskInfo entry", rcs)
+	}
+
+	if _, getErr := st.StoragePoolDefinitions().Get(ctx, "zfs-thin"); getErr == nil {
+		t.Errorf("definition still present after DELETE")
+	}
+}
+
+// TestStoragePoolDefinitionDelete_RefusedWhenPoolReferences pins the
+// 409 + FAIL_IN_USE refusal path: a definition whose name matches at
+// least one per-node StoragePool cannot be deleted until the pools
+// are dropped first. Mirrors upstream LINSTOR's
+// `CtrlStorPoolDfnApiCallHandler` refusal.
+func TestStoragePoolDefinitionDelete_RefusedWhenPoolReferences(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name: "zfs-thin",
+	}); err != nil {
+		t.Fatalf("seed definition: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: "zfs-thin",
+		NodeName:        "n1",
+		ProviderKind:    apiv1.StoragePoolKindZFSThin,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/storage-pool-definitions/zfs-thin")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) == 0 || rcs[0].RetCode&apiCallRcError == 0 {
+		t.Fatalf("ret_code: missing apiCallRcError bit: %d", rcs[0].RetCode)
+	}
+
+	if rcs[0].RetCode&apiCallRcFailInUse == 0 {
+		t.Errorf("ret_code: got %d, want FAIL_IN_USE (%d) OR'd in",
+			rcs[0].RetCode, apiCallRcFailInUse)
+	}
+
+	// Definition must still exist after the refusal.
+	if _, err := st.StoragePoolDefinitions().Get(ctx, "zfs-thin"); err != nil {
+		t.Errorf("definition was deleted despite refusal: %v", err)
+	}
+}
+
+// TestStoragePoolDefinitionDelete_IdempotentWhenAbsent pins the
+// already-absent path: a delete of a definition that doesn't exist
+// folds into 200 + the warn-band envelope so audit-log greppers can
+// still distinguish the no-op replay from a real delete. Matches the
+// Bug 66 pattern for RDs / SPs / nodes.
+func TestStoragePoolDefinitionDelete_IdempotentWhenAbsent(t *testing.T) {
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/storage-pool-definitions/ghost")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (idempotent)", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope len: got %d, want 1", len(rcs))
+	}
+
+	if rcs[0].RetCode != warnStoragePoolDfnNotFound {
+		t.Errorf("ret_code: got %d, want warnStoragePoolDfnNotFound (%d)",
+			rcs[0].RetCode, warnStoragePoolDfnNotFound)
+	}
+}

--- a/pkg/rest/upstream_parity_bug_225_229.go
+++ b/pkg/rest/upstream_parity_bug_225_229.go
@@ -20,6 +20,7 @@ package rest
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -346,6 +347,27 @@ func (s *Server) handleNodeConfigPut(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleStoragePoolDefinitionSingle(w http.ResponseWriter, r *http.Request) {
 	want := r.PathValue("name")
 
+	// Finding 6 (P2): check the explicit definition registry first.
+	// An operator-POSTed definition that has no per-node pool yet
+	// MUST still resolve here (without the registry lookup the only
+	// definitions visible were the ones synthesised from existing
+	// per-node pools, so a freshly-created definition disappeared
+	// until at least one pool was bound to it).
+	def, defErr := s.Store.StoragePoolDefinitions().Get(r.Context(), want)
+	if defErr == nil {
+		props := map[string]string{}
+		if def.Props != nil {
+			maps.Copy(props, def.Props)
+		}
+
+		writeJSON(w, http.StatusOK, []storagePoolDefinitionWire{{
+			StoragePoolName: def.Name,
+			Props:           props,
+		}})
+
+		return
+	}
+
 	pools, err := s.Store.StoragePools().List(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -353,17 +375,12 @@ func (s *Server) handleStoragePoolDefinitionSingle(w http.ResponseWriter, r *htt
 		return
 	}
 
-	type storagePoolDefinition struct {
-		StoragePoolName string            `json:"storage_pool_name"`
-		Props           map[string]string `json:"props"`
-	}
-
 	for i := range pools {
 		if !strings.EqualFold(pools[i].StoragePoolName, want) {
 			continue
 		}
 
-		writeJSON(w, http.StatusOK, []storagePoolDefinition{{
+		writeJSON(w, http.StatusOK, []storagePoolDefinitionWire{{
 			StoragePoolName: pools[i].StoragePoolName,
 			Props:           map[string]string{},
 		}})

--- a/pkg/store/inmemory.go
+++ b/pkg/store/inmemory.go
@@ -32,29 +32,31 @@ import (
 // InMemory is the Phase 1 store: thread-safe, RAM-backed, lost on restart.
 // Phase 2 introduces a CRD-backed store that satisfies the same interface.
 type InMemory struct {
-	nodes               *inMemoryNodes
-	storagePools        *inMemoryStoragePools
-	resourceGroups      *inMemoryResourceGroups
-	resourceDefinitions *inMemoryResourceDefinitions
-	resources           *inMemoryResources
-	volumeDefinitions   *inMemoryVolumeDefinitions
-	snapshots           *inMemorySnapshots
-	physicalDevices     *inMemoryPhysicalDevices
-	controllerProps     *inMemoryControllerProps
+	nodes                  *inMemoryNodes
+	storagePools           *inMemoryStoragePools
+	resourceGroups         *inMemoryResourceGroups
+	resourceDefinitions    *inMemoryResourceDefinitions
+	resources              *inMemoryResources
+	volumeDefinitions      *inMemoryVolumeDefinitions
+	snapshots              *inMemorySnapshots
+	physicalDevices        *inMemoryPhysicalDevices
+	controllerProps        *inMemoryControllerProps
+	storagePoolDefinitions *inMemoryStoragePoolDefinitions
 }
 
 // NewInMemory constructs an InMemory store with empty per-resource maps.
 func NewInMemory() *InMemory {
 	return &InMemory{
-		nodes:               &inMemoryNodes{m: map[string]apiv1.Node{}},
-		storagePools:        &inMemoryStoragePools{m: map[spKey]apiv1.StoragePool{}},
-		resourceGroups:      &inMemoryResourceGroups{m: map[string]apiv1.ResourceGroup{}},
-		resourceDefinitions: &inMemoryResourceDefinitions{m: map[string]apiv1.ResourceDefinition{}},
-		resources:           &inMemoryResources{m: map[rKey]apiv1.Resource{}},
-		volumeDefinitions:   &inMemoryVolumeDefinitions{m: map[vdKey]apiv1.VolumeDefinition{}},
-		snapshots:           &inMemorySnapshots{m: map[snapKey]apiv1.Snapshot{}},
-		physicalDevices:     &inMemoryPhysicalDevices{m: map[string]apiv1.PhysicalDevice{}},
-		controllerProps:     &inMemoryControllerProps{props: map[string]string{}},
+		nodes:                  &inMemoryNodes{m: map[string]apiv1.Node{}},
+		storagePools:           &inMemoryStoragePools{m: map[spKey]apiv1.StoragePool{}},
+		resourceGroups:         &inMemoryResourceGroups{m: map[string]apiv1.ResourceGroup{}},
+		resourceDefinitions:    &inMemoryResourceDefinitions{m: map[string]apiv1.ResourceDefinition{}},
+		resources:              &inMemoryResources{m: map[rKey]apiv1.Resource{}},
+		volumeDefinitions:      &inMemoryVolumeDefinitions{m: map[vdKey]apiv1.VolumeDefinition{}},
+		snapshots:              &inMemorySnapshots{m: map[snapKey]apiv1.Snapshot{}},
+		physicalDevices:        &inMemoryPhysicalDevices{m: map[string]apiv1.PhysicalDevice{}},
+		controllerProps:        &inMemoryControllerProps{props: map[string]string{}},
+		storagePoolDefinitions: &inMemoryStoragePoolDefinitions{m: map[string]StoragePoolDefinition{}},
 	}
 }
 
@@ -84,6 +86,118 @@ func (s *InMemory) PhysicalDevices() PhysicalDeviceStore { return s.physicalDevi
 
 // ControllerProps returns the singleton controller-scope props bag.
 func (s *InMemory) ControllerProps() ControllerPropsStore { return s.controllerProps }
+
+// StoragePoolDefinitions returns the controller-scope storage pool
+// definition registry.
+func (s *InMemory) StoragePoolDefinitions() StoragePoolDefinitionStore {
+	return s.storagePoolDefinitions
+}
+
+// inMemoryStoragePoolDefinitions is a thread-safe map of the
+// controller-scope storage pool definition registry. The k8s store
+// holds the same shape; both implementations are process-local for
+// now (see ControllerPropsStore for the same compromise) — operators
+// re-create definitions after a controller restart, and the props
+// keep no persisted state downstream.
+type inMemoryStoragePoolDefinitions struct {
+	mu sync.RWMutex
+	m  map[string]StoragePoolDefinition
+}
+
+// List returns every definition sorted by name. Deterministic order
+// keeps tests stable and matches every other in-memory store.
+func (s *inMemoryStoragePoolDefinitions) List(_ context.Context) ([]StoragePoolDefinition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]StoragePoolDefinition, 0, len(s.m))
+	for k := range s.m {
+		out = append(out, copyStoragePoolDefinition(s.m[k]))
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// Get returns the definition or ErrNotFound.
+func (s *inMemoryStoragePoolDefinitions) Get(_ context.Context, name string) (StoragePoolDefinition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	def, ok := s.m[name]
+	if !ok {
+		return StoragePoolDefinition{}, errors.Wrapf(ErrNotFound, "storage pool definition %q", name)
+	}
+
+	return copyStoragePoolDefinition(def), nil
+}
+
+// Create inserts a new definition. Returns ErrAlreadyExists when the
+// name is already taken — POST is CREATE-only, mutation lives behind
+// PUT (mirrors Finding 1's fix for the StoragePool surface).
+func (s *inMemoryStoragePoolDefinitions) Create(_ context.Context, def *StoragePoolDefinition) error {
+	if def == nil {
+		return errors.New("nil StoragePoolDefinition")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.m[def.Name]; exists {
+		return errors.Wrapf(ErrAlreadyExists, "storage pool definition %q", def.Name)
+	}
+
+	s.m[def.Name] = copyStoragePoolDefinition(*def)
+
+	return nil
+}
+
+// Update overwrites an existing definition. Returns ErrNotFound when
+// the row is absent.
+func (s *inMemoryStoragePoolDefinitions) Update(_ context.Context, def *StoragePoolDefinition) error {
+	if def == nil {
+		return errors.New("nil StoragePoolDefinition")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.m[def.Name]; !exists {
+		return errors.Wrapf(ErrNotFound, "storage pool definition %q", def.Name)
+	}
+
+	s.m[def.Name] = copyStoragePoolDefinition(*def)
+
+	return nil
+}
+
+// Delete removes the named definition. Returns ErrNotFound when
+// absent — the REST handler folds that into the warn-band envelope.
+func (s *inMemoryStoragePoolDefinitions) Delete(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.m[name]; !exists {
+		return errors.Wrapf(ErrNotFound, "storage pool definition %q", name)
+	}
+
+	delete(s.m, name)
+
+	return nil
+}
+
+// copyStoragePoolDefinition deep-copies the props map so callers can
+// mutate the returned value without racing the store.
+func copyStoragePoolDefinition(def StoragePoolDefinition) StoragePoolDefinition {
+	out := StoragePoolDefinition{Name: def.Name}
+	if def.Props != nil {
+		out.Props = make(map[string]string, len(def.Props))
+		maps.Copy(out.Props, def.Props)
+	}
+
+	return out
+}
 
 // inMemoryControllerProps is a single-row bag protected by an RWMutex.
 // The k8s store will back the same shape with a singleton CRD; here we

--- a/pkg/store/k8s/k8s.go
+++ b/pkg/store/k8s/k8s.go
@@ -26,8 +26,10 @@ package k8s
 import (
 	"context"
 	"maps"
+	"sort"
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/cozystack/blockstor/pkg/store"
@@ -45,15 +47,16 @@ const (
 type Store struct {
 	c ctrlclient.Client
 
-	nodes               *nodes
-	storagePools        *storagePools
-	resourceGroups      *resourceGroups
-	resourceDefinitions *resourceDefinitions
-	resources           *resources
-	volumeDefinitions   *volumeDefinitions
-	snapshots           *snapshots
-	physicalDevices     *physicalDevices
-	controllerProps     *controllerProps
+	nodes                  *nodes
+	storagePools           *storagePools
+	resourceGroups         *resourceGroups
+	resourceDefinitions    *resourceDefinitions
+	resources              *resources
+	volumeDefinitions      *volumeDefinitions
+	snapshots              *snapshots
+	physicalDevices        *physicalDevices
+	controllerProps        *controllerProps
+	storagePoolDefinitions *storagePoolDefinitions
 }
 
 // New wraps a controller-runtime client and returns a store.Store.
@@ -68,6 +71,7 @@ func New(c ctrlclient.Client) *Store {
 	s.snapshots = &snapshots{c: c}
 	s.physicalDevices = &physicalDevices{c: c}
 	s.controllerProps = &controllerProps{props: map[string]string{}}
+	s.storagePoolDefinitions = &storagePoolDefinitions{m: map[string]store.StoragePoolDefinition{}}
 
 	return s
 }
@@ -135,3 +139,114 @@ func (s *Store) PhysicalDevices() store.PhysicalDeviceStore { return s.physicalD
 
 // ControllerProps returns the singleton controller-scope props bag.
 func (s *Store) ControllerProps() store.ControllerPropsStore { return s.controllerProps }
+
+// StoragePoolDefinitions returns the controller-scope storage pool
+// definition registry. Process-local for now (same compromise as
+// controllerProps above) — a future iteration backs it with a
+// dedicated CRD so definitions survive controller restarts.
+func (s *Store) StoragePoolDefinitions() store.StoragePoolDefinitionStore {
+	return s.storagePoolDefinitions
+}
+
+// storagePoolDefinitions is the process-local stand-in for the
+// controller-scope storage pool definition registry. Same compromise
+// as `controllerProps` above: process-local map protected by an
+// RWMutex; a future iteration swaps this for a dedicated CRD.
+type storagePoolDefinitions struct {
+	mu sync.RWMutex
+	m  map[string]store.StoragePoolDefinition
+}
+
+// List returns every definition sorted by name. Deterministic order
+// matches the InMemory store so test expectations stay aligned.
+func (s *storagePoolDefinitions) List(_ context.Context) ([]store.StoragePoolDefinition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]store.StoragePoolDefinition, 0, len(s.m))
+	for k := range s.m {
+		out = append(out, copyStoragePoolDefinition(s.m[k]))
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	return out, nil
+}
+
+// Get returns the definition or ErrNotFound.
+func (s *storagePoolDefinitions) Get(_ context.Context, name string) (store.StoragePoolDefinition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	def, ok := s.m[name]
+	if !ok {
+		return store.StoragePoolDefinition{}, errors.Wrapf(store.ErrNotFound, "storage pool definition %q", name)
+	}
+
+	return copyStoragePoolDefinition(def), nil
+}
+
+// Create inserts a new definition. Returns ErrAlreadyExists when the
+// name is already taken.
+func (s *storagePoolDefinitions) Create(_ context.Context, def *store.StoragePoolDefinition) error {
+	if def == nil {
+		return errors.New("nil StoragePoolDefinition")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.m[def.Name]; exists {
+		return errors.Wrapf(store.ErrAlreadyExists, "storage pool definition %q", def.Name)
+	}
+
+	s.m[def.Name] = copyStoragePoolDefinition(*def)
+
+	return nil
+}
+
+// Update overwrites an existing definition. Returns ErrNotFound when
+// the row is absent.
+func (s *storagePoolDefinitions) Update(_ context.Context, def *store.StoragePoolDefinition) error {
+	if def == nil {
+		return errors.New("nil StoragePoolDefinition")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.m[def.Name]; !exists {
+		return errors.Wrapf(store.ErrNotFound, "storage pool definition %q", def.Name)
+	}
+
+	s.m[def.Name] = copyStoragePoolDefinition(*def)
+
+	return nil
+}
+
+// Delete removes the named definition. Returns ErrNotFound when
+// absent.
+func (s *storagePoolDefinitions) Delete(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.m[name]; !exists {
+		return errors.Wrapf(store.ErrNotFound, "storage pool definition %q", name)
+	}
+
+	delete(s.m, name)
+
+	return nil
+}
+
+// copyStoragePoolDefinition deep-copies the props map so callers can
+// mutate the returned value without racing the store.
+func copyStoragePoolDefinition(def store.StoragePoolDefinition) store.StoragePoolDefinition {
+	out := store.StoragePoolDefinition{Name: def.Name}
+	if def.Props != nil {
+		out.Props = make(map[string]string, len(def.Props))
+		maps.Copy(out.Props, def.Props)
+	}
+
+	return out
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -276,6 +276,40 @@ type ControllerPropsStore interface {
 	Set(ctx context.Context, props map[string]string) error
 }
 
+// StoragePoolDefinition is the controller-scope row that registers a
+// StoragePool *name* (e.g. "zfs-thin") independent of which nodes
+// host it. Upstream LINSTOR keeps a dedicated `StorPoolDfn` table
+// next to per-node StoragePools; the `MaxOversubscriptionRatio`
+// and similar cluster-wide knobs hang off this row. Blockstor folds
+// the per-node and the definition surface into one CRD (StoragePool),
+// so a definition without any per-node pool is purely a name+props
+// registration, captured here in a small process-local table.
+//
+// The row survives only for the lifetime of the controller process —
+// no CRD or Secret backs it yet. This is the same compromise
+// ControllerPropsStore makes; operators can re-create definitions
+// after a controller restart, and the four upstream-defined props
+// (`MaxOversubscriptionRatio` etc.) are pure scoring multipliers
+// with no persisted state depending on them.
+type StoragePoolDefinition struct {
+	Name  string
+	Props map[string]string
+}
+
+// StoragePoolDefinitionStore persists the controller-scope storage
+// pool definition registry. The REST handlers at
+// `/v1/storage-pool-definitions[/{name}]` are the operator surface;
+// the store is intentionally minimal (no patch helpers, no status
+// subresource) because the definition row carries no state beyond
+// its name + props.
+type StoragePoolDefinitionStore interface {
+	List(ctx context.Context) ([]StoragePoolDefinition, error)
+	Get(ctx context.Context, name string) (StoragePoolDefinition, error)
+	Create(ctx context.Context, def *StoragePoolDefinition) error
+	Update(ctx context.Context, def *StoragePoolDefinition) error
+	Delete(ctx context.Context, name string) error
+}
+
 // Store aggregates per-resource stores.
 type Store interface {
 	Nodes() NodeStore
@@ -287,4 +321,5 @@ type Store interface {
 	Snapshots() SnapshotStore
 	PhysicalDevices() PhysicalDeviceStore
 	ControllerProps() ControllerPropsStore
+	StoragePoolDefinitions() StoragePoolDefinitionStore
 }


### PR DESCRIPTION
## Summary

Closes Findings 6, 7, 8 from the v0.1.3 bug-hunt report at `2026-05-30-bughunt-v0.1.3.md`.

### Finding 6 — POST/PUT/DELETE on `/v1/storage-pool-definitions` returned 405

Upstream OpenAPI defines all three verbs (rest_v1_openapi.yaml lines 59-161). Blockstor had only the GET surface wired.

- POST creates a definition. CREATE-only: a duplicate POST returns 409 + `FAIL_EXISTS_STOR_POOL_DFN` (mirrors Finding 1's POST-must-not-mutate contract for the per-node StoragePool surface).
- PUT modifies props via the standard `GenericPropsModify` envelope (override_props / delete_props / delete_namespaces). PUT auto-creates the row when absent so `linstor sp-d set-property new-def k v` works in one round-trip.
- DELETE refuses with 409 + `FAIL_IN_USE` when any per-node StoragePool still references the definition. Idempotent on already-absent (200 + `warnStoragePoolDfnNotFound`) to match Bug 56's pattern for RDs / SPs / nodes.

A small process-local `StoragePoolDefinitionStore` interface backs the wire surface (same compromise as `ControllerPropsStore` — the row carries no persisted state). A future iteration can swap the in-memory map for a dedicated CRD without churning the REST contract.

The existing GET list/single handlers now merge the explicit registry with the synthesised per-pool-name list so an operator-POSTed definition surfaces in `linstor sp-d l` immediately, before any per-node pool is bound to it.

### Finding 7 — `PUT /v1/.../migrate-disk/{src}` (no `/{pool}` suffix) returned 404

Upstream OpenAPI defines both forms (lines 2611-2646). python-linstor's common `linstor r migrate-disk <to_node> <rd> <from_node>` form ships without the pool segment and decodes it from the JSON body. The bodyless route is added; both variants converge on a shared `migrateDiskCommon` helper so validation + add-before-drop semantics stay identical. Empty body is tolerated — the destination is created without a stamped pool, leaving the controller's auto-diskful path to pick one on the next reconcile.

### Finding 8 — `/v1/{nodes,resource-definitions,resource-groups,storage-pool-definitions}/properties/info` returned 404 or "object not found"

The nodes variant was swallowed by the `/v1/nodes/{node}/info` wildcard router (the path-segment "properties" was treated as a node name). The other three had no handler.

Wire literal-path handlers for all four. Go 1.22 ServeMux precedence puts literal paths above wildcards, so the nodes routing trap closes without further changes. The catalogue is a hand-curated `PropsInfo` array covering `DrbdOptions/`, `Aux/`, `StorDriver/`, `StorPoolName`, plus the per-kind autoplacer + rebalance knobs blockstor accepts. PropsInfo catalogs are best-effort and can be expanded in follow-up commits without breaking wire compat (additive only — the python CLI only consumes `name` + `info`).

## Test plan

- [x] `go test ./pkg/rest/...` — new tests cover POST/PUT/DELETE happy + refusal paths for storage-pool-definitions, the migrate-disk bodyless variant (with body + empty), and all four properties/info routes.
- [x] `go test ./pkg/store/...` — store interface bump compiles cleanly against the k8s + inmemory backends.
- [x] `golangci-lint run ./pkg/rest/... ./pkg/store/...` — clean.
- [ ] Manual smoke test against a hunt-stand satellite cluster (deferred — wire-shape unit tests cover the regression surface).