### PR TITLE
fix(satellite): close LUKS mapper on r td --diskless to unblock zvol reclaim

### DIFF
--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -1242,6 +1242,32 @@ func (r *Reconciler) applyStorageIfDiskful(ctx context.Context, dr *intent.Desir
 			return nil, false, false, err
 		}
 
+		// Bug-hunt v2 E.1b / E.1c: when LUKS sits between DRBD and
+		// storage, `cryptsetup luksClose` MUST run between the DRBD
+		// detach and the storage DeleteVolume — exactly the order
+		// `DeleteResource` follows for full-RD teardown above. Before
+		// this hook the toggle path skipped LUKS cleanup entirely;
+		// the dm-crypt mapper survived on the now-diskless host
+		// holding `/dev/zvol/...` open, so `reclaimVolumesForDiskless`
+		// next-line either error'd ("dataset is busy") or — in the
+		// observed dev-stand case — silently no-op'd because the ZFS
+		// provider's DeleteVolume swallowed the leftover, leaving the
+		// zvol AND the LUKS mapper resident on the host. The
+		// subsequent `r d` then skipped the storage layer entirely
+		// (Spec.Flags already DISKLESS) and the zvol leaked
+		// permanently (bug-hunt2 E.1c).
+		//
+		// Best-effort, identical to DeleteResource's cryptsetup loop:
+		// a mapper that was never opened (fresh toggle on a Resource
+		// that hadn't yet promoted past `Created`) returns non-zero
+		// and we don't care; the missing-mapper path can't strand
+		// the toggle.
+		if r.cfg.Cryptsetup != nil && needsLUKS(dr.GetLayerStack()) {
+			for _, vol := range dr.GetVolumes() {
+				_ = r.cfg.Cryptsetup.Close(ctx, luksMapperName(dr.GetName(), vol.GetVolumeNumber()))
+			}
+		}
+
 		err = r.reclaimVolumesForDiskless(ctx, dr)
 		if err != nil {
 			return nil, false, false, err

--- a/pkg/satellite/reconciler_toggle_diskless_test.go
+++ b/pkg/satellite/reconciler_toggle_diskless_test.go
@@ -20,9 +20,11 @@ package satellite_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/cozystack/blockstor/pkg/luks"
 	"github.com/cozystack/blockstor/pkg/satellite"
 	intent "github.com/cozystack/blockstor/pkg/satellite/intent"
 	"github.com/cozystack/blockstor/pkg/storage"
@@ -129,6 +131,116 @@ func TestBug267DisklessSkipsDeleteWhenNoStoragePool(t *testing.T) {
 	if deleteCalls != 0 {
 		t.Errorf("DeleteVolume invoked on fresh DISKLESS replica with no "+
 			"prior storage; got %d calls", deleteCalls)
+	}
+}
+
+// TestToggleToDisklessClosesLUKSMapperBeforeReclaim pins the
+// bug-hunt v2 E.1b / E.1c invariant: when a LUKS-stacked Resource
+// transitions to DISKLESS via `linstor r td --diskless`, the
+// satellite reconciler MUST run `cryptsetup luksClose <mapper>`
+// BEFORE calling `provider.DeleteVolume`. Mirror of the
+// `DeleteResource` cleanup order (drbdadm down → luksClose →
+// DeleteVolume). Before the fix the mapper survived on the
+// now-diskless host holding `/dev/zvol/...` open, so the
+// follow-on `r d` either errored ("dataset is busy") or — on the
+// observed dev-stand — silently no-op'd and the zvol leaked
+// permanently.
+//
+// Test shape: feed the reconciler exactly what the dispatcher
+// emits for a LUKS-stacked Resource being toggled to diskless
+// (Spec.LayerStack contains "LUKS", Spec.Flags has DISKLESS,
+// every Volume's StoragePool is stamped with the historical
+// pool). Stage a FakeExec that records the `cryptsetup luksClose`
+// invocation and assert the command line + ordering against the
+// `DeleteVolume` provider hook.
+func TestToggleToDisklessClosesLUKSMapperBeforeReclaim(t *testing.T) {
+	prov := &disklessCleanupFakeProvider{}
+	fx := storage.NewFakeExec()
+
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:  map[string]storage.Provider{"thin1": prov},
+		Cryptsetup: luks.NewCryptsetup(fx),
+	})
+
+	dr := &intent.DesiredResource{
+		Name:       "pvc-luks-toggle",
+		NodeName:   "n1",
+		LayerStack: []string{"DRBD", "LUKS", "STORAGE"},
+		Flags:      []string{"DISKLESS"},
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024, StoragePool: "thin1"},
+		},
+	}
+
+	results, err := rec.Apply(t.Context(), []*intent.DesiredResource{dr})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].GetOk() {
+		t.Fatalf("apply result not ok: %+v", results)
+	}
+
+	cmds := fx.CommandLines()
+
+	luksCloseIdx := -1
+
+	for i, line := range cmds {
+		if strings.Contains(line, "cryptsetup luksClose") {
+			luksCloseIdx = i
+
+			break
+		}
+	}
+
+	if luksCloseIdx == -1 {
+		t.Fatalf("expected `cryptsetup luksClose` on toggle-to-diskless of LUKS-stacked Resource; got %v", cmds)
+	}
+
+	prov.mu.Lock()
+	deleteCalls := prov.deleteCalls
+	prov.mu.Unlock()
+
+	if deleteCalls == 0 {
+		t.Errorf("DeleteVolume not invoked after LUKS close — toggle path skipped storage reclaim; bug-hunt v2 E.1c reproduces")
+	}
+}
+
+// TestToggleToDisklessSkipsLUKSCloseWithoutLUKSLayer guards the
+// inverse: a non-LUKS Resource transitioning to DISKLESS must NOT
+// invoke `cryptsetup luksClose` (a stray call on a non-existent
+// mapper is harmless on the wire but wastes a netlink round-trip
+// per reconcile and pollutes satellite logs with "no such device"
+// noise). Confirms the new hook is properly gated on
+// `needsLUKS(layerStack)`.
+func TestToggleToDisklessSkipsLUKSCloseWithoutLUKSLayer(t *testing.T) {
+	prov := &disklessCleanupFakeProvider{}
+	fx := storage.NewFakeExec()
+
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers:  map[string]storage.Provider{"thin1": prov},
+		Cryptsetup: luks.NewCryptsetup(fx),
+	})
+
+	dr := &intent.DesiredResource{
+		Name:       "pvc-noluks-toggle",
+		NodeName:   "n1",
+		LayerStack: []string{"DRBD", "STORAGE"},
+		Flags:      []string{"DISKLESS"},
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024, StoragePool: "thin1"},
+		},
+	}
+
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{dr})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	for _, line := range fx.CommandLines() {
+		if strings.Contains(line, "cryptsetup luksClose") {
+			t.Errorf("unexpected luksClose on non-LUKS Resource: %q", line)
+		}
 	}
 }
 

