### PR TITLE
fix(rest): refuse duplicate SP POST; strip internal annotations (bughunt v0.1.3 P1)

### DIFF
--- a/pkg/rest/api_call_rc.go
+++ b/pkg/rest/api_call_rc.go
@@ -262,6 +262,25 @@ const apiCallRcFailExistsVlmDfn int64 = 502
 // without a separate rule.
 const apiCallRcFailInvldStorPoolName int64 = 552
 
+// apiCallRcFailExistsStorPool mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_EXISTS_STOR_POOL` (508). Emitted by
+// `POST /v1/nodes/{node}/storage-pools` when an SP with the same
+// (node, pool) already exists. Bug-hunt v0.1.3 Finding 1: the pre-fix
+// handler silently mutated the live row's Props / ProviderKind /
+// FreeSpaceMgrName from the POST body and returned 201, so a retrying
+// CSI driver or a mistaken `linstor sp c` repeat could wipe
+// `StorDriver/ZPool`, flip `provider_kind`, etc. The new contract:
+// POST is CREATE-only; mutation lives behind PUT (storage-pool modify).
+//
+// The MASK_ERROR bit is OR'd in by the `apiCallRcError` envelope
+// wrapper at the call site; the bare 508 sub-code here keeps the
+// wire shape byte-identical to upstream's `linstor sp c` reply on
+// the same input. Choosing 508 (rather than a fresh sub-code in our
+// 996+ range) lets audit-log greppers that already classify
+// upstream's FAIL_EXISTS_STOR_POOL traffic catch blockstor's
+// equivalent without a separate rule.
+const apiCallRcFailExistsStorPool int64 = 508
+
 // ObjRefs key constants — the wire-side identifiers upstream LINSTOR
 // uses to tag ApiCallRc entries with the object(s) the message refers
 // to. The strings are case-sensitive (the Python CLI matches on the

--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -124,6 +124,13 @@ func (s *Server) handleResourceList(w http.ResponseWriter, r *http.Request) {
 		redactSensitiveProps(out[i].Props)
 	}
 
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal annotations
+	// before the JSON encode. The reconcilers stamp `blockstor.io/*`
+	// and `bug<N>.blockstor.cozystack.io/*` keys for in-process
+	// bookkeeping; the wire shape must not carry them. See
+	// pkg/rest/internal_annotations.go.
+	stripInternalAnnotationsFromResourcesWithVolumes(out)
+
 	writeJSON(w, http.StatusOK, out)
 }
 
@@ -173,6 +180,10 @@ func (s *Server) handleResourceGet(w http.ResponseWriter, r *http.Request) {
 	// Resources().Get returns a value copy, so the in-place mutation
 	// stays local to this response. Mirrors the list-side scrub above.
 	redactSensitiveProps(res.Props)
+
+	// Bug-hunt v0.1.3 Finding 2: same controller-internal-annotation
+	// strip applied on the cluster-wide view and per-RD list paths.
+	res.Annotations = stripInternalAnnotations(res.Annotations)
 
 	writeJSON(w, http.StatusOK, apiv1.ResourceWithVolumes{Resource: res})
 }

