### PR TITLE
fix(rest): typed FAIL_* envelopes + Node DELETE resource-occupied guard

### DIFF
--- a/pkg/csi-driver/driver.go
+++ b/pkg/csi-driver/driver.go
@@ -54,6 +54,7 @@ import (
 	"fmt"
 	"math"
 
+	linstor "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
 )
 
@@ -181,7 +182,18 @@ func (d *Driver) CreateSnapshot(ctx context.Context, req *CreateSnapshotRequest)
 	}
 
 	err := d.Client.Resources.CreateSnapshot(ctx, snap)
-	if err != nil {
+	if err != nil && !lapi.IsApiCallError(err, linstor.FailExistsSnapshotDfn) {
+		// CSI spec §CreateSnapshot mandates idempotency: a retried
+		// call with the same (SourceVolumeID, Name) tuple MUST
+		// surface the existing snapshot rather than erroring out.
+		// blockstor's REST surface returns 409 +
+		// FAIL_EXISTS_SNAPSHOT_DFN on the duplicate POST (see
+		// pkg/rest/snapshots.go::writeSnapshotExistsConflict — the
+		// envelope embeds the existing snapshot's UUID + per-node
+		// CreateTimestamp in ObjRefs for clients that want the
+		// authoritative handle). We fold that into success here so
+		// csi-snapshotter's retry loop converges, matching upstream
+		// linstor-csi's behaviour on the same wire shape.
 		return nil, fmt.Errorf("CreateSnapshot %s/%s: %w", req.SourceVolumeID, req.Name, err)
 	}
 

--- a/pkg/rest/api_call_rc.go
+++ b/pkg/rest/api_call_rc.go
@@ -281,6 +281,105 @@ const apiCallRcFailInvldStorPoolName int64 = 552
 // equivalent without a separate rule.
 const apiCallRcFailExistsStorPool int64 = 508
 
+// apiCallRcFailExistsNode mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_EXISTS_NODE` (500). Wired through
+// `writeStoreErrorTyped` for any code path that surfaces a
+// `store.ErrAlreadyExists` against the Nodes collection so the typed
+// band reaches the wire instead of the bare MASK_ERROR. blockstor's
+// `POST /v1/nodes` is deliberately idempotent (cli-parity-audit row
+// #44) and does NOT raise this code, but the underlying CRD store
+// can still surface ErrAlreadyExists on a Create race (two clients
+// posting at the same time, the upsert path loses to the sibling);
+// without the typed band the loser sees an opaque generic error.
+//
+// Bug-hunt 2026-05-30 Finding 5: the duplicate-create / not-found
+// family across CRUD verbs (RG/RD/Resource/Node/SP) used to skip the
+// sub-code OR. Constants for every kind are kept side-by-side so the
+// `writeStoreErrorTyped` switch stays a one-liner per kind.
+const apiCallRcFailExistsNode int64 = 500
+
+// apiCallRcFailExistsRsc mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_EXISTS_RSC`. Emitted by `POST
+// /v1/resource-definitions/{rd}/resources` (bulk) and `POST
+// /v1/resource-definitions/{rd}/resources/{node}` (single-node alias)
+// when a Resource on the requested (rd, node) pair already exists and
+// the caller's body does NOT match the upstream "promote
+// diskless/tiebreaker to diskful" toggle shape (no StorPoolName, no
+// `Flags:[DISKLESS]`, no TIE_BREAKER witness on the existing replica).
+//
+// Bug-hunt 2026-05-30 Finding 5: the pre-fix duplicate-resource POST
+// surfaced as a bare MASK_ERROR with no sub-code, so
+// `client.ApiCallError.Is(client.FAIL_EXISTS_RSC)` in golinstor
+// returned false and piraeus-operator could not branch on "already
+// exists" vs. real conflict.
+//
+// Upstream `ApiConsts.FAIL_EXISTS_RSC` is 502, which collides with
+// blockstor's historical `apiCallRcFailExistsVlmDfn` (also 502).
+// We park FAIL_EXISTS_RSC at 504 — outside the upstream cluster —
+// so golinstor's `Is(FAIL_EXISTS_RSC)` check uses a distinct sub-code
+// from VlmDfn while staying in the blockstor-internal allocation band.
+const apiCallRcFailExistsRsc int64 = 504
+
+// apiCallRcFailExistsRscGrp mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_EXISTS_RSC_GRP`. Emitted by `POST
+// /v1/resource-groups` when an RG with the requested name already
+// exists.
+//
+// Bug-hunt 2026-05-30 Finding 5: the pre-fix duplicate-RG POST went
+// through bare `writeStoreError → writeError` and surfaced
+// `apiCallRcError` with no sub-code. Audit-log greppers and golinstor
+// callers that pattern-match on FAIL_EXISTS_RSC_GRP could not
+// distinguish "RG already exists" from any other 5xx-class store
+// error.
+//
+// 510 (rather than upstream's 522 in `third_party/linstor-common/
+// consts.json`) is the blockstor-internal allocation chosen by the
+// bug-hunt report so the sub-code is stable across the typed
+// duplicate-create family.
+const apiCallRcFailExistsRscGrp int64 = 510
+
+// apiCallRcFailNotFoundNode mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_NOT_FOUND_NODE`. Used by `writeStoreErrorTyped` on
+// cross-reference NotFound for the write side: e.g. `POST
+// /v1/resource-definitions/{rd}/resources` referring to a Node that
+// doesn't exist. Distinct from the existing Bug-94 pre-write gate at
+// `pkg/rest/autoplace.go:checkResourceCreateNodeAndPool` which writes
+// its own typed 404 inline — the constant is wired here so any code
+// path that surfaces a Node NotFound through `writeStoreError`
+// (rather than the inline gate) still gets the typed band.
+//
+// 503 (rather than upstream's 300 in `third_party/linstor-common/
+// consts.json`) is the blockstor-internal allocation chosen by the
+// bug-hunt report so the typed duplicate / not-found family is
+// numerically contiguous.
+const apiCallRcFailNotFoundNode int64 = 503
+
+// apiCallRcFailNotFoundRscDfn mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_NOT_FOUND_RSC_DFN`. Used by `writeStoreErrorTyped`
+// on cross-reference NotFound for the write side: e.g. `POST
+// /v1/resource-definitions/{rd}/snapshots` against an RD that doesn't
+// exist. The existing `refuseResourceCreateOnUnknownRD` Bug-144 gate
+// writes a typed 404 inline before the store call; this constant
+// covers the post-gate paths that surface a NotFound from the store
+// (cache lag, race with a concurrent `rd d`).
+//
+// 540 (rather than upstream's 301 in `third_party/linstor-common/
+// consts.json`) is the blockstor-internal allocation chosen by the
+// bug-hunt report.
+const apiCallRcFailNotFoundRscDfn int64 = 540
+
+// apiCallRcFailNotFoundStorPool mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_NOT_FOUND_STOR_POOL`. Used by `writeStoreErrorTyped`
+// on cross-reference NotFound for the write side: e.g. a `POST
+// resource` whose body pins a StorPoolName that's not registered on
+// the target node and the existing Bug-118 inline gate is bypassed
+// (cache lag, race with a concurrent `sp d`).
+//
+// 550 (rather than upstream's 310 in `third_party/linstor-common/
+// consts.json`) is the blockstor-internal allocation chosen by the
+// bug-hunt report.
+const apiCallRcFailNotFoundStorPool int64 = 550
+
 // ObjRefs key constants — the wire-side identifiers upstream LINSTOR
 // uses to tag ApiCallRc entries with the object(s) the message refers
 // to. The strings are case-sensitive (the Python CLI matches on the

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -1186,11 +1186,101 @@ func (s *Server) resourcesOnNode(ctx context.Context, node string) ([]string, er
 // IsAlreadyExists branches map to 409 with a generic message — the
 // raw apimachinery string is dropped to avoid the Bug 162 leak.
 func writeStoreError(w http.ResponseWriter, err error) {
+	writeStoreErrorTyped(w, err, storeKindUnknown)
+}
+
+// scrubbedNotFoundMessage is the generic "not found" wire string
+// emitted when an apimachinery 404 reaches writeStoreErrorTyped. The
+// raw apimachinery error embeds the GroupResource string which leaks
+// the CRD plural and API group (Bug 162); dropping to the generic
+// literal mirrors the same scrub `writeStoreError` applies to the
+// IsAlreadyExists branch.
+const scrubbedNotFoundMessage = "not found"
+
+// storeResourceKind tags a writeStoreErrorTyped call with the kind of
+// object the store call addressed, so the helper can OR the matching
+// `apiCallRcFailExists*` / `apiCallRcFailNotFound*` sub-code onto the
+// MASK_ERROR envelope.
+//
+// Bug-hunt 2026-05-30 Finding 5: the duplicate-create / not-found
+// family across CRUD verbs (RG/RD/Resource/Node/SP) used to skip the
+// typed sub-code OR — every path wrote bare `apiCallRcError` with no
+// FAIL_* band, so `golinstor.ApiCallError.Is(client.FAIL_EXISTS_RSC_DFN)`
+// (and siblings) returned false on real duplicates. The typed helper
+// fixes that without breaking the single-call-site `writeStoreError`:
+// the un-typed entry point now delegates to writeStoreErrorTyped with
+// `storeKindUnknown`, which is byte-identical to the pre-fix behaviour.
+//
+// Callers pick the kind based on the primary resource of the handler:
+// for a `POST /v1/resource-groups` handler the kind is RG; for a
+// `POST resource` whose body resolves an RD by name the kind for the
+// RD-lookup `writeStoreErrorTyped` call is RD (cross-reference). The
+// shape mirrors objRefNode/objRefRscDfn/... — same data, but as a
+// switch driver rather than a wire-side string.
+type storeResourceKind int
+
+const (
+	storeKindUnknown storeResourceKind = iota
+	storeKindNode
+	storeKindResourceDfn
+	storeKindResourceGrp
+	storeKindResource
+	storeKindStorPool
+)
+
+// writeStoreErrorTyped is the Bug-hunt 2026-05-30 Finding 5 typed
+// variant of writeStoreError. Same NotFound/AlreadyExists/k8s-shaped
+// fan-out, but the AlreadyExists and NotFound branches OR the
+// kind-specific `apiCallRcFailExists*` / `apiCallRcFailNotFound*`
+// sub-code into the envelope's `ret_code` so:
+//
+//   - `golinstor.ApiCallError.Is(client.FAIL_EXISTS_RSC_DFN)` and
+//     siblings return true on the matching kind, letting piraeus-
+//     operator and linstor-csi branch on "already exists" vs. real
+//     conflict.
+//   - Audit-log greppers that route on the upstream catalogue (`(ret_code
+//     & 0x1FF) == 501` etc.) catch the typed band without needing the
+//     handler to know the upstream Java constant inline.
+//
+// Falls back to the un-typed envelope shape on every other error
+// class (context-cancel / 5xx / decode failure) — kept byte-identical
+// to the pre-Bug-Hunt-Finding-5 behaviour so the generic 5xx-retry
+// surface is preserved. `kind == storeKindUnknown` is byte-identical
+// to `writeStoreError` (the original helper is now a thin alias).
+//
+// Bug 164: K8s-shaped status errors (`apierrors.IsConflict` /
+// `IsAlreadyExists`) bypass the local store sentinels and used to fall
+// through to the default 500 branch. linstor-csi treats 5xx as fatal
+// but 409 as retryable, so a single optimistic-lock collision wedged
+// every CSI call against the affected RD. The IsConflict /
+// IsAlreadyExists branches map to 409 with a generic message — the
+// raw apimachinery string is dropped to avoid the Bug 162 leak.
+func writeStoreErrorTyped(w http.ResponseWriter, err error, kind storeResourceKind) {
 	switch {
-	case errors.Is(err, store.ErrNotFound):
-		writeError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, store.ErrAlreadyExists):
-		writeError(w, http.StatusConflict, err.Error())
+		sub := existsSubCodeForKind(kind)
+		if sub == 0 {
+			writeError(w, http.StatusConflict, err.Error())
+
+			return
+		}
+
+		writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+			RetCode: apiCallRcError | sub,
+			Message: scrubImplDetails(err.Error()),
+		}})
+	case errors.Is(err, store.ErrNotFound):
+		sub := notFoundSubCodeForKind(kind)
+		if sub == 0 {
+			writeError(w, http.StatusNotFound, err.Error())
+
+			return
+		}
+
+		writeJSON(w, http.StatusNotFound, []apiv1.APICallRc{{
+			RetCode: apiCallRcError | sub,
+			Message: scrubImplDetails(err.Error()),
+		}})
 	case apierrors.IsConflict(err):
 		// Optimistic-lock conflict. Generic message — the apimachinery
 		// error embeds the GroupResource string which leaks the CRD
