### PR TITLE
fix(e2e): harden 4 flaky scenarios surfaced in 2026-05-31 CI runs

### DIFF
--- a/tests/e2e/recovery-deleting-convert.sh
+++ b/tests/e2e/recovery-deleting-convert.sh
@@ -198,15 +198,25 @@ done
 # Reuse wait_uptodate for the (N1,N2) pair; check N3 separately so
 # the 180 s budget is shared but per-peer status is explicit.
 wait_uptodate "$RD" "$N1" "$N2"
-deadline=$(( $(date +%s) + 60 ))
+# Accept kernel ground truth too (mirrors wait_uptodate's own fallback) —
+# run 26662475084 FAILed here with N3's CRD .status briefly empty while the
+# kernel was already UpToDate, the same projection-lag pattern documented
+# above for the (N1,N2) pair. Bumped 60→120 for extra headroom on the
+# 3-peer initial sync at the QEMU stand's native disk rate.
+deadline=$(( $(date +%s) + 120 ))
+n3_ok=0
 while (( $(date +%s) < deadline )); do
     if [[ "$(disk_state "$N3")" == *"UpToDate"* ]]; then
-        break
+        n3_ok=1; break
+    fi
+    if [[ "$(kernel_pair_uptodate "$RD" "$N1" "$N3")" == "ok" ]]; then
+        n3_ok=1; break
     fi
     sleep 2
 done
-if [[ "$(disk_state "$N3")" != *"UpToDate"* ]]; then
+if (( n3_ok == 0 )); then
     echo "FAIL: N3 not UpToDate before scenario starts"
+    on_node "$N1" drbdsetup status "$RD" --verbose 2>/dev/null || true
     exit 1
 fi
 echo "   all 3 peers UpToDate"

--- a/tests/e2e/recovery-down-reverses.sh
+++ b/tests/e2e/recovery-down-reverses.sh
@@ -84,7 +84,11 @@ N1=$WORKER_1
 N2=$WORKER_2
 SIZE_KIB=65536
 REVIVE_DEADLINE_SECS=60
-UPTODATE_DEADLINE_SECS=60
+# Bumped 60→120: the StandAlone-after-revive convergence path (see
+# shouldSkipNetOnAdjust block comment above) routinely takes >60s on the
+# QEMU stand when the reconcile-tick hits mid-handshake; runs 26693209114
+# and 26662475084 both timed out here on already-healthy resources.
+UPTODATE_DEADLINE_SECS=120
 
 trap 'delete_rd "$RD"' EXIT
 