--- a/pkg/rest/internal_annotations.go
+++ b/pkg/rest/internal_annotations.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"strings"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// internalAnnotationPrefix is the canonical blockstor controller
+// namespace for annotations the reconcilers stamp onto Resource /
+// ResourceDefinition / ResourceGroup / Snapshot CRDs for their own
+// bookkeeping (e.g. `blockstor.io/volume-numbers`,
+// `blockstor.io/peer-changed`). The reconciler MUST keep reading
+// these from the in-process struct, so the struct field stays — only
+// the wire boundary strips them.
+const internalAnnotationPrefix = "blockstor.io/"
+
+// internalAnnotationSuffix matches the per-bug controller scratch
+// namespace pattern `bug<NNN>.blockstor.cozystack.io/<key>`. The
+// reconciler uses this scheme to scope bug-specific state to a single
+// Reconcile loop without polluting the top-level
+// `blockstor.io/` namespace. Bug-hunt v0.1.3 Finding 2: this pattern
+// (e.g. `bug136.blockstor.cozystack.io/resize-pending-size-kib-vol-0`)
+// was leaking onto the wire alongside the canonical prefix; the
+// suffix check covers every existing and future `bug<N>` namespace
+// without enumerating each prefix individually.
+const internalAnnotationSuffix = ".blockstor.cozystack.io/"
+
+// isInternalAnnotationKey returns true when `key` belongs to a
+// blockstor-controller-private annotation namespace and must NOT
+// leak onto the REST wire. The two patterns covered (see the
+// per-const docs above) are:
+//
+//   - prefix `blockstor.io/`                — canonical controller namespace
+//   - any prefix ending in `.blockstor.cozystack.io/` — per-bug scratch
+//
+// Anything else (e.g. operator-set `kubectl.kubernetes.io/last-applied-
+// configuration`, third-party tooling annotations) is passed through
+// unchanged — those keys are part of the K8s object's contract with
+// the cluster operator, not blockstor's internal state.
+func isInternalAnnotationKey(key string) bool {
+	if key == "" {
+		return false
+	}
+
+	if strings.HasPrefix(key, internalAnnotationPrefix) {
+		return true
+	}
+
+	if i := strings.Index(key, internalAnnotationSuffix); i > 0 {
+		// Require the suffix to anchor against a `/`-bounded
+		// namespace (`<ns>/<name>` shape per K8s annotation rules).
+		// `i > 0` ensures there's a non-empty `<ns>` segment in
+		// front of the suffix.
+		return true
+	}
+
+	return false
+}
+
+// stripInternalAnnotations returns a defensive copy of `annotations`
+// with every blockstor-internal key dropped. Returns nil when the
+// input is nil and an empty (but non-nil) map when every key was
+// internal — that's the right shape for `json:"annotations,omitempty"`
+// (an empty map is omitted by the encoder, so the wire field
+// disappears entirely on a fully-internal annotation bag).
+//
+// Bug-hunt v0.1.3 Finding 2: every Resource / ResourceDefinition /
+// ResourceGroup / Snapshot type carries `Annotations map[string]string`
+// for the reconciler's bookkeeping. The reconciler MUST keep reading
+// these from the in-process struct, so the field can't be removed.
+// The fix is purely at the REST wire boundary: every list / get
+// handler clones the visible-on-wire copy through this helper so
+// the controller's internal state never escapes to clients (golinstor,
+// linstor-csi, piraeus-operator, the python CLI).
+//
+// The returned map is always a fresh allocation — callers can mutate
+// it without disturbing the source struct's annotations.
+func stripInternalAnnotations(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		if isInternalAnnotationKey(k) {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
+}
+
+// stripInternalAnnotationsFromResourcesWithVolumes is the slice sweep
+// used by the per-RD `r l` list and the cluster-wide `view/resources`
+// aggregate. Mutates each entry's embedded `Resource.Annotations`
+// field in place — the slice is owned by the handler at this point
+// (Resources().List returns a value copy), so the strip is local to
+// the response.
+func stripInternalAnnotationsFromResourcesWithVolumes(resources []apiv1.ResourceWithVolumes) {
+	for i := range resources {
+		resources[i].Annotations = stripInternalAnnotations(resources[i].Annotations)
+	}
+}
+
+// stripInternalAnnotationsFromRDs scrubs the per-RD wire shape used
+// by `rd l` (list) and `rd s <name>` (get-single, wrapped in a
+// 1-element slice by the caller for re-use).
+func stripInternalAnnotationsFromRDs(rds []apiv1.ResourceDefinition) {
+	for i := range rds {
+		rds[i].Annotations = stripInternalAnnotations(rds[i].Annotations)
+	}
+}
+
+// stripInternalAnnotationsFromRGs is the RG-side sweep — covers
+// `rg l` (list) and `rg s <name>` (get) the same way as
+// stripInternalAnnotationsFromRDs covers the RD side.
+func stripInternalAnnotationsFromRGs(rgs []apiv1.ResourceGroup) {
+	for i := range rgs {
+		rgs[i].Annotations = stripInternalAnnotations(rgs[i].Annotations)
+	}
+}
+
+// stripInternalAnnotationsFromSnapshots is the Snapshot-side sweep —
+// covers `s l` (cluster-wide view), `s l --resource <rd>` (per-RD
+// list), and `s l <rd> <snap>` (get-single, wrapped in a 1-element
+// slice by the caller). Mirrors the redactSnapshotsInPlace shape
+// already used for sensitive-key scrubbing on the same handlers.
+func stripInternalAnnotationsFromSnapshots(snaps []apiv1.Snapshot) {
+	for i := range snaps {
+		snaps[i].Annotations = stripInternalAnnotations(snaps[i].Annotations)
+	}
+}

--- a/pkg/rest/internal_annotations_test.go
+++ b/pkg/rest/internal_annotations_test.go
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestInternalAnnotationsStrippedOnWireBoundary pins Bug-hunt v0.1.3
+// Finding 2: the REST list / get handlers for Resource,
+// ResourceDefinition, ResourceGroup, and Snapshot must NOT leak
+// controller-internal `blockstor.io/*` and
+// `bug<N>.blockstor.cozystack.io/*` annotations. The reconcilers stamp
+// these onto the in-process structs for their own bookkeeping (the
+// struct field must stay so reconcilers can keep reading), but the
+// wire boundary scrubs them.
+//
+// The test seeds one CRD of each type, each carrying:
+//   - one internal `blockstor.io/...` annotation,
+//   - one per-bug `bugNNN.blockstor.cozystack.io/...` annotation,
+//   - one third-party / operator-set annotation that MUST pass through.
+//
+// then exercises every list / get path mentioned in the bug-hunt
+// report (view/resources, per-RD list, per-RD per-node get, RD list,
+// RD get, RG list, RG get, snapshot view, per-RD snapshot list, per-
+// RD per-snapshot get) and asserts that the wire payload carries only
+// the third-party key.
+func TestInternalAnnotationsStrippedOnWireBoundary(t *testing.T) {
+	const (
+		canonicalInternalKey = "blockstor.io/peer-changed"
+		bugScopedInternalKey = "bug136.blockstor.cozystack.io/resize-pending-size-kib-vol-0"
+		thirdPartyKey        = "operator.example.com/owner"
+		thirdPartyValue      = "cozystack-team"
+	)
+
+	internalAnnotations := map[string]string{
+		canonicalInternalKey: "2026-05-30T16:57:22.019326537Z",
+		bugScopedInternalKey: "4096",
+		thirdPartyKey:        thirdPartyValue,
+	}
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	// Seed: one RG, one RD, one Resource (single node), one Snapshot —
+	// each carrying the same annotation bag so every wire path is
+	// exercised uniformly.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name:        "rg-leak",
+		Annotations: cloneMap(internalAnnotations),
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "rd-leak",
+		ResourceGroupName: "rg-leak",
+		Annotations:       cloneMap(internalAnnotations),
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name:        "rd-leak",
+		NodeName:    "n1",
+		Annotations: cloneMap(internalAnnotations),
+	}); err != nil {
+		t.Fatalf("seed Resource: %v", err)
+	}
+
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap-leak",
+		ResourceName: "rd-leak",
+		Annotations:  cloneMap(internalAnnotations),
+	}); err != nil {
+		t.Fatalf("seed Snapshot: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Each row is one wire path + a closure that pulls the annotations
+	// bag out of the decoded payload. The two assertions on every
+	// path are identical, so we factor the wire check into a single
+	// helper to keep the table dense.
+	cases := []struct {
+		name string
+		path string
+		// extractAnnotations is invoked with the response body and
+		// returns the (possibly multiple) per-object annotation maps
+		// the path emits.
+		extractAnnotations func(t *testing.T, body []byte) []map[string]string
+	}{
+		{
+			name: "view/resources",
+			path: "/v1/view/resources",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got []apiv1.ResourceWithVolumes
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return resourceWithVolumesAnnotations(got)
+			},
+		},
+		{
+			name: "resource-definitions/{rd}/resources",
+			path: "/v1/resource-definitions/rd-leak/resources",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got []apiv1.ResourceWithVolumes
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return resourceWithVolumesAnnotations(got)
+			},
+		},
+		{
+			name: "resource-definitions/{rd}/resources/{node}",
+			path: "/v1/resource-definitions/rd-leak/resources/n1",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got apiv1.ResourceWithVolumes
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return []map[string]string{got.Annotations}
+			},
+		},
+		{
+			name: "resource-definitions list",
+			path: "/v1/resource-definitions",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got []apiv1.ResourceDefinition
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				out := make([]map[string]string, 0, len(got))
+				for i := range got {
+					out = append(out, got[i].Annotations)
+				}
+				return out
+			},
+		},
+		{
+			name: "resource-definitions/{rd} get",
+			path: "/v1/resource-definitions/rd-leak",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got apiv1.ResourceDefinition
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return []map[string]string{got.Annotations}
+			},
+		},
+		{
+			name: "resource-groups list",
+			path: "/v1/resource-groups",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got []apiv1.ResourceGroup
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				out := make([]map[string]string, 0, len(got))
+				for i := range got {
+					out = append(out, got[i].Annotations)
+				}
+				return out
+			},
+		},
+		{
+			name: "resource-groups/{rg} get",
+			path: "/v1/resource-groups/rg-leak",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got apiv1.ResourceGroup
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return []map[string]string{got.Annotations}
+			},
+		},
+		{
+			name: "view/snapshots",
+			path: "/v1/view/snapshots",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got []apiv1.Snapshot
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return snapshotAnnotations(got)
+			},
+		},
+		{
+			name: "resource-definitions/{rd}/snapshots list",
+			path: "/v1/resource-definitions/rd-leak/snapshots",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got []apiv1.Snapshot
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return snapshotAnnotations(got)
+			},
+		},
+		{
+			name: "resource-definitions/{rd}/snapshots/{snap} get",
+			path: "/v1/resource-definitions/rd-leak/snapshots/snap-leak",
+			extractAnnotations: func(t *testing.T, body []byte) []map[string]string {
+				t.Helper()
+				var got apiv1.Snapshot
+				if err := json.Unmarshal(body, &got); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				return []map[string]string{got.Annotations}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := httpGet(t, base+tc.path)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status: got %d, want 200", resp.StatusCode)
+			}
+
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				t.Fatalf("read body: %v", readErr)
+			}
+
+			annoMaps := tc.extractAnnotations(t, body)
+
+			if len(annoMaps) == 0 {
+				t.Fatalf("no annotation maps decoded from %s — wire payload: %s",
+					tc.path, body)
+			}
+
+			for i, anno := range annoMaps {
+				if _, leaked := anno[canonicalInternalKey]; leaked {
+					t.Errorf("path %s entry %d leaks internal annotation %q: %v",
+						tc.path, i, canonicalInternalKey, anno)
+				}
+
+				if _, leaked := anno[bugScopedInternalKey]; leaked {
+					t.Errorf("path %s entry %d leaks bug-scoped annotation %q: %v",
+						tc.path, i, bugScopedInternalKey, anno)
+				}
+
+				if got := anno[thirdPartyKey]; got != thirdPartyValue {
+					t.Errorf("path %s entry %d dropped operator annotation: got %q for key %q, want %q (full anno bag: %v)",
+						tc.path, i, got, thirdPartyKey, thirdPartyValue, anno)
+				}
+			}
+		})
+	}
+
+	// After the wire exercises, every in-store Annotations bag MUST
+	// still carry the internal keys — the strip is on the wire copy,
+	// not the source struct. Without this assertion a regression that
+	// mutated the store-cached object (e.g. via in-place strip without
+	// cloning) would slip through.
+	rsc, err := st.Resources().Get(ctx, "rd-leak", "n1")
+	if err != nil {
+		t.Fatalf("post-test resource get: %v", err)
+	}
+
+	if _, kept := rsc.Annotations[canonicalInternalKey]; !kept {
+		t.Errorf("stored Resource.Annotations lost internal key %q after wire reads: %v",
+			canonicalInternalKey, rsc.Annotations)
+	}
+
+	if _, kept := rsc.Annotations[bugScopedInternalKey]; !kept {
+		t.Errorf("stored Resource.Annotations lost bug-scoped key %q after wire reads: %v",
+			bugScopedInternalKey, rsc.Annotations)
+	}
+}
+
+// TestStripInternalAnnotationsHelper pins the prefix-match contract
+// for the shared helper. The wire-boundary tests above already cover
+// the integration path; this unit-level pin is the canary for any
+// future caller that wants to scrub a hand-built map (e.g. a
+// hypothetical new CRD type that grows an Annotations slot).
+func TestStripInternalAnnotationsHelper(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		dropped bool
+	}{
+		{name: "canonical internal", key: "blockstor.io/volume-numbers", dropped: true},
+		{name: "canonical internal nested", key: "blockstor.io/auto-tiebreaker-suppressed-until", dropped: true},
+		{name: "bug-scoped internal", key: "bug136.blockstor.cozystack.io/resize-pending", dropped: true},
+		{name: "bug-scoped variant", key: "bug342.blockstor.cozystack.io/uid", dropped: true},
+		{name: "k8s last-applied passthrough", key: "kubectl.kubernetes.io/last-applied-configuration", dropped: false},
+		{name: "operator passthrough", key: "operator.example.com/owner", dropped: false},
+		// Empty key is non-sensitive — defensive guard, never appears
+		// in practice.
+		{name: "empty", key: "", dropped: false},
+		// A key that contains the suffix substring but not anchored at
+		// the `<ns>/<name>` boundary stays — defensive against
+		// accidental over-match.
+		{name: "suffix in value position", key: "foo/" + internalAnnotationSuffix[1:] + "bar", dropped: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := map[string]string{tc.key: "v"}
+			out := stripInternalAnnotations(in)
+
+			_, present := out[tc.key]
+			if tc.dropped && present {
+				t.Errorf("key %q should have been dropped but stayed: %v", tc.key, out)
+			}
+
+			if !tc.dropped && !present {
+				t.Errorf("key %q should have passed through but was dropped: %v", tc.key, out)
+			}
+		})
+	}
+
+	// nil-in => nil-out preserves omitempty on the wire (no surprise
+	// `"annotations":{}` on objects that never had any).
+	if out := stripInternalAnnotations(nil); out != nil {
+		t.Errorf("nil-in: got %v, want nil", out)
+	}
+}
+
+// cloneMap returns a shallow copy of `in` so each seeded CRD owns its
+// own annotations bag — the store is in-memory and would otherwise
+// share references across rows.
+func cloneMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+// resourceWithVolumesAnnotations flattens a slice of
+// ResourceWithVolumes into the embedded `Resource.Annotations` slot
+// for the assertion loop.
+func resourceWithVolumesAnnotations(in []apiv1.ResourceWithVolumes) []map[string]string {
+	out := make([]map[string]string, 0, len(in))
+	for i := range in {
+		out = append(out, in[i].Annotations)
+	}
+
+	return out
+}
+
+// snapshotAnnotations is the Snapshot sibling.
+func snapshotAnnotations(in []apiv1.Snapshot) []map[string]string {
+	out := make([]map[string]string, 0, len(in))
+	for i := range in {
+		out = append(out, in[i].Annotations)
+	}
+
+	return out
+}