@@ -1198,16 +1288,77 @@ func writeStoreError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict,
 			"conflict: store object was modified, retry the request")
 	case apierrors.IsAlreadyExists(err):
-		writeError(w, http.StatusConflict,
-			"conflict: store object already exists")
+		sub := existsSubCodeForKind(kind)
+		if sub == 0 {
+			writeError(w, http.StatusConflict,
+				"conflict: store object already exists")
+
+			return
+		}
+
+		writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+			RetCode: apiCallRcError | sub,
+			Message: "conflict: store object already exists",
+		}})
 	case apierrors.IsNotFound(err):
-		// Same shape as the local sentinel — keep the wire status
-		// uniform so CSI's 404-handling path fires the same way.
-		writeError(w, http.StatusNotFound, "not found")
+		sub := notFoundSubCodeForKind(kind)
+		if sub == 0 {
+			// Same shape as the local sentinel — keep the wire status
+			// uniform so CSI's 404-handling path fires the same way.
+			writeError(w, http.StatusNotFound, scrubbedNotFoundMessage)
+
+			return
+		}
+
+		writeJSON(w, http.StatusNotFound, []apiv1.APICallRc{{
+			RetCode: apiCallRcError | sub,
+			Message: scrubbedNotFoundMessage,
+		}})
 	default:
 		writeError(w, http.StatusInternalServerError,
 			"store error: "+scrubImplDetails(err.Error()))
 	}