--- a/tests/e2e/state-auto-resync.sh
+++ b/tests/e2e/state-auto-resync.sh
@@ -131,7 +131,11 @@ trap 'cleanup_partition; delete_rd "$RD"' EXIT
 # a genuinely non-converged RD still shows non-UpToDate, so real
 # failures are not masked.
 wait_uptodate_3() {
-    local rd=$1 deadline=$(( $(date +%s) + 240 ))
+    # Bumped 240→300 and added an at-deadline retry: lane6/run 26706441200
+    # FAILed and the immediate post-fail `drbdsetup status` dump showed all
+    # three peers UpToDate, meaning convergence raced the deadline by a
+    # few seconds. The retry below absorbs that edge window.
+    local rd=$1 deadline=$(( $(date +%s) + 300 ))
     while (( $(date +%s) < deadline )); do
         local ok=1
         for n in "$N1" "$N2" "$N3"; do
@@ -151,6 +155,14 @@ wait_uptodate_3() {
 
         sleep 2
     done
+
+    # Last-chance check before declaring failure — pads against the
+    # converged-during-final-sleep race surfaced in run 26706441200.
+    sleep 5
+    if [[ "$(kernel_all_uptodate "$rd" "$N1")" == "ok" ]]; then
+        return 0
+    fi
+
     echo "FAIL: $rd never reached UpToDate on all 3 peers" >&2
     echo "   last CRD diskState: $N1=$(status_disk_state "$rd" "$N1") $N2=$(status_disk_state "$rd" "$N2") $N3=$(status_disk_state "$rd" "$N3")" >&2
     on_node "$N1" drbdsetup status "$rd" 2>/dev/null || true

--- a/tests/e2e/state-offline-unknown.sh
+++ b/tests/e2e/state-offline-unknown.sh
@@ -114,14 +114,22 @@ cleanup() {
         2>/dev/null || true
     kubectl label node "$WORKER_3" "${EVICT_LABEL}-" 2>/dev/null || true
 
-    # Wait briefly for satellite Pod readiness before tearing the RD —
-    # gives delete_rd's per-pod drbdsetup-down clean shot at WORKER_3.
-    local deadline=$(( $(date +%s) + 60 ))
+    # Wait for ALL 3 satellite Pods Ready before tearing the RD — checking
+    # only WORKER_3 raced the next scenario's `require_workers 3` preflight
+    # when DS desired/ready briefly desynced after the affinity-revert
+    # (toggle-disk SKIPped with "found 2" on lane 3 of run 26646144009).
+    # Widen window to 120s and require numberReady==desiredNumberScheduled,
+    # the same signal `reset_cluster_state` and `require_workers` use.
+    local deadline=$(( $(date +%s) + 120 ))
+    local ds_ready=0 ds_desired=0
     while (( $(date +%s) < deadline )); do
-        local ready
-        ready=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
-            -o "jsonpath={.items[?(@.spec.nodeName==\"${WORKER_3}\")].status.containerStatuses[0].ready}" 2>/dev/null || true)
-        [[ "$ready" == "true" ]] && break
+        ds_desired=$(kubectl -n "$NS" get ds blockstor-satellite \
+            -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
+        ds_ready=$(kubectl -n "$NS" get ds blockstor-satellite \
+            -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+        if [[ -n "$ds_desired" ]] && (( ds_desired > 0 )) && (( ds_desired == ds_ready )); then
+            break
+        fi
         sleep 2
     done
 
@@ -245,11 +253,15 @@ echo ">> label $N3 with $EVICT_LABEL=offline so DS affinity excludes it"
 kubectl label node "$N3" "${EVICT_LABEL}=offline" --overwrite
 
 echo ">> force-delete satellite Pod on $N3 (no grace — bypass preStop, race the DS eviction)"
-sat_pod=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
-    -o "jsonpath={.items[?(@.spec.nodeName==\"${N3}\")].metadata.name}")
-if [[ -n "$sat_pod" ]]; then
-    kubectl -n "$NS" delete pod "$sat_pod" --force --grace-period=0 --wait=false
-fi
+# Closes the get-then-delete race: between `get pod name` and `delete pod $name`
+# the DS controller can complete its own eviction first (the affinity patch
+# above already excluded $N3), and the `delete pod $name` then 404s. Use a
+# field-selector delete instead so kubectl resolves the target server-side
+# under the satellite label, and tolerate NotFound — either the DS controller
+# already evicted the pod (success) or we beat it to the punch (also success).
+kubectl -n "$NS" delete pod -l app=blockstor-satellite \
+    --field-selector "spec.nodeName=${N3}" \
+    --force --grace-period=0 --wait=false --ignore-not-found
 
 # Confirm the DaemonSet refused to re-schedule (so heartbeats truly stop).
 sleep 8


### PR DESCRIPTION
## Summary

Test-hardening pass on four scenarios that surfaced as flakes (PASS on one CI run, FAIL on the next, on the same or near-identical product code) in the last ~24h of CI history. No product code touched — pkg/ is unchanged.

CI history sample: 21 failed `pull-request.yml` runs over 2026-05-29 .. 2026-05-31. Scenarios already excluded via `E2E_EXCLUDE` (csi-pvc-local, observability-capacity-correlation, node-replace-hardware) are left as-is and are NOT product gaps closed here.

## Scenarios fixed

- **state-offline-unknown** — `kubectl get pods … | save name | kubectl delete pod $name` is a documented race between the pod-name read and the delete: the DaemonSet controller observes the affinity patch first, evicts the satellite Pod on `WORKER_3` itself, and the by-name delete then 404s with `Error from server (NotFound)`. Replaced with a label-plus-field-selector delete + `--ignore-not-found`, so the DS controller and the test cannot lose the race. Additionally, the EXIT cleanup now waits for ALL 3 satellite Pods to be Ready (`numberReady == desiredNumberScheduled`) within 120s, not only `WORKER_3`'s container, so the next scenario's `require_workers 3` preflight cannot race the DS desired/ready desync after the affinity-revert (this was the toggle-disk SKIP cascade on lane 3 of run 26646144009).

- **state-auto-resync** — `wait_uptodate_3` was tripping at the 240s deadline while the post-fail `drbdsetup status` dump showed all three peers UpToDate (run 26706441200). Bumped to 300s and added a 5s grace re-check after the loop exits, so a convergence that lands within seconds of the deadline still passes.

- **recovery-down-reverses** — `UPTODATE_DEADLINE_SECS` raised from 60 to 120 to absorb the StandAlone-after-revive handshake window the script's own comment block already calls out as flaky on the QEMU stand. Both run 26693209114 and run 26662475084 timed out here against resources that were otherwise healthy.

- **recovery-deleting-convert** — the pre-scenario N3 readiness wait read only the CRD `.status.diskState` projection, which can lag tens of seconds behind the kernel after a fresh autoplace. Added a `kernel_pair_uptodate` fallback (mirroring `lib.sh::wait_uptodate`'s own dual-source check) and widened the budget from 60s to 120s. Run 26662475084 FAILed at `FAIL: N3 not UpToDate before scenario starts` with the kernel converged.

## Out of scope

- `node-replace-hardware` and `observability-capacity-correlation` stay excluded — those are product gaps (satellite re-registration regression, linstor-csi bypassing the REST capacity gate), not flake.
- No product code changes. If a scenario asserts a genuinely broken product behavior, the scenario is left alone.

## Test plan

- [ ] CI green on this branch across all 6 lanes
- [ ] Spot-check that `state-offline-unknown` still observes `ConnectionStatus=OFFLINE` on N3 within `OFFLINE_TIMEOUT` (the race fix does not change the DS eviction semantics, only the test's own delete-by-name brittleness)
- [ ] Confirm `toggle-disk` no longer SKIPs with "found 2 (previous-test cascade)" when it follows `state-offline-unknown` in lane ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended timeout windows in end-to-end tests to improve reliability of state reconciliation checks
  * Enhanced determinism of satellite teardown and pod eviction under reconciliation races
  * Added graceful fallback mechanisms and enhanced diagnostics to reduce false test failures
  * Refined polling strategies and deadline logic to account for delayed convergence in test environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->