--- a/pkg/rest/resource_definitions.go
+++ b/pkg/rest/resource_definitions.go
@@ -117,6 +117,12 @@ func (s *Server) handleRDList(w http.ResponseWriter, r *http.Request) {
 		stampRDLayerDataFromStack(&rds[i])
 	}
 
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal
+	// `blockstor.io/*` + `bug<N>.blockstor.cozystack.io/*` annotations
+	// from every RD before the JSON encode. See
+	// pkg/rest/internal_annotations.go.
+	stripInternalAnnotationsFromRDs(rds)
+
 	writeJSON(w, http.StatusOK, rds)
 }
 
@@ -148,6 +154,11 @@ func (s *Server) handleRDGet(w http.ResponseWriter, r *http.Request) {
 	// per-RD GET path, matching the bulk-list handler above. See
 	// stampRDLayerDataFromStack for the projection rules.
 	stampRDLayerDataFromStack(&rd)
+
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal
+	// annotations on the single-RD wire shape — mirrors the bulk-list
+	// scrub above.
+	rd.Annotations = stripInternalAnnotations(rd.Annotations)
 
 	writeJSON(w, http.StatusOK, rd)
 }

--- a/pkg/rest/resource_groups.go
+++ b/pkg/rest/resource_groups.go
@@ -108,6 +108,11 @@ func (s *Server) handleRGList(w http.ResponseWriter, r *http.Request) {
 		redactSensitiveProps(rgs[i].Props)
 	}
 
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal
+	// annotations from every RG before the JSON encode. See
+	// pkg/rest/internal_annotations.go.
+	stripInternalAnnotationsFromRGs(rgs)
+
 	writeJSON(w, http.StatusOK, rgs)
 }
 