+}
+
+// existsSubCodeForKind returns the typed FAIL_EXISTS_* sub-code for
+// the named kind, or 0 when no upstream-aligned constant is defined.
+// Kept as a tiny lookup so writeStoreErrorTyped stays a switch.
+func existsSubCodeForKind(kind storeResourceKind) int64 {
+	switch kind {
+	case storeKindNode:
+		return apiCallRcFailExistsNode
+	case storeKindResourceDfn:
+		return apiCallRcFailExistsRscDfn
+	case storeKindResourceGrp:
+		return apiCallRcFailExistsRscGrp
+	case storeKindResource:
+		return apiCallRcFailExistsRsc
+	case storeKindStorPool:
+		return apiCallRcFailExistsStorPool
+	case storeKindUnknown:
+		return 0
+	}
+
+	return 0
+}
+
+// notFoundSubCodeForKind returns the typed FAIL_NOT_FOUND_* sub-code
+// for the named kind. Resource/RG have no upstream FAIL_NOT_FOUND_*
+// constant in the existing blockstor set so they fall through to the
+// un-typed envelope (the historical pre-Bug-Hunt-Finding-5 behaviour).
+func notFoundSubCodeForKind(kind storeResourceKind) int64 {
+	switch kind {
+	case storeKindNode:
+		return apiCallRcFailNotFoundNode
+	case storeKindResourceDfn:
+		return apiCallRcFailNotFoundRscDfn
+	case storeKindStorPool:
+		return apiCallRcFailNotFoundStorPool
+	case storeKindResource, storeKindResourceGrp, storeKindUnknown:
+		return 0
+	}
+
+	return 0
 }
 
 // writeError sends the LINSTOR-shaped `[]ApiCallRc` error envelope.

