### PR TITLE
fix(satellite): close TB-relocate StandAlone wedge on bitmap-bothdisks

### DIFF
--- a/pkg/drbd/errcodes.go
+++ b/pkg/drbd/errcodes.go
@@ -21,6 +21,7 @@ package drbd
 import (
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // DrbdsetupErrCode is a numeric DRBD-utils error code surfaced in
@@ -76,6 +77,14 @@ const (
 	// scenario 5.32 probe-vs-adjust race the reconciler's adjust
 	// path recovers from via `drbdadm up`.
 	ErrMinorNotKnownOnPeer DrbdsetupErrCode = 158
+
+	// ErrInvalidConfigRequest (162) — drbdsetup's generic
+	// "kernel rejected the request" envelope, with the specific
+	// failure mode carried in the `additional info from kernel:`
+	// trailer. The reconciler matches on the (162) prefix when
+	// pairing with a known kernel trailer signature; see
+	// IsBitmapDropBothDisksErr for the tiebreaker-relocate case.
+	ErrInvalidConfigRequest DrbdsetupErrCode = 162
 
 	// ErrNeedApplyAL (167) — drbdsetup needs an activity-log
 	// apply pass before the requested verb can proceed.
@@ -142,4 +151,43 @@ func IsErrCode(err error, code DrbdsetupErrCode) bool {
 // documenting.
 func IsUnknownResourceErr(err error) bool {
 	return IsErrCode(err, ErrMinorNotKnownOnPeer)
+}
+
+// IsBitmapDropBothDisksErr reports whether `err` matches the
+// tiebreaker-relocate-StandAlone-wedge signature: the kernel
+// refused to drop the per-peer bitmap because its on-disk
+// metadata still reads the peer as diskful for that node-id
+// slot. The verbatim signature is `(162) Invalid configuration
+// request` + kernel info `Can not drop the bitmap when both
+// sides have a disk` emitted by `drbdsetup peer-device-options
+// <res> <peer-node-id> <vol> --set-defaults --bitmap=no` — the
+// declarative form `drbdadm adjust` runs for any `disk none`
+// peer in the .res.
+//
+// Triggered when the controller re-allocates DRBDNodeID for a
+// returning TIE_BREAKER onto a peer-slot whose v09 metadata has
+// never been used (default-initialised non-zero bitmap-uuid
+// reads back as `peer-disk:Outdated`). A single full bring-up
+// cycle (`drbdadm down` + `drbdadm up`) flushes the in-memory
+// peer-disk state so the next `drbdadm adjust` accepts
+// `--bitmap=no` cleanly.
+//
+// The first failed adjust leaves a StandAlone slot with
+// peer-device entries registered (kernel allocated them via
+// new-peer before peer-device-options fired), at which point
+// shouldSkipNetOnAdjust permanently misfires for that slot —
+// surface the predicate here so the adjust-error handler can
+// take the recovery path before the gate latches.
+func IsBitmapDropBothDisksErr(err error) bool {
+	if !IsErrCode(err, ErrInvalidConfigRequest) {
+		return false
+	}
+
+	// Other (162) failure modes exist (e.g. ineligible flag
+	// combinations on `new-peer`); the kernel-info trailer is
+	// the disambiguator. Match on the stable "Can not drop the
+	// bitmap" phrase emitted from drbd-utils `wire.c` so locale
+	// translations of surrounding kernel diagnostics don't
+	// false-match.
+	return strings.Contains(err.Error(), "Can not drop the bitmap")
 }

--- a/pkg/satellite/export_test.go
+++ b/pkg/satellite/export_test.go
@@ -21,6 +21,7 @@ package satellite
 import (
 	"context"
 
+	"github.com/cozystack/blockstor/pkg/satellite/intent"
 	"github.com/cozystack/blockstor/pkg/storage"
 )
 
@@ -38,4 +39,15 @@ func Day0GiForTest(resourceName string, volumeNumber int32) string {
 // without exposing the helper to production callers.
 func WipeDeviceForTest(ctx context.Context, exec storage.Exec, devicePath string) error {
 	return wipeDevice(ctx, exec, devicePath)
+}
+
+// RecoverFromBitmapBothDisksForTest re-exports the package-private
+// `recoverFromBitmapBothDisks` recovery helper so the external test
+// package can pin the down + up + adjust contract that breaks the
+// tiebreaker-relocate StandAlone wedge — without exposing the
+// helper on the production Reconciler surface (it is intentionally
+// only callable from `runAdjust` after the specific
+// IsBitmapDropBothDisksErr signature is detected).
+func (r *Reconciler) RecoverFromBitmapBothDisksForTest(ctx context.Context, dr *intent.DesiredResource, skipDisk, skipNet bool) error {
+	return r.recoverFromBitmapBothDisks(ctx, dr, skipDisk, skipNet)
 }

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -3514,7 +3514,65 @@ func (r *Reconciler) runAdjust(ctx context.Context, dr *intent.DesiredResource, 
 		return nil
 	}
 
+	// Recover from the tiebreaker-relocate StandAlone wedge:
+	// when the controller re-allocates DRBDNodeID for a returning
+	// TIE_BREAKER onto a fresh peer-slot, the surviving diskful's
+	// v09 metadata for that slot reads back as
+	// `peer-disk:Outdated` (default-initialised bitmap-uuid). The
+	// failing adjust hits `peer-device-options --bitmap=no` and
+	// the kernel refuses with `(162) Can not drop the bitmap when
+	// both sides have a disk`. recoverFromBitmapBothDisks below
+	// runs a full down + up + adjust cycle so the next adjust
+	// reads peer-disk from a fresh handshake (DUnknown) rather
+	// than from the stale metadata default — see
+	// tests/e2e/tiebreaker-r-d-r-c-other-node.sh.
+	if drbd.IsBitmapDropBothDisksErr(err) {
+		return r.recoverFromBitmapBothDisks(ctx, dr, skipDisk, skipNet)
+	}
+
 	return errors.Wrapf(err, "adjust %s", dr.GetName())
+}
+
+// recoverFromBitmapBothDisks executes the down + up + adjust
+// recovery for the tiebreaker-relocate StandAlone wedge.
+// Without this recovery the first failed adjust leaves the
+// returning TB's kernel slot StandAlone with peer-device entries
+// kernel-registered (the new-peer call ran before peer-device-
+// options failed); shouldSkipNetOnAdjust then permanently
+// latches `--skip-net` for that slot and the slot stays
+// StandAlone forever.
+//
+// Bounded to a single bounce per adjust pass: the recovery
+// retries dispatchAdjust once; if the second adjust still
+// fails, bubble the error so the reconciler retry loop
+// re-converges on the next tick instead of looping in-place.
+//
+// Down on a Primary-Open resource would block, but the
+// signature only fires on the moment a returning TB joins —
+// the wedge surfaces on the surviving diskful side which is
+// Secondary (unmounted at the moment the TB respawns).
+func (r *Reconciler) recoverFromBitmapBothDisks(ctx context.Context, dr *intent.DesiredResource, skipDisk, skipNet bool) error {
+	log.FromContext(ctx).Info("adjust failed with bitmap-bothdisks; recovering via down + up + adjust",
+		"resource", dr.GetName())
+
+	err := r.cfg.Adm.Down(ctx, dr.GetName())
+	if err != nil {
+		return errors.Wrapf(err, "drbdadm down %s (recovery from bitmap-bothdisks)", dr.GetName())
+	}
+
+	err = r.cfg.Adm.Up(ctx, dr.GetName())
+	if err != nil {
+		return errors.Wrapf(err, "drbdadm up %s (recovery from bitmap-bothdisks)", dr.GetName())
+	}
+
+	err = r.dispatchAdjust(ctx, dr.GetName(), skipDisk, skipNet)
+	if err != nil {
+		return errors.Wrapf(err, "adjust %s (after bitmap-bothdisks recovery)", dr.GetName())
+	}
+
+	ensureDeviceNodes(ctx, dr)
+
+	return nil
 }
 
 // dispatchAdjust picks the right `drbdadm adjust` variant for the

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -64,6 +64,33 @@ var (
 	errDrbdadmAdjust158 = errors.New("pvc-down158: Failure: (158) Unknown resource\n" +
 		"additional info from kernel:\nunknown resource\n" +
 		"Command 'drbdsetup new-minor pvc-down158 1000 0' terminated with exit code 10: exit status 1")
+	// errDrbdadmAdjust162BitmapBothDisks mirrors the verbatim stderr
+	// drbdadm-9 emits when the controller has just re-allocated a
+	// returning TIE_BREAKER onto a peer-slot whose v09 metadata reads
+	// `peer-disk:Outdated` (default-initialised bitmap-uuid) and
+	// adjust's declarative `--bitmap=no` reaches the kernel before
+	// any handshake has reset the peer-disk view. Captured live from
+	// the dev stand during the wedge repro; the substring
+	// "Can not drop the bitmap" is the disambiguator
+	// IsBitmapDropBothDisksErr matches on top of the (162) code.
+	errDrbdadmAdjust162BitmapBothDisks = errors.New(
+		"pvc-tb-relocate: Failure: (162) Invalid configuration request\n" +
+			"additional info from kernel:\nCan not drop the bitmap when both sides have a disk\n" +
+			"Command 'drbdsetup peer-device-options pvc-tb-relocate 2 0 --set-defaults --bitmap=no' terminated with exit code 10: exit status 1")
+	// errDrbdadmAdjust162OtherReason mirrors a (162) failure mode
+	// whose kernel-info trailer is unrelated to the bitmap drop —
+	// the bitmap-bothdisks predicate must reject this so unrelated
+	// 162-class errors don't trigger the down + up + adjust
+	// recovery (which would needlessly bounce the resource).
+	errDrbdadmAdjust162OtherReason = errors.New("pvc-x: Failure: (162) Invalid configuration request\n" +
+		"additional info from kernel:\nsome other reason")
+	// errDrbdadmBitmapTrailerOnlyNoCode is the symmetric reject:
+	// a "Can not drop the bitmap" diagnostic that doesn't carry
+	// the (162) errno prefix. drbdsetup is consistent about
+	// emitting both together, so the bitmap-bothdisks predicate
+	// must refuse to fire on the kernel-info trailer alone.
+	errDrbdadmBitmapTrailerOnlyNoCode = errors.New("pvc-x: some other failure\n" +
+		"additional info from kernel:\nCan not drop the bitmap")
 	// errDrbdadmPrimaryStateChange mirrors the verbatim stderr drbdadm
 	// emits when `drbdadm primary --force` races the initial-sync
 	// handshake on a fresh diskful replica (Bug 311 reproducer):
@@ -6420,6 +6447,167 @@ func TestApplyFallsBackToUpOnAdjust158(t *testing.T) {
 
 	if len(results) != 1 || !results[0].GetOk() {
 		t.Errorf("expected Ok=true after up-fallback recovery; got results=%+v", results)
+	}
+}
+
+// TestRecoverFromBitmapBothDisks pins the tiebreaker-relocate
+// StandAlone wedge recovery contract: the recovery helper called
+// from runAdjust when adjust fails with the (162) "Can not drop
+// the bitmap when both sides have a disk" signature MUST issue
+// `drbdadm down` → `drbdadm up` → retry `drbdadm adjust` in that
+// order, so the kernel re-reads peer-disk from a fresh handshake
+// (DUnknown) rather than from the stale-default metadata
+// (Outdated) on the second adjust pass.
+//
+// Without this recovery the first failed adjust leaves the slot
+// StandAlone with kernel-registered peer-device entries (new-peer
+// runs before peer-device-options fails), at which point
+// shouldSkipNetOnAdjust permanently latches `--skip-net` for that
+// slot — the slot stays StandAlone forever.
+//
+// We drive the helper directly via the export_test re-export
+// rather than through Apply because the package's FakeExec map
+// is keyed on the full command line and not sequence-aware —
+// staging two distinct responses for the same `drbdadm adjust`
+// invocation isn't possible. The end-to-end coverage lives in
+// tests/e2e/tiebreaker-r-d-r-c-other-node.sh.
+func TestRecoverFromBitmapBothDisks(t *testing.T) {
+	fx := storage.NewFakeExec()
+
+	// Stage all three recovery commands as plain successes. The
+	// helper itself doesn't trigger the failing adjust — that
+	// branch lives in runAdjust above the call site — so we only
+	// care that down + up + retry-adjust fire in order.
+	fx.Expect("drbdadm down pvc-tb-relocate", storage.FakeResponse{})
+	fx.Expect("drbdadm up pvc-tb-relocate", storage.FakeResponse{})
+	fx.Expect("drbdadm adjust pvc-tb-relocate", storage.FakeResponse{})
+
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		StateDir: t.TempDir(),
+		NodeName: "n1",
+	})
+
+	dr := &intent.DesiredResource{
+		Name:     "pvc-tb-relocate",
+		NodeName: "n1",
+	}
+
+	err := rec.RecoverFromBitmapBothDisksForTest(t.Context(), dr, false, false)
+	if err != nil {
+		t.Fatalf("recovery returned error: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+
+	downIdx, upIdx, adjustIdx := -1, -1, -1
+
+	for i, line := range cmds {
+		switch {
+		case strings.Contains(line, "drbdadm down pvc-tb-relocate"):
+			downIdx = i
+		case strings.Contains(line, "drbdadm up pvc-tb-relocate"):
+			upIdx = i
+		case strings.Contains(line, "drbdadm adjust pvc-tb-relocate"):
+			adjustIdx = i
+		}
+	}
+
+	if downIdx == -1 || upIdx == -1 || adjustIdx == -1 {
+		t.Fatalf("expected recovery to issue down + up + adjust; got %v", cmds)
+	}
+
+	if downIdx >= upIdx || upIdx >= adjustIdx {
+		t.Errorf("recovery sequence out of order: down=%d up=%d adjust=%d; got %v",
+			downIdx, upIdx, adjustIdx, cmds)
+	}
+}
+
+// TestRecoverFromBitmapBothDisksBubblesDownErr pins the
+// fail-loud contract on the recovery's first step: if
+// `drbdadm down` itself fails the recovery surfaces the error
+// (rather than charging into `drbdadm up` against unknown
+// kernel state).
+func TestRecoverFromBitmapBothDisksBubblesDownErr(t *testing.T) {
+	fx := storage.NewFakeExec()
+
+	fx.Expect("drbdadm down pvc-tb-relocate", storage.FakeResponse{
+		Err: errDrbdadmDownNotInConfig,
+	})
+
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		StateDir: t.TempDir(),
+		NodeName: "n1",
+	})
+
+	dr := &intent.DesiredResource{
+		Name:     "pvc-tb-relocate",
+		NodeName: "n1",
+	}
+
+	err := rec.RecoverFromBitmapBothDisksForTest(t.Context(), dr, false, false)
+	if err == nil {
+		t.Fatal("expected recovery to bubble drbdadm down failure; got nil")
+	}
+
+	// Up + adjust must NOT fire after a failed down — they
+	// would race a half-torn kernel state and the next
+	// reconcile would loop on the same wedge signature.
+	for _, line := range fx.CommandLines() {
+		if strings.Contains(line, "drbdadm up pvc-tb-relocate") ||
+			strings.Contains(line, "drbdadm adjust pvc-tb-relocate") {
+			t.Errorf("recovery must stop after a failed down; saw %q", line)
+		}
+	}
+}
+
+// TestIsBitmapDropBothDisksErr pins the predicate that drives the
+// reactive recovery in runAdjust. The (162) code alone is not
+// enough — drbdsetup emits the same code for unrelated config
+// errors — so the predicate must also match the kernel-info
+// trailer "Can not drop the bitmap" verbatim. Locale-translated
+// kernel diagnostics around it must not break the match.
+func TestIsBitmapDropBothDisksErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "verbatim live signature",
+			err:  errDrbdadmAdjust162BitmapBothDisks,
+			want: true,
+		},
+		{
+			name: "162 without the bitmap trailer (different kernel reject)",
+			err:  errDrbdadmAdjust162OtherReason,
+			want: false,
+		},
+		{
+			name: "bitmap trailer without (162) code",
+			err:  errDrbdadmBitmapTrailerOnlyNoCode,
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "(158) unknown resource (Bug 287 path) must NOT match",
+			err:  errDrbdadmAdjust158,
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := drbd.IsBitmapDropBothDisksErr(c.err)
+			if got != c.want {
+				t.Errorf("IsBitmapDropBothDisksErr(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
 	}
 }
 

--- a/tests/e2e/tiebreaker-r-d-r-c-other-node.sh
+++ b/tests/e2e/tiebreaker-r-d-r-c-other-node.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# usage: tiebreaker-r-d-r-c-other-node.sh WORK_DIR
+#
+# Regression catcher for the "diskful relocate → StandAlone wedge"
+# pattern. Topology: 3-node cluster with 2 diskful + 1 TIE_BREAKER.
+# When the operator deletes a diskful on node A and re-creates a
+# diskful on the previous TIE_BREAKER host C, the controller
+# reshuffles DRBDNodeID allocations: node A returns as the new
+# TIE_BREAKER but at a freshly-allocated peer-slot the on-disk
+# metadata of the surviving diskful nodes has never used. The
+# default-initialised v09 metadata for the new peer-slot has a
+# non-zero bitmap-uuid that the kernel reads as
+# `peer-disk:Outdated`. When `drbdadm adjust` then issues
+# `drbdsetup peer-device-options --bitmap=no` (the declarative
+# wire form for a `disk none` peer in the .res), the kernel
+# refuses with:
+#
+#     test: Failure: (162) Invalid configuration request
+#     additional info from kernel:
+#     Can not drop the bitmap when both sides have a disk
+#
+# The first adjust fails leaving the slot StandAlone with peer-
+# device entries registered (kernel allocated them via new-peer
+# before peer-device-options fired). The next reconcile's
+# shouldSkipNetOnAdjust gate (StandAlone + peer-devices-present)
+# now permanently misfires, so subsequent adjusts skip the net
+# section and the slot stays StandAlone forever. The user-visible
+# symptom is the surviving diskful's `linstor r l` row showing
+# `Conns: StandAlone(<departed-diskful>)` indefinitely while the
+# returning TIE_BREAKER spins in `Connecting(<survivor>)`.
+#
+# This scenario lives in tests/e2e/ (not unit) because the failure
+# mode is a four-way interaction:
+#   - controller-side DRBDNodeID allocator (Bug 87 / Bug 302)
+#   - satellite-side .res renderer (peer.<n>.diskless prop)
+#   - drbdadm/drbdsetup peer-device-options semantics
+#   - DRBD-9 kernel v09 default metadata state
+# No mock can fake all four — only a real QEMU+Talos cluster can
+# trigger the kernel-side bitmap-uuid behavior. See
+# feedback_tiebreaker_e2e_must_exist.md in MEMORY.md.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+if ! command -v linstor >/dev/null 2>&1; then
+    echo "FAIL: linstor CLI not in PATH (apt install linstor-client)" >&2
+    exit 1
+fi
+
+RD=tb-relocate-wedge
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+# Per-step convergence budget. Worst observed re-converge after
+# the wedge fix is ~25s on a healthy QEMU stand (down + up +
+# adjust + handshake + bitmap-no acceptance); 90s gives 3x
+# headroom for CI noise.
+CONVERGE=${CONVERGE:-90}
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/tb-relocate-wedge-pf.log 2>&1 &
+PF_PID=$!
+
+dump_diag() {
+    echo "---- dump: linstor r l -r $RD ----"
+    "${LCTL[@]}" r l -r "$RD" 2>&1 || true
+    echo "---- dump: per-node drbdsetup status ----"
+    for n in "$N1" "$N2" "$N3"; do
+        echo "  -- $n --"
+        on_node "$n" drbdsetup status "$RD" 2>&1 || true
+    done
+    echo "---- dump: Resource.Status.connections ----"
+    for n in "$N1" "$N2" "$N3"; do
+        echo "  -- $n --"
+        kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{range .status.connections[*]}{.peerNodeName}{"="}{.message}{"; "}{end}{"\n"}' \
+            2>/dev/null || true
+    done
+    echo "---- dump: kubectl logs -n $NS daemonset/blockstor-satellite --tail=80 ----"
+    kubectl logs -n "$NS" daemonset/blockstor-satellite --tail=80 2>/dev/null \
+        | grep -E "(bitmap|StandAlone|del-peer|adjust|test)" | tail -40 || true
+}
+
+cleanup() {
+    local rc=$?
+    if (( rc != 0 )); then
+        dump_diag
+    fi
+    delete_rd "$RD" 2>/dev/null || true
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+LCTL=(linstor --controllers "http://localhost:$PF_PORT")
+
+# Clean any leftover state from a prior run.
+delete_rd "$RD" 2>/dev/null || true
+
+# assert_no_standalone <rd> — fail unless every (node,peer) pair
+# in Resource.Status.connections has a non-StandAlone message
+# across all three workers. Polls up to $CONVERGE seconds, exits
+# 0 on first all-clear observation.
+assert_no_standalone() {
+    local rd=$1
+    local deadline=$(( $(date +%s) + CONVERGE ))
+    local saw_sa=""
+    while (( $(date +%s) < deadline )); do
+        saw_sa=""
+        for n in "$N1" "$N2" "$N3"; do
+            for p in "$N1" "$N2" "$N3"; do
+                [[ "$n" == "$p" ]] && continue
+                local m
+                m=$(status_connection_state "$rd" "$n" "$p")
+                if [[ "$m" == "StandAlone" || "$m" == StandAlone* ]]; then
+                    saw_sa="${n}->${p}=${m}"
+                fi
+            done
+        done
+        if [[ -z "$saw_sa" ]]; then
+            return 0
+        fi
+        sleep 3
+    done
+    echo "FAIL: a connection stayed in StandAlone after ${CONVERGE}s (last seen: $saw_sa)" >&2
+    return 1
+}
+
+# ---- STEP 1: 2 diskful on N1+N2, TIE_BREAKER on N3 ----------------
+
+echo ">> create RD $RD with 2 diskful on $N1, $N2 (auto-place=2 picks the TB host)"
+"${LCTL[@]}" resource-definition create "$RD"
+"${LCTL[@]}" volume-definition create "$RD" 64M
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool stand
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool stand
+
+echo ">> wait both diskful replicas UpToDate (<=180s)"
+wait_disk_state "$RD" "$N1" UpToDate 180 0
+wait_disk_state "$RD" "$N2" UpToDate 180 0
+
+# The auto-managed TIE_BREAKER landed on the only uninvolved node.
+echo ">> wait for the TIE_BREAKER witness to settle on $N3"
+wait_disk_state "$RD" "$N3" Diskless 60 0
+
+# Baseline assert: no StandAlone in the initial steady state.
+if ! assert_no_standalone "$RD"; then
+    echo "FAIL: pre-step baseline already shows StandAlone — test cannot trust the wedge assert"
+    exit 1
+fi
+echo "   baseline OK: 2 diskful + 1 TB, all peers connected"
+
+# ---- STEP 2: r d worker-2 → 1 diskful left + (transient) TB --------
+
+echo ">> linstor r d $N2 $RD (delete the second diskful)"
+"${LCTL[@]}" resource delete "$N2" "$RD"
+
+# Allow the controller to reach the post-r-d steady state. We
+# don't pin a specific tiebreaker shape here — the post-r-d
+# topology may be 1-diskful + 0-witness (Bug 338 carve-out) or
+# 1-diskful + 1-witness depending on transient observations.
+# What we need before triggering the wedge is just that the
+# delete finished propagating to the kernel.
+echo ">> wait for $N2 Resource to be gone from the controller"
+deadline=$(( $(date +%s) + 60 ))
+while (( $(date +%s) < deadline )); do
+    if ! kubectl get "resources.blockstor.cozystack.io/${RD}.${N2}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+done
+
+# ---- STEP 3: r c worker-3 → diskful relocate, expose the wedge ----
+#
+# Pre-fix symptom: the controller re-allocates DRBDNodeID for
+# both N3 (now becoming diskful, fresh slot) and N2 (returning as
+# TIE_BREAKER on a peer-slot that the surviving diskful's v09
+# metadata has not yet used). adjust on the surviving diskful's
+# satellite fails with `Can not drop the bitmap when both sides
+# have a disk`. The kernel slot for the returning TB stays
+# StandAlone; shouldSkipNetOnAdjust then misfires forever.
+
+echo ">> linstor r c $N3 $RD (relocate diskful onto the old TIE_BREAKER host)"
+"${LCTL[@]}" resource create "$N3" "$RD" --storage-pool stand
+
+echo ">> wait $N3 UpToDate after relocate (<=180s)"
+wait_disk_state "$RD" "$N3" UpToDate 180 0
+
+# This is the assertion the bug fails: the surviving diskful
+# (N1) must NOT have a StandAlone slot toward the returning
+# TIE_BREAKER (N2), and the returning TB (N2) must not be
+# spinning in Connecting toward N1 either. We check the union
+# across all 6 (node,peer) pairs because either side could be
+# the one that misfires depending on race order.
+
+echo ">> assert no StandAlone slots across the 3-node mesh (<=${CONVERGE}s)"
+if ! assert_no_standalone "$RD"; then
+    echo "ASSERT FAILED: r d $N2 + r c $N3 left a StandAlone slot in the kernel"
+    echo "  This is the bitmap-bothdisks wedge — see scenario header for the chain."
+    exit 1
+fi
+
+# Stability tail: hold for 15s and re-check. The pre-fix wedge
+# is sticky (StandAlone slots don't self-heal), but a flaky
+# fix that resolves on the first reconcile then bounces back on
+# a subsequent adjust would slip past a single-shot probe.
+echo ">> stability tail: hold 15s, no StandAlone may reappear"
+deadline=$(( $(date +%s) + 15 ))
+while (( $(date +%s) < deadline )); do
+    for n in "$N1" "$N2" "$N3"; do
+        for p in "$N1" "$N2" "$N3"; do
+            [[ "$n" == "$p" ]] && continue
+            m=$(status_connection_state "$RD" "$n" "$p")
+            if [[ "$m" == "StandAlone" || "$m" == StandAlone* ]]; then
+                echo "ASSERT FAILED (oscillation): ${n}->${p} flipped to ${m} during stability tail"
+                exit 1
+            fi
+        done
+    done
+    sleep 2
+done
+
+echo ">> PASS: r d + r c relocate converged without StandAlone wedge"


### PR DESCRIPTION
## Summary

Closes the StandAlone wedge that surfaced on the v0.1.4 dev stand when deleting a diskful replica and re-creating a diskful on the previous TIE_BREAKER host:

* When the controller re-allocates `DRBDNodeID` for the returning TIE_BREAKER onto a fresh peer-slot, the surviving diskful's v09 metadata for that slot reads back as `peer-disk:Outdated` (default-initialised bitmap-uuid).
* `drbdadm adjust` then hits the declarative `drbdsetup peer-device-options <res> <peer-node-id> <vol> --set-defaults --bitmap=no` for the new `disk none` peer and the kernel refuses with `(162) Can not drop the bitmap when both sides have a disk`.
* The first failed adjust leaves the slot StandAlone with kernel-registered peer-device entries (the `new-peer` call ran before `peer-device-options` fired); `shouldSkipNetOnAdjust` then permanently latches `--skip-net` for that slot and the slot stays StandAlone forever.

The reconciler now reactively detects the signature in `runAdjust` and runs `drbdadm down → up → adjust` once, so the second adjust reads peer-disk from a fresh handshake (`DUnknown`) and accepts `--bitmap=no` cleanly. Bounded to one bounce per pass; subsequent failures bubble up so the retry loop re-converges on the next tick instead of looping in-place.

## Test plan

- [x] `go test ./pkg/satellite/... ./pkg/drbd/...` (unit) — green.
- [x] New e2e `tests/e2e/tiebreaker-r-d-r-c-other-node.sh` on QEMU+Talos dev stand:
  * baseline: 2 diskful + 1 TB, all peers Connected.
  * `linstor r d <diskful>` + `linstor r c <former-TB>` → returning TIE_BREAKER must converge.
  * Assertion: no `StandAlone` connection-state across the 3-node mesh within 90s + 15s stability tail.
  * Without the fix: e2e times out — surviving diskful row stays `Conns: StandAlone(<departed-diskful>)` indefinitely.
- [x] New unit coverage:
  * `TestRecoverFromBitmapBothDisks` pins the `adjust → down → up → adjust` order.
  * `TestRecoverFromBitmapBothDisksBubblesDownErr` pins fail-loud on a failed `down`.
  * `TestIsBitmapDropBothDisksErr` pins the `(162) + "Can not drop the bitmap"` disambiguator against unrelated 162-class errors and the Bug 287 `(158)` signature.