### PR TITLE
fix(rest): strip TIE_BREAKER on toggle-disk-to-diskful

### DIFF
--- a/pkg/rest/bug_93_98_99_100_wire_routes_test.go
+++ b/pkg/rest/bug_93_98_99_100_wire_routes_test.go
@@ -122,6 +122,104 @@ func TestBug93ToggleDiskDiskfulNoPool(t *testing.T) {
 	}
 }
 
+// TestToggleDiskDiskfulStripsTieBreakerFlag pins the bug-hunt v2 B.4
+// finding: `r td --storage-pool <pool>` on an auto-managed tiebreaker
+// replica (initial flags `{DISKLESS, TIE_BREAKER}`) must clear BOTH
+// flags. Before the fix only DISKLESS was stripped, leaving the
+// promoted diskful peer marked `TIE_BREAKER` — `filterTieBreaker`
+// keys on the flag (not the disk state), so the next
+// `ensureTiebreaker` pass would double-count this slot as both a
+// diskful and a witness, silently violating the witness invariant.
+func TestToggleDiskDiskfulStripsTieBreakerFlag(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{Name: "pvc-tb-promote"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Replica starts as an auto-managed witness — the canonical
+	// shape ensureTiebreaker stamps when it spawns a witness on a
+	// 2-diskful RD. Both flags must be cleared by the promote.
+	if err := st.Resources().Create(t.Context(), &apiv1.Resource{
+		Name:     "pvc-tb-promote",
+		NodeName: "n1",
+		Flags:    []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed Resource: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPut(t, base+"/v1/resource-definitions/pvc-tb-promote/resources/n1/toggle-disk/diskful/stand", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	got, err := st.Resources().Get(t.Context(), "pvc-tb-promote", "n1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if slices.Contains(got.Flags, apiv1.ResourceFlagDiskless) {
+		t.Errorf("DISKLESS still present after promote: %v", got.Flags)
+	}
+
+	if slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("TIE_BREAKER still present after promote — would mark the diskful as a witness; got %v", got.Flags)
+	}
+
+	if got.Props["StorPoolName"] != "stand" {
+		t.Errorf("Props[StorPoolName]: got %q, want stand", got.Props["StorPoolName"])
+	}
+}
+
+// TestToggleDiskDiskfulIsIdempotentOnPlainDiskful is the symmetric
+// guard: stripping TIE_BREAKER on a replica that never carried it
+// must not invent or drop unrelated flags. A non-witness diskless
+// replica being promoted (or a replica already diskful being re-
+// pool-stamped) goes through the same handler.
+func TestToggleDiskDiskfulIsIdempotentOnPlainDiskful(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{Name: "pvc-plain"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// A pre-existing diskful replica with no flags at all. The
+	// promote operation is a no-op on Flags but must still stamp
+	// the pool when one is supplied.
+	if err := st.Resources().Create(t.Context(), &apiv1.Resource{
+		Name:     "pvc-plain",
+		NodeName: "n1",
+	}); err != nil {
+		t.Fatalf("seed Resource: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPut(t, base+"/v1/resource-definitions/pvc-plain/resources/n1/toggle-disk/diskful/stand", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	got, err := st.Resources().Get(t.Context(), "pvc-plain", "n1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got.Flags) != 0 {
+		t.Errorf("expected no flags after idempotent promote; got %v", got.Flags)
+	}
+
+	if got.Props["StorPoolName"] != "stand" {
+		t.Errorf("Props[StorPoolName]: got %q, want stand", got.Props["StorPoolName"])
+	}
+}
+
 // TestBug98SnapshotRollbackCanonicalPath pins the regression for
 // Bug 98: `linstor s rollback <rd> <snap>` POSTs
 // `POST /v1/resource-definitions/{rd}/snapshot-rollback/{snap}` (NOT

--- a/pkg/rest/resource_toggle_disk.go
+++ b/pkg/rest/resource_toggle_disk.go
@@ -297,7 +297,22 @@ func (s *Server) handleResourceToggleDiskToDiskful(w http.ResponseWriter, r *htt
 	// Bug 281: same Get → Update race as handleResourceToggleDisk.
 	err := s.Store.Resources().PatchResourceSpec(r.Context(), rdName, node,
 		func(res *apiv1.Resource) error {
+			// Both DISKLESS and TIE_BREAKER must be stripped: an
+			// auto-managed witness Resource is always created with
+			// `{DISKLESS, TIE_BREAKER}` flags, so promoting it via
+			// `r td --storage-pool <pool>` must clear BOTH or the
+			// CRD ends up `flags=[TIE_BREAKER]` on a diskful peer.
+			// shouldTieBreakerExist / shouldKeepExistingWitness
+			// then double-count the slot (filterTieBreaker
+			// matches on the TIE_BREAKER flag, not on the disk
+			// state) and the diskful peer is treated as a witness
+			// in the next ensureTiebreaker pass — silent
+			// invariant violation. Strip both regardless of which
+			// the caller intended; promoting a non-witness
+			// diskless is the same operation and dropping a flag
+			// that isn't there is a no-op.
 			res.Flags = applyFlagMutation(res.Flags, apiv1.ResourceFlagDiskless, false)
+			res.Flags = applyFlagMutation(res.Flags, apiv1.ResourceFlagTieBreaker, false)
 
 			if pool != "" {
 				stampStoragePool(res, pool)

--- a/tests/e2e/tiebreaker-promote-clears-flag.sh
+++ b/tests/e2e/tiebreaker-promote-clears-flag.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# usage: tiebreaker-promote-clears-flag.sh WORK_DIR
+#
+# Bug-hunt v2 B.4 regression catcher: `linstor r td --storage-pool
+# <pool> <node> <rd>` (promote an auto-managed TIE_BREAKER witness
+# back to a diskful peer) MUST clear BOTH the DISKLESS and the
+# TIE_BREAKER flags on the Resource CRD. Before the fix only
+# DISKLESS was stripped, leaving the promoted diskful peer marked
+# `TIE_BREAKER` on Spec.Flags. The latent failure mode:
+# `filterTieBreaker` and `splitByDiskless` key on the flag (not the
+# observed disk state), so the next `ensureTiebreaker` pass double-
+# counts the slot as both a diskful and a witness and the witness
+# invariant is silently violated.
+#
+# Lives in tests/e2e/ (not unit) because the regression's blast
+# radius is the controller's witness math: a CRD-side unit test
+# pins the REST handler, but only a real reconcile pass that walks
+# `filterTieBreaker` proves the flag drift doesn't reach
+# ensureTiebreaker.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+if ! command -v linstor >/dev/null 2>&1; then
+    echo "FAIL: linstor CLI not in PATH (apt install linstor-client)" >&2
+    exit 1
+fi
+
+RD=tb-promote-clears-flag
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+CONVERGE=${CONVERGE:-60}
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/tb-promote-clears-flag-pf.log 2>&1 &
+PF_PID=$!
+
+dump_diag() {
+    echo "---- dump: linstor r l -r $RD ----"
+    "${LCTL[@]}" r l -r "$RD" 2>&1 || true
+    echo "---- dump: Resource CRDs (flags) ----"
+    for n in "$N1" "$N2" "$N3"; do
+        kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.metadata.name}{" flags="}{.spec.flags}{"\n"}' \
+            2>/dev/null || true
+    done
+}
+
+cleanup() {
+    local rc=$?
+    if (( rc != 0 )); then
+        dump_diag
+    fi
+    delete_rd "$RD" 2>/dev/null || true
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+LCTL=(linstor --controllers "http://localhost:$PF_PORT")
+
+delete_rd "$RD" 2>/dev/null || true
+
+# ---- STEP 1: 2 diskful on N1+N2 → auto-TB lands on N3 -------------
+
+echo ">> create RD $RD with 2 diskful on $N1, $N2 (auto-TB lands on $N3)"
+"${LCTL[@]}" resource-definition create "$RD"
+"${LCTL[@]}" volume-definition create "$RD" 64M
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool stand
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool stand
+
+echo ">> wait both diskful UpToDate (<=180s)"
+wait_disk_state "$RD" "$N1" UpToDate 180 0
+wait_disk_state "$RD" "$N2" UpToDate 180 0
+
+echo ">> wait auto-TB to appear on $N3 (<=${CONVERGE}s)"
+wait_disk_state "$RD" "$N3" Diskless "$CONVERGE" 0
+
+# Pin the pre-promote shape: the witness CRD must carry BOTH
+# DISKLESS and TIE_BREAKER (this is the only state the bug
+# applies to — a non-witness diskless would have only DISKLESS).
+tb_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null)
+
+if [[ "$tb_flags" != *"DISKLESS"* || "$tb_flags" != *"TIE_BREAKER"* ]]; then
+    echo "FAIL: pre-promote shape — auto-TB on $N3 must carry both DISKLESS + TIE_BREAKER, got: $tb_flags"
+    dump_diag
+    exit 1
+fi
+
+echo "   pre-promote OK: ${N3} flags=${tb_flags}"
+
+# ---- STEP 2: promote the auto-TB to diskful ------------------------
+
+echo ">> linstor r td --storage-pool zfs-thin $N3 $RD (promote auto-TB to diskful)"
+"${LCTL[@]}" resource toggle-disk "$N3" "$RD" --storage-pool zfs-thin
+
+echo ">> wait $N3 UpToDate after promote (<=180s)"
+wait_disk_state "$RD" "$N3" UpToDate 180 0
+
+# ---- STEP 3: assert flags on $N3 ----------------------------------
+#
+# Pre-fix observed state: spec.flags = [TIE_BREAKER] (DISKLESS was
+# cleared, TIE_BREAKER was not). Post-fix the toggle-to-diskful
+# handler strips both, so the promoted Resource CRD must end with
+# a flags-free Spec — matching the shape of the other two diskful
+# replicas on $N1 and $N2.
+echo ">> assert promoted Resource CRD has no DISKLESS and no TIE_BREAKER flag"
+
+deadline=$(( $(date +%s) + CONVERGE ))
+final_flags=""
+
+while (( $(date +%s) < deadline )); do
+    final_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null)
+
+    if [[ "$final_flags" != *"DISKLESS"* && "$final_flags" != *"TIE_BREAKER"* ]]; then
+        echo ">> PASS: $N3 flags=${final_flags} (DISKLESS and TIE_BREAKER both cleared)"
+        exit 0
+    fi
+
+    sleep 2
+done
+
+echo "ASSERT FAILED: promoted Resource CRD on $N3 still carries a witness flag"
+echo "  got flags=${final_flags}"
+echo "  expected: no DISKLESS, no TIE_BREAKER (diskful peer should not be marked a witness)"
+echo "  see comment in handleResourceToggleDiskToDiskful for the contract"
+exit 1


### PR DESCRIPTION
## Summary

`linstor r td --storage-pool <pool> <node> <rd>` (the REST `PUT .../toggle-disk/diskful[/{pool}]` shape) promotes a diskless replica back to diskful. When the replica being promoted is an auto-managed TIE_BREAKER witness (initial flags `{DISKLESS, TIE_BREAKER}`), the handler previously cleared only DISKLESS. The promoted Resource CRD ended with `spec.flags=[TIE_BREAKER]` — a diskful peer marked as a witness.

`filterTieBreaker` / `splitByDiskless` in `internal/controller/resourcedefinition_controller.go` key on the TIE_BREAKER flag (not on the observed disk state), so the next `ensureTiebreaker` pass would double-count the slot as both a diskful peer AND a witness. The witness invariant ("witness implies DISKLESS") is silently violated; any follow-on math (witness count, willCreate / willRemove) based on the flag returns wrong results. Data is currently still healthy on the affected RD, but the inconsistency is latent.

Stripping both flags is a no-op when only one was set, so the handler stays idempotent for the non-witness diskless promote path.

## Test plan

- [x] `go test ./pkg/rest/...` (unit) — green.
  - `TestToggleDiskDiskfulStripsTieBreakerFlag` pins that both flags clear on a witness-shape replica.
  - `TestToggleDiskDiskfulIsIdempotentOnPlainDiskful` pins the no-flags promote path stays a no-op (no fields invented, pool stamped).
  - Existing `TestBug93ToggleDiskDiskfulRoundTrip` / `TestBug93ToggleDiskDiskfulNoPool` still pass — the DISKLESS-only path is untouched.
- [x] New e2e `tests/e2e/tiebreaker-promote-clears-flag.sh` on QEMU+Talos dev stand:
  - Pre-promote shape: `dev-worker-3 flags=["DISKLESS","TIE_BREAKER"]` (verified).
  - Post-promote: `dev-worker-3 flags=` (empty — both flags cleared). PASS.
  - Pre-fix the same test FAILs with `flags=["TIE_BREAKER"]`.

## Notes

Surfaced by an internal bug-hunt agent walking the `r c / r d / r td` matrix on the v0.1.4 dev stand. Out of three bug-shaped findings the agent reported, the other two (`r d <auto-TB>` not auto-respawning, `r td --diskless` not collapsing the existing auto-TB) turned out to be working-as-designed under the existing `stampTiebreakerSuppression` 5-minute window and the 3-voter quorum carve-out for `1 diskful + 1 user-diskless + 1 witness`. Only this one is a real invariant violation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource promotion behavior: When promoting a diskless resource to diskful via toggle-disk, both the `DISKLESS` and `TIE_BREAKER` flags are now properly cleared (previously only `DISKLESS` was removed).

* **Tests**
  * Added regression tests for flag-clearing behavior during diskful promotion.
  * Added end-to-end test verifying witness promotion correctly clears all relevant flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->