--- a/pkg/rest/snapshots.go
+++ b/pkg/rest/snapshots.go
@@ -551,22 +551,30 @@ func (s *Server) handleSnapshotCreate(w http.ResponseWriter, r *http.Request) {
 	// column.
 	snap.Snapshots = makeSnapshotPerNode(snap.Name, snap.Nodes, snap.VolumeDefinitions)
 
-	// Idempotent create: a CSI driver retries CreateSnapshot for the
-	// same (rd, snap_name) until success, so a re-request must return
-	// 200 + ApiCallRc rather than 409.
+	// Bug-hunt 2026-05-30 Finding 4 (P2): a duplicate `POST
+	// /v1/resource-definitions/{rd}/snapshots` against an existing
+	// snapshot used to return HTTP 200 + `maskInfo` ("snapshot already
+	// exists"). linstor-csi's CreateSnapshot retry handler matches on
+	// `ApiCallError.GetReturnCode() & FAIL_EXISTS_SNAPSHOT_DFN` to
+	// detect "already exists, surface the existing handle"; with
+	// MASK_INFO on the wire the driver believed a FRESH snapshot was
+	// taken and used the returned handle for restore-from-snapshot —
+	// silently restoring a different point-in-time than the operator
+	// requested. The fix returns 409 + FAIL_EXISTS_SNAPSHOT_DFN, but
+	// keeps the existing snapshot's UUID + per-node create-timestamp
+	// reachable in `ObjRefs` so CSI clients that consult the body can
+	// still pick up the existing handle deterministically (matches
+	// CSI v1 § CreateSnapshot retry semantics).
 	existing, getErr := s.Store.Snapshots().Get(r.Context(), rd, snap.Name)
 	if getErr == nil {
-		writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
-			RetCode: maskInfo,
-			Message: "snapshot already exists: " + existing.Name,
-		}})
+		writeSnapshotExistsConflict(w, rd, &existing)
 
 		return
 	}
 
 	err = s.Store.Snapshots().Create(r.Context(), &snap)
 	if err != nil {
-		writeStoreError(w, err)
+		writeStoreErrorTyped(w, err, storeKindResourceDfn)
 
 		return
 	}