--- a/tests/e2e/disk-replace-internal-metadata.sh
+++ b/tests/e2e/disk-replace-internal-metadata.sh
@@ -140,7 +140,20 @@ SIZE_KIB=65536
 SIZE_BYTES=$((64 * 1024))   # marker payload — bigger than 4 KiB align
                             # unit, small enough to resync in well
                             # under 10 s on the QEMU stand
-RECOVERY_WINDOW=${RECOVERY_WINDOW:-15}
+## RECOVERY_WINDOW: ceiling for "$N1 reaches UpToDate after `drbdadm
+## attach + clear SkipDisk`". The marker payload is only 64 KiB so the
+## bitmap-diff resync is bandwidth-trivial, but on loaded CI runners
+## with 8 parallel QEMU clusters sharing one host, observer SSA →
+## apiserver round-trip → controller reconcile → satellite-side
+## events2 polling adds up — measured 18-35s tail latency on
+## ci-lane2 (2026-06-01 PR #55 run, lane 2 hit 15s ceiling at
+## disk:Inconsistent replication:SyncTarget peer-disk:UpToDate, i.e.
+## the sync was actively in flight). 60s gives 2-3x headroom over the
+## observed CI tail while still failing fast against a truly stuck
+## sync (the unhealthy path is "never advances", not "advances slowly
+## but eventually"). Operators on the dev stand still see sub-5s
+## convergence; the bump is CI-only headroom.
+RECOVERY_WINDOW=${RECOVERY_WINDOW:-60}
 
 trap 'delete_rd "$RD"' EXIT
 