@@ -130,6 +135,11 @@ func (s *Server) handleRGGet(w http.ResponseWriter, r *http.Request) {
 	// mutation is local to this response and does not leak back
 	// into the store cache.
 	redactSensitiveProps(rg.Props)
+
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal
+	// annotations on the single-RG wire shape — mirrors the bulk-list
+	// scrub above.
+	rg.Annotations = stripInternalAnnotations(rg.Annotations)
 
 	writeJSON(w, http.StatusOK, rg)
 }

--- a/pkg/rest/resources.go
+++ b/pkg/rest/resources.go
@@ -111,6 +111,15 @@ func (s *Server) handleResourcesView(w http.ResponseWriter, r *http.Request) {
 		return strings.Compare(left.NodeName, right.NodeName)
 	})
 
+	// Bug-hunt v0.1.3 Finding 2: scrub controller-internal
+	// `blockstor.io/*` + `bug<N>.blockstor.cozystack.io/*` annotations
+	// from every entry before the JSON encode. The reconcilers stamp
+	// these onto the in-process Resource for their own bookkeeping
+	// (peer-changed timestamps, resize-pending size deltas, ...); the
+	// struct field stays, but nothing internal escapes the wire
+	// boundary. See pkg/rest/internal_annotations.go.
+	stripInternalAnnotationsFromResourcesWithVolumes(out)
+
 	writeJSON(w, http.StatusOK, paginateResources(r, out))
 }
 

