### PR TITLE
fix(e2e): csi-pvc-local — use nodeSelector instead of nodeName

### DIFF
--- a/tests/e2e/csi-pvc-local.sh
+++ b/tests/e2e/csi-pvc-local.sh
@@ -131,7 +131,7 @@ apiVersion: v1
 kind: Pod
 metadata: {name: $POD}
 spec:
-  nodeName: $WORKER_1
+  nodeSelector: {kubernetes.io/hostname: $WORKER_1}
   restartPolicy: Never
   securityContext:
     runAsNonRoot: true
@@ -186,7 +186,7 @@ apiVersion: v1
 kind: Pod
 metadata: {name: $POD}
 spec:
-  nodeName: $WORKER_1
+  nodeSelector: {kubernetes.io/hostname: $WORKER_1}
   restartPolicy: Never
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
## Summary

`tests/e2e/csi-pvc-local.sh` pairs `volumeBindingMode: WaitForFirstConsumer` with `Pod.spec.nodeName`, but setting `nodeName` bypasses the kube-scheduler entirely. The scheduler is what writes the `volume.kubernetes.io/selected-node` annotation onto the PVC, and the linstor-csi external-provisioner sidecar uses that annotation as the trigger to fire `CreateVolume`. Without it the PVC stays `Pending` forever and the Pod hangs in `ContainerCreating` with `FailedMount: PVC is not bound`.

The scenario was structurally broken since it landed (PR #37, commit `8b4b15d`). It fails consistently on every bug-hunt PR (#40, #41, #42) and would have failed on any rerun against main. The today-morning live smoke against blockstor v0.1.3 happened to use `nodeSelector` (because the Pod manifest there was hand-typed), which is why it appeared to work.

Replacing `nodeName: $WORKER_1` with `nodeSelector: {kubernetes.io/hostname: $WORKER_1}` at both occurrences keeps the worker-pinning intent but lets the scheduler run.

Reported by an SSH-breakpoint investigation on PR #41's piraeus interop lane.

## Test plan

- [ ] piraeus-interop lane 1 passes `csi-pvc-local` after this PR lands
- [ ] No other scenario regresses (the change is scoped to one test file)