### PR TITLE
fix(rest): gate capacity on the real linstor-csi single-node create path (issue #45)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -243,7 +243,10 @@ jobs:
       # does not re-register after re-labeling on the replaced node); root
       # cause is in the satellite/controller path, not in CI infrastructure,
       # and reverting #48 isn't viable. Track separately; restore once fixed.
-      E2E_EXCLUDE: "rwx-ganesha observability-three-way csi-pvc-replicated-rwo csi-pvc-local node-replace-hardware"
+      # observability-capacity-correlation requires piraeus's LinstorCluster CRD,
+      # which is only installed in the e2e-piraeus job below — keep it out of the
+      # 6-lane matrix or it hard-fails at the prerequisite check.
+      E2E_EXCLUDE: "rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo csi-pvc-local node-replace-hardware"
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -243,7 +243,7 @@ jobs:
       # does not re-register after re-labeling on the replaced node); root
       # cause is in the satellite/controller path, not in CI infrastructure,
       # and reverting #48 isn't viable. Track separately; restore once fixed.
-      E2E_EXCLUDE: "rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-replicated-rwo csi-pvc-local node-replace-hardware"
+      E2E_EXCLUDE: "rwx-ganesha observability-three-way csi-pvc-replicated-rwo csi-pvc-local node-replace-hardware"
     permissions:
       contents: read
       checks: write
@@ -378,12 +378,13 @@ jobs:
         # even after the synchronous Pod-delete fix, races
         # pv-controller's ControllerPublishVolume retries — putting
         # it last keeps that storm out of the local scenario's window.
-        # observability-capacity-correlation is temporarily removed: see
-        # issue #45 — linstor-csi for placementCount=1+nodeList drives a
-        # code path that bypasses the autoplace/spawn/single-node-alias
-        # gates added in PR #47, so the level-1 PVC-stays-Pending
-        # assertion still fails. Re-enable when that path is gated.
-        run: make ci-e2e LANE=1 LANES=1 SCENARIOS="rwx-ganesha observability-three-way csi-pvc-local csi-pvc-replicated-rwo"
+        # observability-capacity-correlation re-enabled: issue #45 closed
+        # by gating the real linstor-csi single-node create path on
+        # `POST /v1/resource-definitions/{rd}/resources/{node}` (the
+        # endpoint linstor-csi's `manual` scheduler hits when the SC
+        # sets `nodeList` + `placementCount=1`). The level-1
+        # PVC-stays-Pending assertion now passes on the dev stand.
+        run: make ci-e2e LANE=1 LANES=1 SCENARIOS="rwx-ganesha observability-three-way observability-capacity-correlation csi-pvc-local csi-pvc-replicated-rwo"
 
       - name: Upload e2e logs
         if: always()

--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -1516,40 +1516,7 @@ func (s *Server) createOneResource(w http.ResponseWriter, r *http.Request, rdNam
 	res := env.Resource
 	res.Name = rdName
 
-	if res.NodeName == "" {
-		writeError(w, http.StatusBadRequest, "node_name is required on every resource create entry")
-
-		return nil, false
-	}
-
-	// Enforce the cluster-wide naming convention up front: the CRD
-	// metadata.name will be `<rd>.<node>`, so an embedded '.' in
-	// either side would shift the boundary and either collide with
-	// another (rd, node) pair or stage a CRD the CEL rule on the
-	// type would later reject with a 422. Catch it here with a
-	// friendly 400.
-	if strings.Contains(res.NodeName, ".") {
-		writeError(w, http.StatusBadRequest,
-			"node_name must not contain '.': metadata.name must equal <rd>.<node>")
-
-		return nil, false
-	}
-
-	if strings.Contains(rdName, ".") {
-		writeError(w, http.StatusBadRequest,
-			"resource_definition name must not contain '.': metadata.name must equal <rd>.<node>")
-
-		return nil, false
-	}
-
-	// Bug 167: refuse Resource-create entries that carry a flag string
-	// outside the documented upstream LINSTOR enum. Pre-fix the phantom
-	// flag persisted onto the CRD; the satellite reconciler then had to
-	// guess whether the typo was a no-op or a misspelled `DISKLESS`.
-	flagErr := validateResourceFlags(res.Flags)
-	if flagErr != nil {
-		writeError(w, http.StatusBadRequest, flagErr.Error())
-
+	if !validateResourceCreateShape(w, rdName, &res) {
 		return nil, false
 	}
 
@@ -1594,6 +1561,29 @@ func (s *Server) createOneResource(w http.ResponseWriter, r *http.Request, rdNam
 	// TIEBREAKER flags into this spawn — we only stamp StorPoolName,
 	// never copy flags from peers.
 	s.resolveStorPoolForFreshCreate(r.Context(), rdName, &res)
+
+	// Issue #45: per-pool capacity gate on the real linstor-csi
+	// CreateVolume path. linstor-csi's manual scheduler (StorageClass
+	// with `nodeList` + `placementCount=1`) fires
+	// `POST /v1/resource-definitions/{rd}/resources/{node}` via
+	// golinstor's `Resources.Create`, which routes here — NOT through
+	// `/autoplace`. The PR #47 capacity gate on `/autoplace` therefore
+	// never sees this request, and pre-fix a CreateVolume against a
+	// now-full pool placed the replica anyway: the PVC reached Bound
+	// immediately and only failed later when the satellite tried to
+	// allocate the backing LV.
+	//
+	// The gate consults the resolved StoragePool's FreeCapacity on the
+	// target node directly — not `computeSizeInfo` — because this code
+	// path knows the EXACT (node, pool) target, so the autoplace gate's
+	// cluster-wide MaxVlmSizeInKib aggregation would mask a full pool
+	// behind sibling pools on other nodes. A 13 GiB lvm-thin on
+	// worker-1 at 100% used while worker-2's lvm-thin is empty MUST
+	// refuse `r c worker-1 <rd>` even though the cluster-wide cap
+	// remains 13 GiB.
+	if !s.rejectResourceCreateIfPoolFull(w, r, rdName, &res) {
+		return nil, false
+	}
 
 	out, ok := s.createOrPromoteResource(w, r, &res)
 	if !ok {
@@ -2004,6 +1994,245 @@ func (s *Server) resolveStorPoolForFreshCreate(ctx context.Context, rdName strin
 	}
 
 	res.Props["StorPoolName"] = pool
+}
+
+// validateResourceCreateShape runs the wire-shape gates that don't
+// touch the store: NodeName presence, the `<rd>.<node>` naming
+// boundary (CRD metadata.name CEL rule), and the upstream LINSTOR
+// flag enum (Bug 167). Hoisted out of `createOneResource` so that
+// function stays under the funlen budget after the Issue #45
+// per-pool capacity gate landed.
+//
+// Returns true when the caller may proceed; false when the HTTP
+// error has already been written.
+func validateResourceCreateShape(w http.ResponseWriter, rdName string, res *apiv1.Resource) bool {
+	if res.NodeName == "" {
+		writeError(w, http.StatusBadRequest, "node_name is required on every resource create entry")
+
+		return false
+	}
+
+	// Enforce the cluster-wide naming convention up front: the CRD
+	// metadata.name will be `<rd>.<node>`, so an embedded '.' in
+	// either side would shift the boundary and either collide with
+	// another (rd, node) pair or stage a CRD the CEL rule on the
+	// type would later reject with a 422. Catch it here with a
+	// friendly 400.
+	if strings.Contains(res.NodeName, ".") {
+		writeError(w, http.StatusBadRequest,
+			"node_name must not contain '.': metadata.name must equal <rd>.<node>")
+
+		return false
+	}
+
+	if strings.Contains(rdName, ".") {
+		writeError(w, http.StatusBadRequest,
+			"resource_definition name must not contain '.': metadata.name must equal <rd>.<node>")
+
+		return false
+	}
+
+	// Bug 167: refuse Resource-create entries that carry a flag string
+	// outside the documented upstream LINSTOR enum. Pre-fix the phantom
+	// flag persisted onto the CRD; the satellite reconciler then had to
+	// guess whether the typo was a no-op or a misspelled `DISKLESS`.
+	flagErr := validateResourceFlags(res.Flags)
+	if flagErr != nil {
+		writeError(w, http.StatusBadRequest, flagErr.Error())
+
+		return false
+	}
+
+	return true
+}
+
+// rejectResourceCreateIfPoolFull is the Issue #45 capacity gate on
+// the real linstor-csi CreateVolume path. Mirrors the parallel
+// `rejectAutoplaceIfExceedsCapacityGate` on /autoplace and
+// `rejectIfExceedsOversubGate` on /spawn so a CreateVolume against
+// a now-full pool fails-fast with a structured 409 envelope BEFORE
+// the Resource is persisted (no orphan CRD on the reject path).
+//
+// Why this gate is per-pool (not computeSizeInfo-shaped):
+//   - `/autoplace` and `/spawn` are placer-driven: they accept a
+//     filter and the placer picks pools. `computeSizeInfo` returns
+//     the cluster-wide worst-case-of-top-N cap so any pool the placer
+//     could pick is covered.
+//   - This handler routes through `POST /v1/resource-definitions/
+//     {rd}/resources/{node}` (the golinstor `Resources.Create`
+//     endpoint linstor-csi's `manual` scheduler uses when the SC sets
+//     `nodeList`). The caller has already named the EXACT (node,
+//     pool) target, so the cluster-wide cap would mask a full target
+//     pool behind sibling pools on other nodes. A 13 GiB lvm-thin on
+//     worker-1 at 100% used while worker-2's lvm-thin is empty MUST
+//     refuse `r c worker-1 <rd>` even though the cluster-wide cap
+//     remains 13 GiB.
+//
+// Skipped when:
+//   - Resource is DISKLESS / TIE_BREAKER (no backing storage needed).
+//   - No pool name could be resolved (consistent with
+//     `refuseResourceCreateOnUnknownPool` — diskless fallback path).
+//   - RD has no VolumeDefinitions yet (definitions-only create; the
+//     subsequent VD POST will get the gate next time around).
+//
+// Returns true when the caller may proceed; false when the HTTP
+// error has already been written.
+func (s *Server) rejectResourceCreateIfPoolFull(w http.ResponseWriter, r *http.Request, rdName string, res *apiv1.Resource) bool {
+	// Diskless / tiebreaker witnesses don't allocate backing storage.
+	if containsResourceFlag(res.Flags, apiv1.ResourceFlagDiskless) ||
+		containsResourceFlag(res.Flags, apiv1.ResourceFlagTieBreaker) {
+		return true
+	}
+
+	poolName := s.resolveGatePoolName(r.Context(), rdName, res)
+	if poolName == "" {
+		// Pool unresolved — `refuseResourceCreateOnUnknownPool` already
+		// returns true in this case (diskless fallback), and the
+		// satellite reconciler's `disk none;` path takes over. The
+		// capacity gate is specifically about a NAMED pool that's
+		// full; "no pool at all" is a different code path.
+		return true
+	}
+
+	pool, err := s.Store.StoragePools().Get(r.Context(), res.NodeName, poolName)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// `refuseResourceCreateOnUnknownPool` ran first and would
+			// have returned the 404 already. Defensive: if we got here
+			// the SP must exist on the target node, so this branch is
+			// a TOCTOU residual — let the post-write Bug 145 re-check
+			// handle it.
+			return true
+		}
+
+		writeStoreError(w, err)
+
+		return false
+	}
+
+	requiredKib, err := s.sumRDVolumeDefinitionsKib(r.Context(), rdName)
+	if err != nil {
+		writeStoreError(w, err)
+
+		return false
+	}
+
+	if requiredKib <= 0 {
+		// No VDs yet (e.g. a definitions-only create racing ahead of
+		// the VD POST). Skip the gate — there's nothing to size
+		// against. Mirrors `rejectAutoplaceIfExceedsCapacityGate` and
+		// `rejectIfExceedsOversubGate` semantics.
+		return true
+	}
+
+	if pool.FreeCapacity >= requiredKib {
+		return true
+	}
+
+	// Reuse the same RetCode + envelope shape as the /autoplace gate
+	// (PR #47) so operators and tools that classify replies by the
+	// `ret_code` + sub-code pair handle both gates uniformly.
+	filter := &apiv1.AutoSelectFilter{
+		StoragePool:  poolName,
+		NodeNameList: []string{res.NodeName},
+		PlaceCount:   1,
+	}
+
+	writeAutoplaceShortfall(w, filter, "", &placer.CapacityShortfallError{
+		RequiredKib: requiredKib,
+		MaxFreeKib:  pool.FreeCapacity,
+	})
+
+	return false
+}
+
+// resolveGatePoolName returns the StoragePool name the Issue #45
+// capacity gate should look up FreeCapacity against. Mirrors the
+// upstream LINSTOR fallback chain
+// (`CtrlRscCrtApiHelper.resolveStorPoolName`) but tolerates a wider
+// set of input shapes since linstor-csi's `CreateVolume` posts an
+// EMPTY body to `POST /v1/resource-definitions/{rd}/resources/{node}`
+// and relies on RG-level propagation for the pool name. The four
+// tiers, in priority order:
+//
+//  1. `res.Props["StorPoolName"]` — explicit `--storage-pool` from
+//     the operator or the CSI client.
+//  2. `rd.Props["StorPoolName"]` — RD-level sticky default (Scenario
+//     4.W15).
+//  3. `rg.SelectFilter.StoragePool` — RG single-pool default
+//     (`linstor rg c --storage-pool <p>`).
+//  4. `rg.SelectFilter.StoragePoolList[0]` — RG list-pool default,
+//     which is the shape linstor-csi posts when the SC sets
+//     `linstor.csi.linbit.com/storagePool: <p>` (the per-pool
+//     fallback `resolveStorPoolForFreshCreate` already covers tiers
+//     1-3 by stamping res.Props, but it does NOT cover tier 4 — by
+//     design, since the placer was the one to pick a specific pool
+//     out of the list, and the per-resource Props gets stamped at
+//     placer time. The capacity gate has to repeat tier 4 here so a
+//     CSI request with no body and only an RG StoragePoolList is
+//     still gated.
+//
+// Returns "" when no tier matches — the gate then skips with a
+// no-op (consistent with `refuseResourceCreateOnUnknownPool`'s
+// "no pool, no gate" semantic on the diskless fallback path). Best-
+// effort throughout: any store lookup error is swallowed so a
+// transient k8s read doesn't escalate a CreateVolume into a 500.
+func (s *Server) resolveGatePoolName(ctx context.Context, rdName string, res *apiv1.Resource) string {
+	if pool := res.Props["StorPoolName"]; pool != "" {
+		return pool
+	}
+
+	rd, err := s.Store.ResourceDefinitions().Get(ctx, rdName)
+	if err != nil {
+		return ""
+	}
+
+	if pool := rd.Props["StorPoolName"]; pool != "" {
+		return pool
+	}
+
+	if rd.ResourceGroupName == "" {
+		return ""
+	}
+
+	rg, err := s.Store.ResourceGroups().Get(ctx, rd.ResourceGroupName)
+	if err != nil {
+		return ""
+	}
+
+	if pool := rg.SelectFilter.StoragePool; pool != "" {
+		return pool
+	}
+
+	if len(rg.SelectFilter.StoragePoolList) > 0 {
+		return rg.SelectFilter.StoragePoolList[0]
+	}
+
+	return ""
+}
+
+// sumRDVolumeDefinitionsKib returns the largest VolumeDefinition's
+// SizeKib on the named RD. Every volume of an RD provisions against
+// the same pool (upstream LINSTOR contract), so the per-pool
+// capacity gate must clear the biggest of them. Returns 0 — no
+// filter — when the RD has no VDs yet. Mirrors
+// `Placer.requiredKib` exactly so the gate semantics agree with the
+// placer's own per-pool check on the autoplace path.
+func (s *Server) sumRDVolumeDefinitionsKib(ctx context.Context, rdName string) (int64, error) {
+	vds, err := s.Store.VolumeDefinitions().List(ctx, rdName)
+	if err != nil {
+		return 0, err //nolint:wrapcheck // handler wraps via writeStoreError
+	}
+
+	var maxKib int64
+
+	for i := range vds {
+		if vds[i].SizeKib > maxKib {
+			maxKib = vds[i].SizeKib
+		}
+	}
+
+	return maxKib, nil
 }
 
 // stripDisklessAndWitnessFlags walks `flags` and produces the post-promote

--- a/pkg/rest/resource_create_issue_45_test.go
+++ b/pkg/rest/resource_create_issue_45_test.go
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestResourceCreateOnNodeIssue45RejectsFullPool pins the Issue #45
+// fix on the real linstor-csi CreateVolume path:
+// `POST /v1/resource-definitions/{rd}/resources/{node}` against a
+// pool whose `FreeCapacity < requiredKib` MUST refuse the placement
+// with a structured 409 envelope BEFORE the Resource is persisted.
+// Pre-fix the request reached the store, the Resource CRD was
+// stamped, the PVC reached Bound, and only the satellite's LV
+// allocation surfaced the capacity problem.
+//
+// This is the endpoint linstor-csi's `manual` scheduler hits when
+// the StorageClass sets `nodeList` + `placementCount=1` — the
+// `/autoplace` PR #47 gate never sees this traffic.
+func TestResourceCreateOnNodeIssue45RejectsFullPool(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const (
+		rdName = "pvc-issue45-on-node"
+		node   = "n1"
+		pool   = "lvm-thin"
+	)
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: node}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// 1 GiB VolumeDefinition.
+	if err := st.VolumeDefinitions().Create(ctx, rdName, &apiv1.VolumeDefinition{
+		VolumeNumber: 0,
+		SizeKib:      1048576,
+	}); err != nil {
+		t.Fatalf("seed VD: %v", err)
+	}
+
+	// FreeCapacity=0: pool is fully consumed. The gate compares
+	// `pool.FreeCapacity < requiredKib` so any FreeCapacity below
+	// 1 GiB MUST trip the gate.
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: pool,
+		NodeName:        node,
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    0,
+		TotalCapacity:   13631488, // 13 GiB
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Body matches the wire shape linstor-csi's `Resources.Create`
+	// posts: empty Props (StorPoolName is resolved server-side from
+	// the parent RG / fallback chain), no flags, just the node target.
+	body, _ := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{
+			NodeName: node,
+			Props:    map[string]string{"StorPoolName": pool},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources/"+node, body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (Issue #45 per-pool capacity gate)", resp.StatusCode)
+	}
+
+	var rc []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rc); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rc) == 0 {
+		t.Fatalf("envelope: empty array")
+	}
+
+	// Wire shape: same RetCode bits as the /autoplace gate so
+	// operators classify both paths with one rule.
+	if rc[0].RetCode&apiCallRcError == 0 {
+		t.Errorf("ret_code missing MASK_ERROR bit: %#x", rc[0].RetCode)
+	}
+
+	if rc[0].RetCode&apiCallRcFailNotEnoughNodes == 0 {
+		t.Errorf("ret_code missing FAIL_NOT_ENOUGH_NODES sub-code: %#x", rc[0].RetCode)
+	}
+
+	// Critical: the placement must NOT have happened.
+	got, err := st.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("Issue #45: placement should be refused, got %d Resource(s): %+v", len(got), got)
+	}
+}
+
+// TestResourceCreateOnNodeIssue45AllowsFittingPool sanity-checks the
+// happy path: a pool with sufficient FreeCapacity must let the
+// placement through.
+func TestResourceCreateOnNodeIssue45AllowsFittingPool(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const (
+		rdName = "pvc-issue45-ok"
+		node   = "n1"
+		pool   = "lvm-thin"
+	)
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: node}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.VolumeDefinitions().Create(ctx, rdName, &apiv1.VolumeDefinition{
+		VolumeNumber: 0,
+		SizeKib:      1024, // 1 MiB
+	}); err != nil {
+		t.Fatalf("seed VD: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: pool,
+		NodeName:        node,
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    13631488, // 13 GiB free
+		TotalCapacity:   13631488,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{
+			NodeName: node,
+			Props:    map[string]string{"StorPoolName": pool},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources/"+node, body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (sufficient capacity)", resp.StatusCode)
+	}
+
+	got, err := st.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Errorf("placed: got %d, want 1", len(got))
+	}
+}
+
+// TestResourceCreateOnNodeIssue45SkipsGateForDiskless verifies that
+// a DISKLESS / TIE_BREAKER replica passes through unchecked — no
+// backing storage is allocated, so a full target pool is irrelevant.
+// The witness-takeover / make-available paths land here; gating them
+// would regress legitimate auto-witness placement on a near-full
+// pool.
+func TestResourceCreateOnNodeIssue45SkipsGateForDiskless(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const (
+		rdName = "pvc-issue45-diskless"
+		node   = "n1"
+		pool   = "lvm-thin"
+	)
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: node}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.VolumeDefinitions().Create(ctx, rdName, &apiv1.VolumeDefinition{
+		VolumeNumber: 0,
+		SizeKib:      1048576,
+	}); err != nil {
+		t.Fatalf("seed VD: %v", err)
+	}
+
+	// Pool full — gate WOULD fire on a diskful create.
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: pool,
+		NodeName:        node,
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    0,
+		TotalCapacity:   13631488,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Diskless witness: gate must NOT fire.
+	body, _ := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{
+			NodeName: node,
+			Flags:    []string{apiv1.ResourceFlagDiskless},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources/"+node, body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("diskless create on full pool: got %d, want 201 (gate must skip diskless)", resp.StatusCode)
+	}
+
+	got, err := st.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Errorf("diskless placed: got %d, want 1", len(got))
+	}
+}
+
+// TestResourceCreateBulkIssue45RejectsFullPool pins the gate on the
+// bulk array endpoint `POST /v1/resource-definitions/{rd}/resources`
+// — same shape upstream LINSTOR uses for `linstor r c n1 n2 n3 rd`
+// and the alternate route some CSI clients pick. The per-pool gate
+// must fire on the FIRST envelope that exceeds capacity; no
+// envelopes should land in the store on the reject path.
+func TestResourceCreateBulkIssue45RejectsFullPool(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const (
+		rdName = "pvc-issue45-bulk"
+		node   = "n1"
+		pool   = "lvm-thin"
+	)
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: node}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.VolumeDefinitions().Create(ctx, rdName, &apiv1.VolumeDefinition{
+		VolumeNumber: 0,
+		SizeKib:      1048576,
+	}); err != nil {
+		t.Fatalf("seed VD: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: pool,
+		NodeName:        node,
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    0,
+		TotalCapacity:   13631488,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal([]apiv1.ResourceCreate{{
+		Resource: apiv1.Resource{
+			NodeName: node,
+			Props:    map[string]string{"StorPoolName": pool},
+		},
+	}})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources", body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (bulk endpoint capacity gate)", resp.StatusCode)
+	}
+
+	got, err := st.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("Issue #45 bulk: placement should be refused, got %d", len(got))
+	}
+}
+
+// TestResourceCreateOnNodeIssue45ResolvesPoolFromRGStoragePoolList
+// pins the actual CSI wire shape: linstor-csi's `Resources.Create`
+// posts an empty body (no `Props.StorPoolName`); the pool name lives
+// only on the parent ResourceGroup's
+// `SelectFilter.StoragePoolList`. The gate MUST resolve the pool
+// from tier 4 of `resolveGatePoolName`, look up its FreeCapacity,
+// and fail-fast. Pre-fix the gate skipped because `Props` was empty
+// and the RG single-pool tier didn't match StoragePoolList — the
+// observed dev-stand failure mode that drove the empirical Phase 3
+// re-run.
+func TestResourceCreateOnNodeIssue45ResolvesPoolFromRGStoragePoolList(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const (
+		rgName = "rg-issue45-list"
+		rdName = "pvc-issue45-list"
+		node   = "n1"
+		pool   = "lvm-thin"
+	)
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: node}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	// RG carries the pool ONLY on StoragePoolList — this is the
+	// shape linstor-csi posts when the SC sets
+	// `linstor.csi.linbit.com/storagePool: <p>`.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: rgName,
+		SelectFilter: apiv1.AutoSelectFilter{
+			StoragePoolList: []string{pool},
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              rdName,
+		ResourceGroupName: rgName,
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.VolumeDefinitions().Create(ctx, rdName, &apiv1.VolumeDefinition{
+		VolumeNumber: 0,
+		SizeKib:      1048576,
+	}); err != nil {
+		t.Fatalf("seed VD: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: pool,
+		NodeName:        node,
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    0,
+		TotalCapacity:   13631488,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// CSI wire shape: empty body — the URL path carries the node,
+	// Props is left empty for the server to resolve from the RG.
+	body := []byte(`{}`)
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources/"+node, body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (gate must resolve pool from RG StoragePoolList)", resp.StatusCode)
+	}
+
+	got, err := st.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("Issue #45 RG-list path: placement should be refused, got %d", len(got))
+	}
+}
+
+// TestResourceCreateOnNodeIssue45SkipsWhenNoVDs verifies the
+// definitions-only path: an RD with no VolumeDefinitions yet must
+// pass the gate (nothing to size against). Mirrors the autoplace
+// and spawn gate semantics for empty VDs.
+func TestResourceCreateOnNodeIssue45SkipsWhenNoVDs(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const (
+		rdName = "pvc-issue45-novds"
+		node   = "n1"
+		pool   = "lvm-thin"
+	)
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: node}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Pool with zero free — would trip the gate IF there were VDs.
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: pool,
+		NodeName:        node,
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    0,
+		TotalCapacity:   13631488,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{
+			NodeName: node,
+			Props:    map[string]string{"StorPoolName": pool},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources/"+node, body)
+	_ = resp.Body.Close()
+
+	// No VDs → gate is a no-op. Resource Create should succeed.
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (no-VDs gate skip)", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #45 by gating capacity on the actual endpoint linstor-csi hits when a StorageClass sets `nodeList` + `placementCount=1`. PR #47 gated `/autoplace` and the single-node alias's bulk variant, but the real CSI request lands on `POST /v1/resource-definitions/{rd}/resources/{node}` via golinstor's `Resources.Create`, which routes to `handleResourceCreateOnNode` with no capacity check.

## Phase 1 — empirical endpoint capture on stand

Apiserver access lines from a CreateVolume against `linstor.csi.linbit.com/storagePool: lvm-thin`, `placementCount=1`, `nodeList=dev-worker-1`:

```
POST /v1/resource-groups                                              201
POST /v1/resource-groups/sc-…/volume-groups                           201
PUT  /v1/resource-groups/sc-…                                         200
POST /v1/resource-definitions                                         201
POST /v1/resource-definitions/pvc-…/volume-definitions                200
POST /v1/resource-definitions/pvc-…/resources/dev-worker-1            201   <-- gate target
PUT  /v1/resource-definitions/pvc-…                                   200
```

No `/spawn` call. linstor-csi's `manual` scheduler (selected because `nodeList` flips `PlacementPolicy = Manual` in `volume.Parameters`) calls `Resources.Create` per node, which golinstor maps to the single-node alias above.

## Phase 2 — fix

Inline per-pool gate added in `createOneResource` (shared by both the bulk endpoint and the single-node alias):

- Resolves the target pool via a 4-tier fallback (`Props["StorPoolName"]` → `RD.Props["StorPoolName"]` → `RG.SelectFilter.StoragePool` → `RG.SelectFilter.StoragePoolList[0]`). Tier 4 is new — linstor-csi's `ToResourceGroupModify` writes the SC pool into `StoragePoolList`, which the existing fallback chain doesn't read.
- Reads `pool.FreeCapacity` directly (not `computeSizeInfo`). The cluster-wide `MaxVlmSizeInKib` aggregation would mask a full target pool behind sibling pools on other nodes — a 13 GiB lvm-thin on worker-1 at 100% used while worker-2's is empty must refuse `r c worker-1 <rd>` even though the cluster cap remains 13 GiB.
- Skips for DISKLESS / TIE_BREAKER (no backing storage), unresolved pool (diskless fallback), and definitions-only creates (no VDs).
- Returns 409 with the same RetCode bits + envelope shape PR #47 uses on `/autoplace`, so operators can classify both paths with one rule.

**`pkg/placer` is NOT touched.** A previous attempt exported `placer.MatchesPoolFilter` and that intercepted the migrate flow, regressing `node-replace-hardware` (the bundle was reverted in PR #47 final force-push). The migrate flow goes through `Resource.Spec.Nodes` reconciliation in the controller, not through this REST handler.

6 new unit tests in `resource_create_issue_45_test.go`: reject-on-full / allow-on-fit / skip-diskless / bulk-endpoint / RG-StoragePoolList-fallback / skip-no-VDs.

## Phase 3 — stand validation

`observability-capacity-correlation` on dev stand (lvm-thin, worker-1, 13 GiB total filled to 0 KiB free):

```
Level 1 (PVC pending + event)     : OK (capacity-keyword)
Level 2a (sp list free <100 MiB)  : free=0 KiB
Level 2b (autoplace rejection)    : OK
Level 3 (lvm-thin view)           : free=0 KiB
>> OBSERVABILITY-CAPACITY-CORRELATION OK
```

`observability-capacity-correlation` re-enabled in the e2e-piraeus job. `node-replace-hardware` stays excluded — its failure (`SP stand.dev-worker-3 already exists` after `linstor n d --lost`) is in the satellite/controller path (PR #48 follow-up), unrelated to this REST gate.

## Test plan

- [x] `go test ./pkg/rest/...` — full suite green (58s)
- [x] `golangci-lint run ./pkg/rest/...` — 0 issues
- [x] `pkg/placer/...` tests untouched and green
- [x] Stand validation: `observability-capacity-correlation` PASSES on dev stand
- [x] Stand validation confirmed: `node-replace-hardware` failure is the pre-existing PR #48 regression on storage-pool re-registration, NOT caused by this gate

Refs #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage pool capacity is now validated during resource creation. When a pool is full, requests are rejected with a structured error response, preventing resource persistence.

* **Tests**
  * Added comprehensive test suite verifying pool capacity validation behavior across various scenarios.

* **Chores**
  * Updated CI/E2E test workflows to enable additional observability test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->