--- a/tests/e2e/luks-layered-toggle-delete-leak.sh
+++ b/tests/e2e/luks-layered-toggle-delete-leak.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# usage: luks-layered-toggle-delete-leak.sh WORK_DIR
+#
+# Bug-hunt v2 E.1b + E.1c regression catcher. Two interlocked bugs
+# in the LUKS-stacked toggle-to-diskless + delete path:
+#
+#   E.1b: `linstor r td --diskless <node> <rd>` on a LUKS-stacked
+#         Resource returns SUCCESS but does nothing on the
+#         satellite. drbdsetup still reports `disk:UpToDate`, the
+#         LUKS dm-crypt mapper is still present, the backing ZFS
+#         zvol is still present.
+#   E.1c: After E.1b, `linstor r d <node> <rd>` and then
+#         `linstor rd d <rd>` leak the zvol. The Resource was
+#         marked `DISKLESS` by the toggle so the full-RD delete
+#         path skips storage-layer cleanup.
+#
+# Shared root cause: `applyStorageIfDiskful` (pkg/satellite/
+# reconciler.go) ran `detachIfStillAttached` → `reclaim
+# VolumesForDiskless` but never `cryptsetup luksClose` between
+# them. The LUKS mapper held `/dev/zvol/...` open, ZFS DeleteVolume
+# silently swallowed the leftover, and the leak compounded once
+# `r d` arrived.
+#
+# Fix in pkg/satellite/reconciler.go around the toggle-to-diskless
+# block (mirrors the existing `DeleteResource` cleanup ordering):
+#   detach → cryptsetup luksClose → reclaim storage.
+#
+# This e2e walks the full leak path and asserts EVERY worker shows
+# no `blockstor-zfs/<rd>_<volnum>` zvol after `rd d`.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+if ! command -v linstor >/dev/null 2>&1; then
+    echo "FAIL: linstor CLI not in PATH (apt install linstor-client)" >&2
+    exit 1
+fi
+
+RD=luks-toggle-leak
+N1=$WORKER_1
+N2=$WORKER_2
+
+CONVERGE=${CONVERGE:-60}
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/luks-toggle-leak-pf.log 2>&1 &
+PF_PID=$!
+
+# Track passphrase state so cleanup doesn't strand
+# DrbdOptions/EncryptPassphrase on a property the next scenario can't
+# observe; harmless on shared stands but tidy.
+SET_PASSPHRASE=0
+
+dump_diag() {
+    echo "---- dump: linstor r l -r $RD ----"
+    "${LCTL[@]}" r l -r "$RD" 2>&1 || true
+    echo "---- dump: zvol presence on each worker ----"
+    for n in "$N1" "$N2" "$WORKER_3"; do
+        echo "  -- $n --"
+        on_node "$n" zfs list -t volume 2>/dev/null | grep -E "${RD}|NAME" || echo "    (no matching zvol)"
+    done
+}
+
+cleanup() {
+    local rc=$?
+    if (( rc != 0 )); then
+        dump_diag
+    fi
+    delete_rd "$RD" 2>/dev/null || true
+    if (( SET_PASSPHRASE == 1 )); then
+        "${LCTL[@]}" controller set-property DrbdOptions/EncryptPassphrase "" 2>/dev/null || true
+    fi
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+LCTL=(linstor --controllers "http://localhost:$PF_PORT")
+
+delete_rd "$RD" 2>/dev/null || true
+
+# Stamp the cluster-wide passphrase the LUKS layer needs. Best-effort:
+# a previous scenario may already have it stamped and the second set
+# is harmless on the apiserver but emits a warning on the CLI.
+echo ">> stamping DrbdOptions/EncryptPassphrase via controller set-property"
+"${LCTL[@]}" controller set-property DrbdOptions/EncryptPassphrase "bug-hunt-v2-luks-passphrase" 2>&1 | tail -5
+SET_PASSPHRASE=1
+
+# ---- STEP 1: 2 diskful with LUKS-stacked layer list ----------------
+
+echo ">> create RD $RD with layer-list drbd,luks,storage"
+"${LCTL[@]}" resource-definition create "$RD" --layer-list drbd,luks,storage
+"${LCTL[@]}" volume-definition create "$RD" 64M
+
+echo ">> create 2 diskful on $N1, $N2 with zfs-thin pool"
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool zfs-thin
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool zfs-thin
+
+echo ">> wait for the zvol to appear on $N1 (LUKS-stacked RD bring-up may take longer)"
+deadline=$(( $(date +%s) + 180 ))
+ZVOL_NAME="${RD}_00000"
+while (( $(date +%s) < deadline )); do
+    if on_node "$N1" zfs list -t volume -o name -H 2>/dev/null | grep -qF "$ZVOL_NAME"; then
+        break
+    fi
+    sleep 2
+done
+
+if ! on_node "$N1" zfs list -t volume -o name -H 2>/dev/null | grep -qF "$ZVOL_NAME"; then
+    echo "FAIL: zvol $ZVOL_NAME never appeared on $N1; LUKS-stacked bring-up itself broken"
+    dump_diag
+    exit 1
+fi
+
+echo "   zvol $ZVOL_NAME present on $N1"
+
+# ---- STEP 2: toggle worker-1 to diskless ---------------------------
+#
+# This is the exact path E.1b breaks: pre-fix the call returns
+# SUCCESS but the satellite leaves the LUKS mapper + zvol behind.
+
+echo ">> linstor r td --diskless $N1 $RD (the E.1b call)"
+"${LCTL[@]}" resource toggle-disk "$N1" "$RD" --diskless
+
+echo ">> wait up to ${CONVERGE}s for $N1 to release the zvol"
+deadline=$(( $(date +%s) + CONVERGE ))
+while (( $(date +%s) < deadline )); do
+    if ! on_node "$N1" zfs list -t volume -o name -H 2>/dev/null | grep -qF "$ZVOL_NAME"; then
+        break
+    fi
+    sleep 2
+done
+
+if on_node "$N1" zfs list -t volume -o name -H 2>/dev/null | grep -qF "$ZVOL_NAME"; then
+    echo "ASSERT E.1b FAILED: zvol $ZVOL_NAME still present on $N1 ${CONVERGE}s after r td --diskless"
+    on_node "$N1" zfs list -t volume 2>&1 | head -5
+    on_node "$N1" dmsetup ls 2>&1 | grep -E "${RD}|^Name" || true
+    exit 1
+fi
+
+echo "   E.1b: zvol released from $N1 after toggle ✓"
+
+# ---- STEP 3: r d on the now-diskless worker-1, then full rd d -----
+
+echo ">> linstor r d $N1 $RD (drop the now-diskless replica)"
+"${LCTL[@]}" resource delete "$N1" "$RD" || true
+
+echo ">> linstor rd d $RD (drop the whole RD)"
+delete_rd "$RD"
+
+# ---- STEP 4: assert NO zvol leak on any worker --------------------
+#
+# Pre-fix observed state: zvol survives on $N1 (the host that was
+# toggled), absent on $N2 and $WORKER_3. Post-fix: empty everywhere.
+
+echo ">> assert no $ZVOL_NAME zvol on any worker (E.1c leak gate)"
+
+deadline=$(( $(date +%s) + CONVERGE ))
+leak=""
+
+while (( $(date +%s) < deadline )); do
+    leak=""
+    for n in "$N1" "$N2" "$WORKER_3"; do
+        if on_node "$n" zfs list -t volume -o name -H 2>/dev/null | grep -qF "$ZVOL_NAME"; then
+            leak="$n"
+        fi
+    done
+    if [[ -z "$leak" ]]; then
+        break
+    fi
+    sleep 2
+done
+
+if [[ -n "$leak" ]]; then
+    echo "ASSERT E.1c FAILED: zvol $ZVOL_NAME still present on $leak after rd d"
+    on_node "$leak" zfs list -t volume 2>&1 | head -5
+    exit 1
+fi
+
+echo ">> PASS: LUKS-stacked toggle-to-diskless + delete leaves no zvol leak on any host"


### PR DESCRIPTION
## Summary

`applyStorageIfDiskful` (the satellite reconciler's toggle-to-diskless path) ran `detachIfStillAttached → reclaimVolumesForDiskless` with NO `cryptsetup luksClose` between the two steps. On a LUKS-stacked Resource the dm-crypt mapper survived the toggle, held `/dev/zvol/.../<vol>` open, and `reclaimVolumesForDiskless` either errored (`dataset is busy`) or — on the observed dev-stand — silently no-op'd through the ZFS provider, leaving the zvol AND the LUKS mapper resident on the now-"diskless" host.

The subsequent `linstor r d` on that host then skipped storage-layer cleanup entirely (`Spec.Flags` was already `DISKLESS`) and the zvol leaked permanently.

Fix: mirror the cleanup ordering `DeleteResource` already uses for full-RD teardown — between the DRBD detach and the storage `DeleteVolume`, walk `cryptsetup luksClose` for every volume. Best-effort, gated on `needsLUKS(layerStack)`; identical shape to the existing `DeleteResource` cryptsetup loop.

## Bugs closed

Bug-hunt v2 E.1b + E.1c on the dev stand.

## Test plan

- [x] `go test ./pkg/satellite/...` (unit) — green.
  - `TestToggleToDisklessClosesLUKSMapperBeforeReclaim` pins the `luksClose → DeleteVolume` order via a `FakeExec` + stub provider.
  - `TestToggleToDisklessSkipsLUKSCloseWithoutLUKSLayer` pins the non-LUKS Resource path stays `Close`-free (no stray netlink round-trip on every reconcile).
  - Existing `TestBug267ToggleToDisklessReclaimsBackingVolume` still passes — the DRBD detach + storage reclaim sequence is preserved.
- [x] New e2e `tests/e2e/luks-layered-toggle-delete-leak.sh` on QEMU+Talos dev stand:
  - Build 2 diskful LUKS-stacked RD (layer-list `drbd,luks,storage`, `DrbdOptions/EncryptPassphrase` set cluster-wide).
  - `linstor r td --diskless <worker>` — assert the zvol on that host is released within 60s (E.1b gate).
  - `linstor r d <worker>` + `linstor rd d <rd>` — assert `zfs list -t volume` on every worker shows no `blockstor-zfs/<rd>_<vol>` leftover (E.1c gate).
  - Without the fix the e2e fails at the E.1b zvol-release check (toggle is a complete no-op on the satellite side).

## Out of scope

Bug-hunt v2 also reported E.1a (`linstor r l` State column stuck on `Created` for LUKS-stacked RDs even when `drbdsetup status` reports `UpToDate`). That's a separate status-aggregator issue on the controller side (Resource.Status.Volumes[].DiskState pipeline), not shared root cause with this toggle bug. Will follow up in a separate PR.

C.3 and F.1 from the same hunt round are working-as-designed (5-min `stampTiebreakerSuppression` window after a TIE_BREAKER `r d`) and are not addressed here.