### PR TITLE
fix(satellite): narrow skip-net gate to StandAlone peers with peer-device entries

### DIFF
--- a/pkg/satellite/adjust_test.go
+++ b/pkg/satellite/adjust_test.go
@@ -519,3 +519,274 @@ func TestAdjustResourceBareWhenAllPeersConnected(t *testing.T) {
 			skipNetCmd, cmds)
 	}
 }
+
+// TestAdjustResourceBareOnStandAloneWithoutPeerDevices pins scenario
+// 5.32 / `tests/e2e/recovery-down-reverses.sh`: when the operator
+// ran `drbdadm down <rd>` and the reconciler revived the kernel
+// slot via the Bug-287 `drbdadm up` fallback, the freshly-allocated
+// connection slots can stick in `StandAlone` WITHOUT peer-device
+// entries (the kernel created the slot but the connect handshake
+// never registered the per-volume peer-device table). The next
+// `drbdadm adjust` MUST be a bare adjust — not `--skip-net` — so
+// `drbdsetup connect` is re-issued and the slot exits StandAlone.
+//
+// Smoking-gun evidence captured on PR #46 lane 1 breakpoint:
+//
+//	ci-lane1-worker-2 view:
+//	down-reverses node-id:1 role:Secondary suspended:quorum force-io-failures:no
+//	  volume:0 minor:20000 disk:Inconsistent backing_dev:/dev/loop5 quorum:no
+//	  ci-lane1-worker-1 node-id:0 connection:StandAlone role:Unknown
+//	  ci-lane1-worker-3 node-id:2 connection:StandAlone role:Unknown
+//
+// Both peers StandAlone, no peer-device entries — the recovery-
+// revive signature. Pre-fix the reconciler dispatched `--skip-net`
+// here (StandAlone alone was enough to flip the gate) and the
+// scenario aborted after 60s with both peers still StandAlone.
+// The fix narrows the gate to StandAlone AND peer-devices-present
+// (the operator-disconnect signal), so this case falls through to
+// bare adjust.
+func TestAdjustResourceBareOnStandAloneWithoutPeerDevices(t *testing.T) {
+	fx := storage.NewFakeExec()
+
+	// Local disk reads UpToDate (so the SkipDisk coercion path stays
+	// off — we're isolating the SkipNet gate). Peer slot exists in
+	// the kernel but its `peer_devices` array is empty: the post-
+	// `drbdadm up` recovery signature.
+	fx.Expect("drbdsetup status --verbose pvc-down-revive", storage.FakeResponse{
+		Stdout: []byte(`pvc-down-revive node-id:0 role:Secondary
+  volume:0 minor:1000 disk:UpToDate backing_dev:/dev/vg/pvc-down-revive_00000 quorum:yes
+      worker-2 node-id:1 connection:StandAlone role:Unknown
+    volume:0 replication:Off peer-disk:DUnknown
+`),
+	})
+
+	fx.Expect("drbdsetup status -j pvc-down-revive", storage.FakeResponse{
+		Stdout: []byte(`[
+  {
+    "name": "pvc-down-revive",
+    "connections": [
+      {
+        "peer-node-id": 1,
+        "name": "worker-2",
+        "connection-state": "StandAlone",
+        "peer_devices": []
+      }
+    ]
+  }
+]
+`),
+	})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "n1",
+	})
+
+	dr := &intent.DesiredResource{
+		Name:     "pvc-down-revive",
+		NodeName: "n1",
+		Props:    map[string]string{},
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+		},
+		DrbdOptions: map[string]string{
+			"port":    "7000",
+			"node-id": "0",
+			"address": "10.0.0.1",
+			"minor":   "1000",
+		},
+	}
+
+	if err := rec.adjustResource(context.Background(), dr, false); err != nil {
+		t.Fatalf("adjustResource: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+
+	bareCmd := "drbdadm adjust pvc-down-revive"
+	skipNetCmd := "drbdadm adjust --skip-net pvc-down-revive"
+
+	if !slices.Contains(cmds, bareCmd) {
+		t.Errorf("StandAlone without peer-devices: expected bare %q in commands; "+
+			"got %v (scenario 5.32 wedge — reconciler stuck both peers StandAlone)", bareCmd, cmds)
+	}
+
+	if slices.Contains(cmds, skipNetCmd) {
+		t.Errorf("StandAlone without peer-devices: %q must not run "+
+			"(would strand fresh-revive slots in StandAlone forever); got %v",
+			skipNetCmd, cmds)
+	}
+}
+
+// TestAdjustResourceBareOnMultiPeerStandAloneAllWithoutPeerDevices
+// covers the exact multi-peer shape captured in the PR #46 smoking
+// gun: two peers (UpToDate sibling + Diskless TieBreaker), both
+// stuck in `StandAlone` without peer-device entries after the
+// operator's `drbdadm down`+ Bug-287 `up` revive. Same invariant
+// as the single-peer test, but pinned for the multi-peer case so a
+// future regression that special-cased "exactly one peer" would
+// surface here.
+func TestAdjustResourceBareOnMultiPeerStandAloneAllWithoutPeerDevices(t *testing.T) {
+	fx := storage.NewFakeExec()
+
+	fx.Expect("drbdsetup status --verbose down-reverses", storage.FakeResponse{
+		Stdout: []byte(`down-reverses node-id:1 role:Secondary suspended:quorum force-io-failures:no
+  volume:0 minor:20000 disk:Inconsistent backing_dev:/dev/loop5 quorum:no
+      ci-lane1-worker-1 node-id:0 connection:StandAlone role:Unknown
+    volume:0 replication:Off peer-disk:DUnknown
+      ci-lane1-worker-3 node-id:2 connection:StandAlone role:Unknown
+    volume:0 replication:Off peer-disk:DUnknown
+`),
+	})
+
+	fx.Expect("drbdsetup status -j down-reverses", storage.FakeResponse{
+		Stdout: []byte(`[
+  {
+    "name": "down-reverses",
+    "connections": [
+      {
+        "peer-node-id": 0,
+        "name": "ci-lane1-worker-1",
+        "connection-state": "StandAlone",
+        "peer_devices": []
+      },
+      {
+        "peer-node-id": 2,
+        "name": "ci-lane1-worker-3",
+        "connection-state": "StandAlone",
+        "peer_devices": []
+      }
+    ]
+  }
+]
+`),
+	})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "ci-lane1-worker-2",
+	})
+
+	dr := &intent.DesiredResource{
+		Name:     "down-reverses",
+		NodeName: "ci-lane1-worker-2",
+		Props:    map[string]string{},
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 65536, StoragePool: "thin1"},
+		},
+		DrbdOptions: map[string]string{
+			"port":    "7000",
+			"node-id": "1",
+			"address": "10.0.0.2",
+			"minor":   "20000",
+		},
+	}
+
+	if err := rec.adjustResource(context.Background(), dr, false); err != nil {
+		t.Fatalf("adjustResource: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+
+	bareCmd := "drbdadm adjust down-reverses"
+	skipNetCmd := "drbdadm adjust --skip-net down-reverses"
+
+	if !slices.Contains(cmds, bareCmd) {
+		t.Errorf("multi-peer StandAlone without peer-devices: expected bare %q; got %v",
+			bareCmd, cmds)
+	}
+
+	if slices.Contains(cmds, skipNetCmd) {
+		t.Errorf("multi-peer StandAlone without peer-devices: %q must not run; got %v",
+			skipNetCmd, cmds)
+	}
+}
+
+// TestAdjustResourceSkipNetOnMixedStandAlonePeerDevices pins the
+// disambiguator's tie-break direction in the multi-peer mixed case:
+// when ONE peer is StandAlone with peer-device entries (operator-
+// disconnect signal) and another is StandAlone WITHOUT peer-device
+// entries (fresh revive), the operator-disconnect signal wins —
+// `--skip-net` MUST fire so the operator's manual disconnect on
+// the first peer survives the reconcile. The fresh-revive peer
+// can wait for the next observer-trigger cycle to be picked up:
+// preserving operator intent on the first peer is the stricter
+// invariant of the two (an unwanted reconnect breaks W12 / split-
+// brain recovery; a delayed reconnect is recoverable).
+func TestAdjustResourceSkipNetOnMixedStandAlonePeerDevices(t *testing.T) {
+	fx := storage.NewFakeExec()
+
+	fx.Expect("drbdsetup status --verbose pvc-mixed-standalone", storage.FakeResponse{
+		Stdout: []byte(`pvc-mixed-standalone node-id:0 role:Secondary
+  volume:0 minor:1000 disk:UpToDate backing_dev:/dev/vg/pvc-mixed-standalone_00000 quorum:yes
+      worker-2 node-id:1 connection:StandAlone role:Unknown
+    volume:0 replication:Off peer-disk:DUnknown
+      worker-3 node-id:2 connection:StandAlone role:Unknown
+    volume:0 replication:Off peer-disk:DUnknown
+`),
+	})
+
+	fx.Expect("drbdsetup status -j pvc-mixed-standalone", storage.FakeResponse{
+		Stdout: []byte(`[
+  {
+    "name": "pvc-mixed-standalone",
+    "connections": [
+      {
+        "peer-node-id": 1,
+        "name": "worker-2",
+        "connection-state": "StandAlone",
+        "peer_devices": [
+          {"volume": 0}
+        ]
+      },
+      {
+        "peer-node-id": 2,
+        "name": "worker-3",
+        "connection-state": "StandAlone",
+        "peer_devices": []
+      }
+    ]
+  }
+]
+`),
+	})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "n1",
+	})
+
+	dr := &intent.DesiredResource{
+		Name:     "pvc-mixed-standalone",
+		NodeName: "n1",
+		Props:    map[string]string{},
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+		},
+		DrbdOptions: map[string]string{
+			"port":    "7000",
+			"node-id": "0",
+			"address": "10.0.0.1",
+			"minor":   "1000",
+		},
+	}
+
+	if err := rec.adjustResource(context.Background(), dr, false); err != nil {
+		t.Fatalf("adjustResource: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+
+	skipNetCmd := "drbdadm adjust --skip-net pvc-mixed-standalone"
+	bareCmd := "drbdadm adjust pvc-mixed-standalone"
+
+	if !slices.Contains(cmds, skipNetCmd) {
+		t.Errorf("mixed StandAlone (one with peer-devices): expected %q "+
+			"(operator-disconnect signal wins); got %v", skipNetCmd, cmds)
+	}
+
+	if slices.Contains(cmds, bareCmd) {
+		t.Errorf("mixed StandAlone (one with peer-devices): %q must not run "+
+			"(would re-connect operator-disconnected peer); got %v", bareCmd, cmds)
+	}
+}

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -3535,9 +3535,10 @@ func (r *Reconciler) dispatchAdjust(ctx context.Context, resource string, skipDi
 
 // shouldSkipNetOnAdjust probes the kernel for operator-initiated
 // `StandAlone` peer connection slots. When any peer is in
-// `StandAlone`, the caller dispatches `drbdadm adjust --skip-net`
-// rather than plain adjust — preserving the operator's manual
-// disconnect across the reconcile.
+// `StandAlone` AND the kernel has peer-device entries registered
+// for it, the caller dispatches `drbdadm adjust --skip-net` rather
+// than plain adjust — preserving the operator's manual disconnect
+// across the reconcile.
 //
 // W12 + network-partition guard: when the operator runs
 // `drbdadm disconnect <rd>` or `drbdsetup disconnect --force=yes <rd>
@@ -3565,6 +3566,28 @@ func (r *Reconciler) dispatchAdjust(ctx context.Context, resource string, skipDi
 // prop changes) still runs; net-attach is left for the operator to
 // restore via `drbdadm connect`.
 //
+// Scenario 5.32 / recovery-down-reverses guard: the same `StandAlone`
+// connection-state token shows up in a SECOND, semantically distinct
+// case — the post-`drbdadm down` recovery window. When an operator
+// runs `drbdadm down <rd>` and the reconciler revives the kernel
+// slot via the Bug-287 `drbdadm up` fallback (ActionUp via FSM), a
+// transient or failed handshake can leave fresh peer connection
+// slots stuck in StandAlone WITHOUT peer-device entries — the
+// kernel allocated the slot but the connect handshake never
+// registered the per-volume peer-device table. The operator-
+// disconnect case ALWAYS retains peer-device entries (kernel keeps
+// the configured volumes around after `drbdadm disconnect`, only
+// the connection-state flips), so the presence of at least one
+// peer-device entry is the disambiguator: it is the kernel's
+// "this slot was successfully negotiated at some point" marker.
+//
+// We therefore require BOTH StandAlone connection-state AND at
+// least one peer-device entry for any volume in the desired set
+// before coercing `--skip-net`. A fresh-revive StandAlone (no
+// peer-devices) falls through to the bare adjust path — which
+// re-issues `drbdsetup connect` and unwedges scenario 5.32
+// (`tests/e2e/recovery-down-reverses.sh`).
+//
 // Best-effort: a probe error returns false so adjust falls through
 // to the existing full-adjust path (failing closed would freeze
 // adjust on any transient drbdsetup hiccup). The probe is
@@ -3577,9 +3600,21 @@ func (r *Reconciler) shouldSkipNetOnAdjust(ctx context.Context, resource string)
 	}
 
 	for _, slot := range slots {
-		if slot.ConnectionState == string(drbd.ConnectionStateStandAlone) {
-			return true
+		if slot.ConnectionState != string(drbd.ConnectionStateStandAlone) {
+			continue
 		}
+		// Recovery-down-reverses disambiguator: a StandAlone slot with
+		// NO peer-device entry is a fresh slot that has not completed a
+		// connect handshake (post-`drbdadm up` revive window). Treat
+		// that as "needs full adjust" so the next `drbdadm adjust`
+		// re-issues `drbdsetup connect`. Only StandAlone slots that
+		// retain peer-device entries (the operator-disconnect signal)
+		// trigger `--skip-net`.
+		if len(slot.PeerDevicesByVolNum) == 0 {
+			continue
+		}
+
+		return true
 	}
 
 	return false

--- a/tests/e2e/recovery-down-reverses.sh
+++ b/tests/e2e/recovery-down-reverses.sh
@@ -37,17 +37,28 @@
 #
 # OBSERVED CURRENT STATE (recorded for the spec-gap)
 # --------------------------------------------------
-# pkg/satellite/reconciler.go::applyDRBD runs `drbdadm adjust <rd>`
-# unconditionally as long as a `.md-created` marker exists for the
-# RD. After `drbdadm down`, the kernel slot is gone but the marker
-# survives, so the reconciler retries `adjust` — which then fails
-# with "Failure: (158) Unknown resource" because adjust expects
-# the resource to already be loaded. The reconciler never falls
-# back to `drbdadm up` / `new-resource`, so the resource stays
-# down indefinitely. See reconciler_drbd_test.go:1606-1615 for
-# the same gap noted under a different scenario (Bug 8 / 5.16).
-# Scenario 5.32 therefore FAILs on master today and serves as the
-# forward-spec for the missing kernel-state-aware revive path.
+# Initial wedge (pre-fix): pkg/satellite/reconciler.go::applyDRBD ran
+# `drbdadm adjust <rd>` unconditionally as long as a `.md-created`
+# marker existed for the RD. After `drbdadm down`, the kernel slot
+# was gone but the marker survived, so the reconciler retried
+# `adjust` — which failed with "Failure: (158) Unknown resource".
+# Fixed by the Bug-287 fallback in runAdjust (catch the 158 error
+# text → fall back to `drbdadm up`) AND the FSM dispatch chain
+# (Phase=MetadataReady → ActionUp). Step 4 of this test pins that
+# revive path.
+#
+# Recovery wedge (flaky on PR #46 lane 1, 2026-05-30): even when
+# the satellite revived the kernel slot via `drbdadm up`, both
+# peer connection slots stuck in `connection:StandAlone` and never
+# reconnected. The next `drbdadm adjust` was coerced onto
+# `--skip-net` by shouldSkipNetOnAdjust (any StandAlone peer was
+# enough to trigger the gate) — preserving the wedge instead of
+# re-issuing `drbdsetup connect`. Fixed by narrowing the gate to
+# StandAlone-AND-peer-devices-present (the operator-disconnect
+# signature). A fresh-revive StandAlone (post-`drbdadm up`, no
+# peer-device entries registered yet) now falls through to bare
+# adjust, which re-issues `connect`. Step 5 below pins that
+# convergence with a 60s budget.
 #
 # Steps
 #   1. Apply 2-replica RD on $N1+$N2, wait UpToDate.
@@ -165,8 +176,28 @@ done
 
 if (( connected == 0 )); then
     echo "FAIL: ${RD} did not reach Connected+UpToDate within ${UPTODATE_DEADLINE_SECS}s"
+    echo "      last observed per-peer connection state:"
+    echo "        ${N1} -> ${N2}: ${n1_conn}"
+    echo "        ${N2} -> ${N1}: ${n2_conn}"
+    echo "        ${N1} local disk: ${n1_local_disk}"
+    echo "        ${N2} local disk: ${n2_local_disk}"
     echo "      ${N1} view:"; on_node "$N1" drbdsetup status "$RD" --verbose 2>&1 | sed 's/^/      /' || true
     echo "      ${N2} view:"; on_node "$N2" drbdsetup status "$RD" --verbose 2>&1 | sed 's/^/      /' || true
+    # Scenario 5.32 forensic dump: when both peers stay StandAlone after
+    # the revive, the json view shows whether peer-device entries were
+    # registered. Empty peer_devices = post-`drbdadm up` revive signature
+    # (kernel slot created but connect handshake never registered the
+    # per-volume table); non-empty = operator-disconnect signature. See
+    # pkg/satellite/reconciler.go::shouldSkipNetOnAdjust and
+    # tests/e2e/recovery-down-reverses.sh comment block above.
+    echo "      ${N2} drbdsetup status -j ${RD}:"
+    on_node "$N2" drbdsetup status -j "$RD" 2>&1 | sed 's/^/      /' || true
+    echo "      satellite logs (last 80 lines, ${N2}):"
+    sat_pod=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o "jsonpath={.items[?(@.spec.nodeName==\"${N2}\")].metadata.name}" 2>/dev/null || true)
+    if [[ -n "${sat_pod}" ]]; then
+        kubectl -n "$NS" logs --tail=80 "$sat_pod" 2>/dev/null | sed 's/^/      /' || true
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

E2E scenario `recovery-down-reverses` (`tests/e2e/recovery-down-reverses.sh`) was flaky on lane 1 (latest hit captured on PR #46 lane breakpoint). After an operator-simulated `drbdadm down` on `ci-lane1-worker-2`, the satellite reconciler correctly re-creates the kernel resource within ~1s via the Bug-287 `drbdadm up` fallback, but both peer connections stick in `connection:StandAlone` and never re-connect. The scenario then aborts at the 60s UpToDate deadline.

## Smoking-gun evidence

Captured via SSH breakpoint on PR #46 lane 1:

**View from worker-2 (the "downed" node) after respawn:**

```
ci-lane1-worker-2 view:
down-reverses node-id:1 role:Secondary suspended:quorum force-io-failures:no
  volume:0 minor:20000 disk:Inconsistent backing_dev:/dev/loop5 quorum:no
  ci-lane1-worker-1 node-id:0 connection:StandAlone role:Unknown
  ci-lane1-worker-3 node-id:2 connection:StandAlone role:Unknown
```

**View from worker-1 (its peer):**

- worker-2 shown as `connection:Connecting` (never `Connected`)
- worker-1 itself is `UpToDate`, worker-3 is `Diskless` (TieBreaker) and `Established`

## Root cause

`pkg/satellite/reconciler.go::shouldSkipNetOnAdjust` coerced `drbdadm adjust --skip-net` on ANY peer slot reported as `StandAlone`. The intent was to preserve operator-initiated disconnects (W12 split-brain recovery, iptables-partition tests). But the SAME `StandAlone` connection-state token also appears in a different, semantically distinct case: the post-`drbdadm down` recovery window. After `drbdadm up` brings the slot back, fresh peer connection slots can sit in `StandAlone` **without** peer-device entries — the kernel allocated the slot but the connect handshake never registered the per-volume peer-device table.

The next reconcile then dispatched `adjust --skip-net`, which leaves the connection slots alone and never re-issues `drbdsetup connect`. The wedge sealed itself: peers stayed StandAlone forever, the next reconcile saw StandAlone, dispatched `--skip-net` again, ad infinitum.

The operator-disconnect path (W12 / iptables-partition) ALWAYS retains peer-device entries — `drbdadm disconnect` only flips the connection-state token, it does not tear down the per-volume peer-device table. That asymmetry is the disambiguator the existing code was missing.

## Fix

Narrow the skip-net gate: require **both** `StandAlone` connection-state **and** at least one peer-device entry before coercing `--skip-net`. The operator-disconnect case is preserved (peer-devices present → skip-net still fires). The fresh-revive case (peer-devices absent) falls through to bare `drbdadm adjust`, which re-issues `drbdsetup connect` and unwedges the scenario.

The disambiguator is the same kernel signal the Bug 342 v3 stuck-slot prune already keys on (`PeerDevicesByVolNum` empty = "no successful handshake on this slot"). No new probe is needed.

## Test plan

- [x] `go test ./pkg/satellite/... ./pkg/drbd/...` — passes
- [x] `golangci-lint run ./pkg/satellite/... ./pkg/drbd/...` — 0 issues
- [x] Existing skip-net tests still pass (`TestAdjustResourceUsesSkipNetOnStandAlonePeer`, `TestAdjustResourceSkipsBothNetAndDiskOnDoubleSignal`, `TestAdjustResourceBareWhenAllPeersConnected`) — peer-device entries present in their fixtures, behavior preserved
- [x] New unit tests added:
  - `TestAdjustResourceBareOnStandAloneWithoutPeerDevices` — single-peer fresh-revive (bare adjust)
  - `TestAdjustResourceBareOnMultiPeerStandAloneAllWithoutPeerDevices` — multi-peer fresh-revive (smoking-gun shape, bare adjust)
  - `TestAdjustResourceSkipNetOnMixedStandAlonePeerDevices` — mixed (one operator-disconnected + one fresh-revive): operator-disconnect signal wins, `--skip-net` fires
- [x] E2E failure dump enriched: prints per-peer connection state, `drbdsetup status -j` JSON view (which carries peer-device entries), and recent satellite logs so future hits surface evidence faster
- [ ] Re-run `tests/e2e/recovery-down-reverses.sh` on the QEMU stand over ≥10 iterations to confirm the flake is gone