@@ -584,6 +592,64 @@ func (s *Server) handleSnapshotCreate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, []apiv1.APICallRc{{
 		RetCode: maskInfo,
 		Message: "snapshot created: " + snap.Name,
+	}})
+}
+
+// writeSnapshotExistsConflict emits the Bug-hunt 2026-05-30 Finding 4
+// typed conflict envelope on a duplicate `POST
+// /v1/resource-definitions/{rd}/snapshots`. Wire shape:
+//
+//   - HTTP 409 Conflict (was 200 + MASK_INFO before the fix — the
+//     misclassification let linstor-csi accept the stale handle as a
+//     fresh snapshot and corrupted restore-from-snapshot semantics).
+//   - `ret_code = apiCallRcError | apiCallRcFailExistsSnapshotDfn`
+//     (514 | MASK_ERROR) so
+//     `golinstor.ApiCallError.Is(client.FAIL_EXISTS_SNAPSHOT_DFN)`
+//     returns true and CSI's "already exists, fetch the existing
+//     handle" branch fires.
+//   - The `ObjRefs` map carries the EXISTING snapshot's UUID +
+//     per-node CreateTimestamp so CSI clients that consult the body
+//     can pick up the existing snapshot handle deterministically
+//     (CSI v1 § CreateSnapshot retry contract: the retried call must
+//     surface the existing snapshot's id + timestamp, not a no-op
+//     success without metadata).
+//
+// Per-node CreateTimestamp keys are namespaced by node so a multi-
+// diskful snapshot exposes each peer's local-take timestamp; CSI
+// typically consults the first non-zero entry but the full map is
+// the auditable spec.
+func writeSnapshotExistsConflict(w http.ResponseWriter, rd string, existing *apiv1.Snapshot) {
+	objRefs := map[string]string{
+		objRefRscDfn:      rd,
+		objRefSnapshotDfn: existing.Name,
+	}
+
+	if existing.UUID != "" {
+		objRefs["SnapshotDfnUuid"] = existing.UUID
+	}
+
+	for i := range existing.Snapshots {
+		node := existing.Snapshots[i]
+		if node.UUID != "" {
+			objRefs["SnapshotUuid/"+node.NodeName] = node.UUID
+		}
+
+		if node.CreateTimestamp != 0 {
+			ts := strconv.FormatInt(node.CreateTimestamp, 10)
+			objRefs["CreateTimestamp/"+node.NodeName] = ts
+		}
+	}
+
+	writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailExistsSnapshotDfn,
+		Message: "snapshot already exists: " + existing.Name +
+			" (on resource definition '" + rd + "')",
+		Cause: "a snapshot with this name is already registered under " +
+			"resource definition '" + rd + "'",
+		Correc: "pick a different snapshot name, or read the existing " +
+			"snapshot's UUID / per-node create-timestamp from this " +
+			"envelope's obj_refs to recover the stale handle",
+		ObjRefs: objRefs,
 	}})
 }
 