--- a/pkg/rest/snapshots.go
+++ b/pkg/rest/snapshots.go
@@ -159,6 +159,13 @@ func (s *Server) handleSnapshotsView(w http.ResponseWriter, r *http.Request) {
 	// Bug 115's RD-side redaction at the REST boundary.
 	redactSnapshotsInPlace(snaps)
 
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal annotations
+	// from every snapshot. The reconcilers stamp the same
+	// `blockstor.io/*` + `bug<N>.blockstor.cozystack.io/*` keys on
+	// Snapshot CRDs as on Resource / RD / RG; the wire shape must not
+	// carry them.
+	stripInternalAnnotationsFromSnapshots(snaps)
+
 	// Optional filters golinstor sends: ?resources=rd1,rd2 &
 	// snapshots=name1,name2 — case-insensitive set membership against
 	// Java LINSTOR's behaviour. Without filtering linstor-csi's "do
@@ -255,6 +262,10 @@ func (s *Server) handleSnapshotList(w http.ResponseWriter, r *http.Request) {
 	// all carry the canary on the wire without this sweep.
 	redactSnapshotsInPlace(snaps)
 
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal annotations
+	// — mirrors the cluster-wide view path.
+	stripInternalAnnotationsFromSnapshots(snaps)
+
 	writeJSON(w, http.StatusOK, snaps)
 }
 
@@ -287,6 +298,10 @@ func (s *Server) handleSnapshotGet(w http.ResponseWriter, r *http.Request) {
 	// this response — the store cache stays un-redacted for the
 	// satellite-side LUKS reads which need the real value.
 	redactSnapshotsInPlace(single)
+
+	// Bug-hunt v0.1.3 Finding 2: strip controller-internal annotations
+	// on the single-snapshot wire shape — mirrors the bulk paths.
+	stripInternalAnnotationsFromSnapshots(single)
 
 	writeJSON(w, http.StatusOK, single[0])
 }

--- a/pkg/rest/storage_pools.go
+++ b/pkg/rest/storage_pools.go
@@ -539,13 +539,16 @@ func isKnownStoragePoolKind(kind string) bool {
 // piraeus assumes that invariant when it iterates over per-node SPs in
 // its reconcile loop.
 //
-// Idempotency: re-POSTing the same (node, pool) is a no-op success rather
-// than 409 Conflict. Piraeus's satellite Hello/heartbeat reposts the same
-// pool on every registration tick; treating it as upsert keeps the retry
-// loop quiet and matches the operator's expectation that "re-announce"
-// is safe. Upstream LINSTOR returns an error on duplicate-create, but
-// piraeus retries through that error indefinitely, so the practical
-// outcome is the same — we just skip the retry storm.
+// Duplicate-create contract (Bug-hunt v0.1.3 Finding 1): a re-POST
+// against an existing (node, pool) returns 409 + (MASK_ERROR | 508
+// = FAIL_EXISTS_STOR_POOL) and does NOT mutate the live row. The
+// pre-fix handler silently overwrote `Props` / `ProviderKind` /
+// `FreeSpaceMgrName` from the POST body and returned 201 — a
+// data-plane-impacting footgun: a retrying CSI driver or a mistaken
+// `linstor sp c` repeat could wipe `StorDriver/ZPool`, flip
+// `provider_kind`, etc. Mutation now lives behind PUT
+// (`storage-pool modify` / `storage-pool set-property`). This
+// matches upstream LINSTOR's behaviour on the same input.
 func (s *Server) handleNodeStoragePoolCreate(w http.ResponseWriter, r *http.Request) {
 	node := r.PathValue("node")
 
@@ -624,7 +627,7 @@ func (s *Server) handleNodeStoragePoolCreate(w http.ResponseWriter, r *http.Requ
 	}
 
 	if errors.Is(createErr, store.ErrAlreadyExists) {
-		s.upsertStoragePool(w, r, &body, node)
+		s.refuseDuplicateStoragePool(w, &body, node)
 
 		return
 	}
@@ -691,43 +694,34 @@ func decodeStoragePoolCreate(w http.ResponseWriter, r *http.Request, node string
 	return body, true
 }
 
-// upsertStoragePool merges the POST body's Spec fields onto the
-// existing row when a pool with the same (node, pool) already exists.
-// Capacity / status fields stay where SetCapacity put them. Returns
-// 201 + envelope on success.
-func (s *Server) upsertStoragePool(w http.ResponseWriter, r *http.Request, body *apiv1.StoragePool, node string) {
-	existing, getErr := s.Store.StoragePools().Get(r.Context(), node, body.StoragePoolName)
-	if getErr != nil {
-		writeStoreError(w, getErr)
-
-		return
-	}
-
-	existing.ProviderKind = body.ProviderKind
-	if body.Props != nil {
-		existing.Props = body.Props
-	}
-
-	if body.FreeSpaceMgrName != "" {
-		existing.FreeSpaceMgrName = body.FreeSpaceMgrName
-	}
-
-	if body.SharedSpaceID != "" {
-		existing.SharedSpaceID = body.SharedSpaceID
-	}
-
-	existing.ExternalLocking = body.ExternalLocking
-
-	updateErr := s.Store.StoragePools().Update(r.Context(), &existing)
-	if updateErr != nil {
-		writeStoreError(w, updateErr)
-
-		return
-	}
-
-	writeJSON(w, http.StatusCreated, []apiv1.APICallRc{{
-		RetCode: maskInfo,
-		Message: "storage pool already present, updated in place: " + body.StoragePoolName + " on " + node,
+// refuseDuplicateStoragePool rejects a POST against an SP that already
+// exists with the upstream-LINSTOR-shaped 409 + FAIL_EXISTS_STOR_POOL
+// envelope. Bug-hunt v0.1.3 Finding 1: the pre-fix handler silently
+// mutated the live row's Props / ProviderKind / FreeSpaceMgrName from
+// the POST body and returned 201 with "storage pool already present,
+// updated in place" — a retrying CSI driver or a mistaken `linstor sp
+// c` repeat could wipe `StorDriver/ZPool`, flip `provider_kind`, or
+// otherwise corrupt the live row without any 4xx surface.
+//
+// New contract: POST is CREATE-only. Mutation lives behind
+// `PUT /v1/nodes/{node}/storage-pools/{pool}` (storage-pool modify).
+// The wire shape is byte-identical to upstream's `linstor sp c`
+// duplicate reply: 409 + (MASK_ERROR | 508) + the existing /
+// requested object refs.
+func (s *Server) refuseDuplicateStoragePool(w http.ResponseWriter, body *apiv1.StoragePool, node string) {
+	writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailExistsStorPool,
+		Message: "storage pool '" + body.StoragePoolName + "' on node '" + node + "' already exists",
+		Cause: "POST /v1/nodes/{node}/storage-pools is CREATE-only; the requested " +
+			"(node, pool) is already registered.",
+		Correc: "To change provider_kind / props / free_space_mgr_name on an " +
+			"existing pool use `PUT /v1/nodes/" + node + "/storage-pools/" +
+			body.StoragePoolName + "` (`linstor storage-pool set-property` / " +
+			"`linstor storage-pool modify`).",
+		ObjRefs: map[string]string{
+			objRefNode:     node,
+			objRefStorPool: body.StoragePoolName,
+		},
 	}})
 }
 

--- a/pkg/rest/storage_pools_test.go
+++ b/pkg/rest/storage_pools_test.go
@@ -497,14 +497,16 @@ func TestPerNodeStoragePoolPostCreatesPool(t *testing.T) {
 	}
 }
 
-// TestPerNodeStoragePoolPostIdempotent pins the upsert semantics: a
-// satellite that re-announces the same (node, pool) every heartbeat
-// must not see 409/error — the registration loop relies on
-// re-POST being a no-op-success. We also assert that an updated
-// ProviderKind / Props on the second POST overwrites the stored row,
-// so operator-driven `linstor storage-pool create` re-runs with
-// corrected config actually take effect.
-func TestPerNodeStoragePoolPostIdempotent(t *testing.T) {
+// TestPerNodeStoragePoolPostDuplicateRefused pins the duplicate-POST
+// contract: a second `POST /v1/nodes/{n}/storage-pools` against an
+// existing (node, pool) must return 409 + (MASK_ERROR | 508) and
+// MUST NOT mutate the stored row's Spec fields. Bug-hunt v0.1.3
+// Finding 1: the pre-fix handler silently overwrote `Props` /
+// `ProviderKind` / `FreeSpaceMgrName` from the POST body and returned
+// 201, so a retrying CSI driver or a mistaken `linstor sp c` repeat
+// could wipe `StorDriver/ZPool`, flip `provider_kind`, etc. Mutation
+// now lives behind `PUT /v1/nodes/{n}/storage-pools/{pool}`.
+func TestPerNodeStoragePoolPostDuplicateRefused(t *testing.T) {
 	st := store.NewInMemory()
 	ctx := t.Context()
 
@@ -532,11 +534,12 @@ func TestPerNodeStoragePoolPostIdempotent(t *testing.T) {
 	}
 
 	// Re-POST same (node, name) with a different ProviderKind/Props.
-	// Must succeed, must overwrite Spec fields, must NOT 409.
+	// MUST 409 — new contract: POST is CREATE-only. Mutation lives
+	// behind PUT.
 	second, err := json.Marshal(apiv1.StoragePool{
 		StoragePoolName: "p1",
 		ProviderKind:    apiv1.StoragePoolKindZFSThin,
-		Props:           map[string]string{"StorDriver/ZPool": "zp1"},
+		Props:           map[string]string{"StorDriver/ZPool": "zp1", "Aux/inject": "x"},
 	})
 	if err != nil {
 		t.Fatalf("marshal second: %v", err)
@@ -545,25 +548,52 @@ func TestPerNodeStoragePoolPostIdempotent(t *testing.T) {
 	resp2 := httpPost(t, base+"/v1/nodes/n1/storage-pools", second)
 	defer func() { _ = resp2.Body.Close() }()
 
-	if resp2.StatusCode == http.StatusConflict {
-		t.Fatalf("idempotency broken: got 409 on re-POST")
+	if resp2.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate POST: got %d, want 409", resp2.StatusCode)
 	}
 
-	if resp2.StatusCode != http.StatusCreated {
-		t.Fatalf("second POST: got %d, want 201", resp2.StatusCode)
+	// Envelope shape: MASK_ERROR | FAIL_EXISTS_STOR_POOL (508).
+	var env []apiv1.APICallRc
+	if err := json.NewDecoder(resp2.Body).Decode(&env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
 	}
 
+	if len(env) == 0 {
+		t.Fatalf("envelope: got empty, want one ApiCallRc with FAIL_EXISTS_STOR_POOL")
+	}
+
+	if env[0].RetCode&apiCallRcError == 0 {
+		t.Errorf("ret_code: missing MASK_ERROR bit, got %d", env[0].RetCode)
+	}
+
+	if env[0].RetCode&apiCallRcFailExistsStorPool == 0 {
+		t.Errorf("ret_code: missing FAIL_EXISTS_STOR_POOL (508) sub-code, got %d", env[0].RetCode)
+	}
+
+	// Stored row MUST be untouched — no Props swap, no ProviderKind
+	// flip, no Aux/inject leak. This is the data-plane integrity bit
+	// of the fix.
 	got, err := st.StoragePools().Get(ctx, "n1", "p1")
 	if err != nil {
-		t.Fatalf("store Get after second POST: %v", err)
+		t.Fatalf("store Get after refused duplicate POST: %v", err)
 	}
 
-	if got.ProviderKind != apiv1.StoragePoolKindZFSThin {
-		t.Errorf("provider_kind not updated: got %q, want ZFS_THIN", got.ProviderKind)
+	if got.ProviderKind != apiv1.StoragePoolKindLVMThin {
+		t.Errorf("provider_kind mutated by refused POST: got %q, want LVM_THIN",
+			got.ProviderKind)
 	}
 
-	if got.Props["StorDriver/ZPool"] != "zp1" || got.Props["StorDriver/LvmVg"] != "" {
-		t.Errorf("props not replaced: got %v, want only StorDriver/ZPool=zp1", got.Props)
+	if got.Props["StorDriver/LvmVg"] != "vg1" {
+		t.Errorf("StorDriver/LvmVg mutated by refused POST: got %q, want vg1",
+			got.Props["StorDriver/LvmVg"])
+	}
+
+	if _, leaked := got.Props["Aux/inject"]; leaked {
+		t.Errorf("Aux/inject from refused POST body landed in stored Props: %v", got.Props)
+	}
+
+	if _, leaked := got.Props["StorDriver/ZPool"]; leaked {
+		t.Errorf("StorDriver/ZPool from refused POST body landed in stored Props: %v", got.Props)
 	}
 }
 

--- a/pkg/store/k8s/objectmeta_write_extended_bug_235_test.go
+++ b/pkg/store/k8s/objectmeta_write_extended_bug_235_test.go
@@ -61,14 +61,42 @@ import (
 
 // extendedObjectMetaWriteAllowList enumerates {dir, file,
 // line-substring} triples the extended audit accepts as deliberately
-// safe. Empty by default — every existing write in the walked dirs
-// is either a nil-guard init, an additive append, or a selective
-// DeleteFunc (verified by the audit on the baseline commit). Add an
-// entry only with a justification comment explaining why the write
-// cannot regress the wipe class.
+// safe. Add an entry only with a justification comment explaining why
+// the write cannot regress the wipe class.
 //
 //nolint:gochecknoglobals // package-level test data
-var extendedObjectMetaWriteAllowList = []extendedObjectMetaWriteAllowListEntry{}
+var extendedObjectMetaWriteAllowList = []extendedObjectMetaWriteAllowListEntry{
+	// Bug-hunt v0.1.3 Finding 2 (wire-boundary annotation strip):
+	// the three single-object GET handlers below replace the local
+	// `Annotations` field on a value-copy returned by `Store.*().Get`
+	// (which returns `apiv1.Resource` / `apiv1.ResourceDefinition` /
+	// `apiv1.ResourceGroup` by value, not pointer — verified at
+	// pkg/store/k8s/{resources,resource_definitions,resource_groups}.go).
+	// `stripInternalAnnotations` allocates a fresh map every call, so
+	// the assignment swaps a local pointer; the in-store object is
+	// never touched. This is the wire-OUT boundary, not a write-back
+	// path — the Bug 211 wipe class (controller-stamped key destroyed
+	// by a write that reaches the store cache) cannot fire here.
+	// Bulk-list siblings (`stripInternalAnnotationsFromRDs` etc. in
+	// `internal_annotations.go`) use the same shape against
+	// `slice[i].Annotations`, which the regex already excludes — only
+	// these three single-object GET sites need the explicit allow.
+	{
+		dir:           "pkg/rest",
+		file:          "autoplace.go",
+		lineSubstring: "res.Annotations = stripInternalAnnotations(res.Annotations)",
+	},
+	{
+		dir:           "pkg/rest",
+		file:          "resource_definitions.go",
+		lineSubstring: "rd.Annotations = stripInternalAnnotations(rd.Annotations)",
+	},
+	{
+		dir:           "pkg/rest",
+		file:          "resource_groups.go",
+		lineSubstring: "rg.Annotations = stripInternalAnnotations(rg.Annotations)",
+	},
+}
 
 type extendedObjectMetaWriteAllowListEntry struct {
 	dir           string // path relative to module root, e.g. "pkg/rest"


### PR DESCRIPTION
## Summary

Closes the two P1 findings from the v0.1.3 bug-hunt report that earlier waves didn't reach.

### Finding 1 — POST `/v1/nodes/{n}/storage-pools` silently mutates existing SP

The pre-fix handler returned 201 + `"storage pool already present, updated in place"` when the (node, pool) already existed and silently overwrote `Props` / `ProviderKind` / `FreeSpaceMgrName` / `SharedSpaceID` / `ExternalLocking` from the POST body. A retrying CSI driver, piraeus reconciler, or a mistaken `linstor sp c` repeat could wipe `StorDriver/ZPool`, flip `provider_kind`, or otherwise corrupt the live row without any 4xx surface — data-plane-impacting.

New contract: POST is CREATE-only. Duplicate (node, pool) returns 409 + `MASK_ERROR | FAIL_EXISTS_STOR_POOL (508)` and leaves the live row untouched. Mutation lives behind `PUT /v1/nodes/{node}/storage-pools/{pool}` (storage-pool modify / set-property). Wire shape matches upstream LINSTOR's duplicate-create reply on the same input.

### Finding 2 — Resource list leaks internal `blockstor.io/*` and `bug<N>.blockstor.cozystack.io/*` annotations

`GET /v1/view/resources`, `GET /v1/resource-definitions/{rd}/resources`, `GET .../resources/{node}`, the RD / RG list+get paths, and the Snapshot view / list / get paths all emitted controller-internal annotations on the wire — e.g. `blockstor.io/peer-changed` (a monotonic timestamp bumped on every reconcile) and `bug136.blockstor.cozystack.io/resize-pending-size-kib-vol-0`. Two concrete harms: strict OpenAPI clients (golinstor with DisallowUnknownFields, openapi-codegen consumers) reject the response, and the `bug<N>.blockstor.cozystack.io` namespace leaks internal bug-tracker IDs as if they were stable wire contract — once piraeus-operator parses one, removing it later becomes breaking.

Fix: a small `stripInternalAnnotations` helper drops every key prefixed with `blockstor.io/` or any namespace ending in `.blockstor.cozystack.io/`, applied on the wire copy in every list / get handler for Resource, ResourceDefinition, ResourceGroup, and Snapshot. The struct field stays — the reconcilers keep reading their internal state from the in-process object; only the JSON encoder sees a scrubbed copy. Pattern mirrors the existing `redactSensitiveProps` / `redactSnapshotsInPlace` helpers in the same package.

## Test plan

- [x] `go test ./pkg/rest/... ./pkg/api/...` passes
- [x] `golangci-lint run ./pkg/rest/... ./pkg/api/...` clean
- [x] New unit test pins the SP duplicate-POST 409 + FAIL_EXISTS_STOR_POOL contract and asserts the stored row is NOT mutated by the refused POST body
- [x] New unit test exercises all 10 list / get wire paths (view/resources, per-RD resource list+get, RD list+get, RG list+get, view/snapshots, per-RD snapshot list+get) and asserts internal annotations are stripped while an operator-set `operator.example.com/owner` annotation passes through
- [x] Post-test assertion that the in-store Resource still carries the internal keys (strip is on the wire copy, not the source struct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Storage pool creation now returns a conflict error (409) when attempting to create a duplicate storage pool, instead of silently updating the existing one.
  * Internal controller annotations are no longer exposed in REST API responses, preventing internal bookkeeping keys from leaking to clients.

* **Tests**
  * Added comprehensive tests for annotation scrubbing and duplicate storage pool creation handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/blockstor/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->