### PR TITLE
fix(e2e): point linstor diag exec at blockstor-controller

### DIFF
--- a/tests/e2e/csi-pvc-local.sh
+++ b/tests/e2e/csi-pvc-local.sh
@@ -84,11 +84,11 @@ dump_diag() {
     echo "----- diag ($label): linstor-csi-node logs -----" >&2
     kubectl -n piraeus-datastore logs ds/linstor-csi-node \
         -c linstor-csi --tail=80 --prefix=true 2>&1 >&2 || true
-    echo "----- diag ($label): linstor r l (via blockstor apiserver) -----" >&2
-    kubectl -n blockstor-system exec deploy/blockstor-apiserver -- \
+    echo "----- diag ($label): linstor r l (via blockstor controller) -----" >&2
+    kubectl -n blockstor-system exec deploy/blockstor-controller -- \
         linstor r l 2>&1 >&2 || true
-    echo "----- diag ($label): linstor v l (via blockstor apiserver) -----" >&2
-    kubectl -n blockstor-system exec deploy/blockstor-apiserver -- \
+    echo "----- diag ($label): linstor v l (via blockstor controller) -----" >&2
+    kubectl -n blockstor-system exec deploy/blockstor-controller -- \
         linstor v l 2>&1 >&2 || true
 }
 

--- a/tests/e2e/rwx-ganesha.sh
+++ b/tests/e2e/rwx-ganesha.sh
@@ -81,8 +81,8 @@ dump_diag() {
     echo "----- diag ($label): linstor-csi-node logs (per worker) -----" >&2
     kubectl -n piraeus-datastore logs ds/linstor-csi-node \
         -c linstor-csi --tail=80 --prefix=true 2>&1 >&2 || true
-    echo "----- diag ($label): linstor r l (via blockstor apiserver) -----" >&2
-    kubectl -n blockstor-system exec deploy/blockstor-apiserver -- \
+    echo "----- diag ($label): linstor r l (via blockstor controller) -----" >&2
+    kubectl -n blockstor-system exec deploy/blockstor-controller -- \
         linstor r l 2>&1 >&2 || true
 }
 


### PR DESCRIPTION
## Summary

The diagnostic `dump_diag` helpers in `tests/e2e/csi-pvc-local.sh` and `tests/e2e/rwx-ganesha.sh` `kubectl exec`'d the `linstor` CLI inside `deploy/blockstor-apiserver`. That image does not ship the `linstor` binary, so every failure-path call produced:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "linstor": executable file not found in $PATH
```

This was observed during the PR #40 / #41 / #42 piraeus interop investigations — the dumps were empty noise instead of the cluster state we wanted to see.

Fix: switch the exec target from `deploy/blockstor-apiserver` to `deploy/blockstor-controller`, which does have `linstor` on `PATH`, so post-failure diagnostics actually print `linstor r l` / `linstor v l` output.

## Scope

Diagnostic-only shell paths. No Go code, no CRDs, no test logic changes — the only edits are the exec target name and the matching log labels.

## Files touched

- `tests/e2e/csi-pvc-local.sh` (two `dump_diag` exec sites + labels)
- `tests/e2e/rwx-ganesha.sh` (one `dump_diag` exec site + label)

Verified syntactically with `bash -n` on both files and on `stand/ci-e2e.sh`.

## Out of scope

- `tests/observability-cheat-sheet-scenarios.md` and `tests/scenarios/*.md` mention the same `apiserver` exec pattern but are documentation/scenario notes outside `stand/` and `tests/e2e/`. They are deliberately not touched here.