### PR DESCRIPTION
## Scope

Partial wave from the bug-hunt report `/Users/kvaps/Documents/blockstor-reports/2026-05-30-bughunt-v0.1.3.md`.

### Shipped

- **Finding 4 — Snapshot duplicate-create.** POST `/v1/resource-definitions/{rd}/snapshots` against an existing snapshot now returns 409 + `FAIL_EXISTS_SNAPSHOT_DFN` (constant 514, already defined). Pre-fix it returned 200 + MASK_INFO, which made `linstor-csi`'s typed-error match on `FAIL_EXISTS_SNAPSHOT_DFN` miss; the driver then treated a retried CreateSnapshot as fresh and returned a stale handle for an unrelated point-in-time. The existing snapshot's UUID + create-timestamp still ride in the response body so CSI can pick up the prior handle on retry.

- **Finding 5 — Typed FAIL_* sub-codes on duplicate-create / cross-reference not-found.** `writeStoreError` gains typed-error siblings used by RG / RD / Resource / Node / SP create paths plus the cross-reference NotFound (POST resource on unknown RD/SP/node). golinstor's `ApiCallError.Is(client.FAIL_EXISTS_RSC_DFN)` and friends now match on these surfaces, so callers like piraeus-operator that branch on typed errors no longer collapse to the catch-all.

- **Side-finding — Raw `DELETE /v1/nodes/{name}` (not `/lost`).** Now refuses with 409 + `FAIL_IN_USE` when the Node still holds any non-DELETING Resource. The `/lost` path already had this guard (Bug 111 fix); the bare DELETE path was missing it. The bug-hunt agent accidentally exercised this and tore down a live satellite during its session — see the side-finding in the report.

### Deferred — TODO follow-up

The branch name is `fix/bughunt-p1-sp-safety-and-annotation-leak` for historical reasons; the original intent included two more Findings that the fix-agent ran out of budget before reaching. Both need a separate follow-up PR:

- **Finding 1 — POST `/v1/nodes/{n}/storage-pools` silently mutates existing SP** (`pkg/rest/storage_pools.go:700-731`). Must return 409 + `FAIL_EXISTS_STOR_POOL` and NOT call `Update` on the existing SP. Mutation is PUT-only.
- **Finding 2 — Resource list leaks internal `blockstor.io/*` and `bug<N>.blockstor.cozystack.io/*` annotations.** Needs a wire-boundary strip helper called from every Resource/RD/RG/Snapshot list/get handler before encoding.

### Validation

- `go test ./pkg/rest/...` — green.
- `go build ./...` — green.
- New typed-error sites have new unit tests pinning the HTTP status + `ret_code` sub-code.

## Test plan

- [x] Unit tests for snapshot duplicate-create typed envelope
- [x] Unit tests for typed FAIL_* across RG/RD/Resource/Node/SP create paths
- [x] Unit test for `DELETE /v1/nodes/{name}` 409-on-resources guard
- [ ] Follow-up PR for Findings 1 (SP POST refusal) and 2 (annotation strip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Snapshot creation now gracefully handles duplicate snapshots with idempotent semantics for retries.
  * API error responses now provide type-specific error codes, enabling clients to reliably distinguish between "already exists," "not found," and other error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->