### PR TITLE
fix(rest): reject invalid RD names on s r rst and rg spawn before partial state lands

### DIFF
--- a/pkg/rest/rd_name_validation_bulk_test.go
+++ b/pkg/rest/rd_name_validation_bulk_test.go
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug-hunt v3 finding C.4: the lowercase-RD-name validator that
+// `POST /v1/resource-definitions` runs (Bug 97) is bypassed on two
+// sibling code paths that ALSO create a fresh RD entry from a user-
+// supplied name:
+//
+//   - `linstor s r rst …  --to-resource <Bad>` (POST
+//     /v1/resource-definitions/{rd}/snapshot-restore-resource/{snap})
+//   - `linstor rg spawn  <rg> <Bad> …`        (POST
+//     /v1/resource-groups/{rg}/spawn)
+//
+// Both call paths flow the raw `to_resource` / `resource_definition_name`
+// value straight into Store.ResourceDefinitions().Create(); the k8s CRD
+// store slugifies the metadata.name and the lowercased value no longer
+// matches the spec.resourceDefinitionName admission webhook check, so
+// the persist fails with a raw "metadata.name must equal …" leak AFTER
+// a partial state mutation has already happened (RD entry observable in
+// the linstor view, orphan finalizers, half-built downstream objects).
+//
+// These tests mirror the shape of TestBug97RDCreateRefused… for both
+// alternate entry points: a 4xx envelope, no leak of the K8s
+// metadata.name internal, and the in-memory Store must hold ZERO RD
+// rows for the offending name after the request returns.
+
+// TestSnapshotRestoreRejectsInvalidRdName drives the s-r-rst handler
+// with several invalid `to_resource` shapes. Each must 400 with a
+// LINSTOR-shaped envelope naming the offending object kind, and the
+// Store must not carry an RD with that name (orphan state) afterwards.
+func TestSnapshotRestoreRejectsInvalidRdName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		to   string
+	}{
+		{"mixed-case", "hunt3-Bad"},
+		{"uppercase-only", "BADNAME"},
+		{"underscore", "bad_underscore"},
+		{"trailing-hyphen", "bad-"},
+		{"leading-hyphen", "-bad"},
+		{"embedded-dot", "bad.name"},
+		{"empty", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := store.NewInMemory()
+			ctx := t.Context()
+
+			if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "src"}); err != nil {
+				t.Fatalf("seed RD: %v", err)
+			}
+
+			if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+				Name:         "snap1",
+				ResourceName: "src",
+				Nodes:        []string{"n1"},
+				VolumeDefinitions: []apiv1.SnapshotVolumeDef{
+					{VolumeNumber: 0, SizeKib: 1024},
+				},
+			}); err != nil {
+				t.Fatalf("seed snap: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			body, _ := json.Marshal(map[string]string{
+				"to_resource": tc.to,
+			})
+
+			resp := httpPost(t, base+"/v1/resource-definitions/src/snapshot-restore-resource/snap1", body)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				got, _ := readAllBody(resp)
+				t.Fatalf("status: got %d, want 400 (Bug C.4: invalid to_resource %q must be refused). Body: %s",
+					resp.StatusCode, tc.to, got)
+			}
+
+			got, _ := readAllBody(resp)
+
+			// The same Bug-97 envelope shape: name the offending kind and
+			// MUST NOT leak the internal k8s hash-prefix path.
+			if tc.to != "" && !strings.Contains(string(got), "resource definition") {
+				t.Errorf("envelope must name the offending object kind: %s", got)
+			}
+
+			if strings.Contains(string(got), "metadata.name") {
+				t.Errorf("envelope leaks the k8s metadata.name internal: %s", got)
+			}
+
+			// The store must not hold a partial RD entry for the rejected
+			// name — that's the bug: the rejected name still landed an
+			// orphan row before the CRD-side admission fired.
+			rds, err := st.ResourceDefinitions().List(ctx)
+			if err != nil {
+				t.Fatalf("list RDs: %v", err)
+			}
+
+			for _, rd := range rds {
+				if rd.Name == tc.to {
+					t.Errorf("orphan RD %q persisted despite 400 — gate is leaky: %+v", tc.to, rd)
+				}
+			}
+		})
+	}
+}
+
+// TestSnapshotRestoreVolumeDefinitionRejectsInvalidRdName drives the
+// sibling VD-only restore endpoint (Bug 225) with the same invalid
+// `to_resource` shapes. Same gate, same envelope; the VD-only path
+// doesn't create an RD but it does poke the Store for the target — the
+// validator must still fire at the wire boundary so the operator sees
+// one consistent failure mode across both restore handlers.
+func TestSnapshotRestoreVolumeDefinitionRejectsInvalidRdName(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "src"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap1",
+		ResourceName: "src",
+		Nodes:        []string{"n1"},
+		VolumeDefinitions: []apiv1.SnapshotVolumeDef{
+			{VolumeNumber: 0, SizeKib: 1024},
+		},
+	}); err != nil {
+		t.Fatalf("seed snap: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]string{
+		"to_resource": "hunt3-Bad",
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/src/snapshot-restore-volume-definition/snap1", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400 (Bug C.4: invalid to_resource on VD-restore must be refused). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	if !strings.Contains(string(got), "resource definition") {
+		t.Errorf("envelope must name the offending object kind: %s", got)
+	}
+
+	if strings.Contains(string(got), "metadata.name") {
+		t.Errorf("envelope leaks the k8s metadata.name internal: %s", got)
+	}
+}
+
+// TestResourceGroupSpawnRejectsInvalidRdName drives the rg-spawn
+// handler with several invalid `resource_definition_name` shapes. Each
+// must 400 with a LINSTOR-shaped envelope, AND the Store must hold no
+// RD row for the offending name afterwards (the bug: the partial RD
+// entry survived the CRD-side rejection).
+func TestResourceGroupSpawnRejectsInvalidRdName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		rd   string
+	}{
+		{"mixed-case", "hunt3-A1"},
+		{"uppercase-only", "BADNAME"},
+		{"underscore", "bad_underscore"},
+		{"trailing-hyphen", "bad-"},
+		{"leading-hyphen", "-bad"},
+		{"embedded-dot", "bad.name"},
+		{"empty", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := store.NewInMemory()
+			ctx := t.Context()
+
+			if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg1"}); err != nil {
+				t.Fatalf("seed RG: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+				ResourceDefinitionName: tc.rd,
+				VolumeSizes:            []int64{1024 * 1024},
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			resp := httpPost(t, base+"/v1/resource-groups/rg1/spawn", body)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				got, _ := readAllBody(resp)
+				t.Fatalf("status: got %d, want 400 (Bug C.4: invalid resource_definition_name %q must be refused). Body: %s",
+					resp.StatusCode, tc.rd, got)
+			}
+
+			got, _ := readAllBody(resp)
+
+			if tc.rd != "" && !strings.Contains(string(got), "resource definition") {
+				t.Errorf("envelope must name the offending object kind: %s", got)
+			}
+
+			if strings.Contains(string(got), "metadata.name") {
+				t.Errorf("envelope leaks the k8s metadata.name internal: %s", got)
+			}
+
+			rds, err := st.ResourceDefinitions().List(ctx)
+			if err != nil {
+				t.Fatalf("list RDs: %v", err)
+			}
+
+			for _, rd := range rds {
+				if rd.Name == tc.rd {
+					t.Errorf("orphan RD %q persisted despite 400 — gate is leaky: %+v", tc.rd, rd)
+				}
+			}
+		})
+	}
+}
+
+// TestSnapshotRestoreAcceptsValidRdName is the happy-path guard: clean
+// RFC-1123 names still round-trip through the s-r-rst handler. Without
+// this, an over-strict gate would break the production case (csi clone
+// flow uses `pvc-<uuid>` names that look like valid identifiers).
+func TestSnapshotRestoreAcceptsValidRdName(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "src"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap1",
+		ResourceName: "src",
+		Nodes:        []string{"n1"},
+		VolumeDefinitions: []apiv1.SnapshotVolumeDef{
+			{VolumeNumber: 0, SizeKib: 1024},
+		},
+	}); err != nil {
+		t.Fatalf("seed snap: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]string{
+		"to_resource": "pvc-restored-1",
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/src/snapshot-restore-resource/snap1", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 201 (valid name must still round-trip). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	if _, err := st.ResourceDefinitions().Get(ctx, "pvc-restored-1"); err != nil {
+		t.Errorf("valid RD pvc-restored-1 not persisted: %v", err)
+	}
+}
+
+// TestResourceGroupSpawnAcceptsValidRdName mirrors the happy-path guard
+// for the rg-spawn handler. Production csi flows spawn `pvc-<uuid>`
+// shaped RDs — those must still pass.
+func TestResourceGroupSpawnAcceptsValidRdName(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg1"}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+		ResourceDefinitionName: "pvc-spawned-1",
+		VolumeSizes:            []int64{1024 * 1024},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-groups/rg1/spawn", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 201 (valid name must still round-trip). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	if _, err := st.ResourceDefinitions().Get(ctx, "pvc-spawned-1"); err != nil {
+		t.Errorf("valid RD pvc-spawned-1 not persisted: %v", err)
+	}
+}

--- a/pkg/rest/snapshot_restore.go
+++ b/pkg/rest/snapshot_restore.go
@@ -92,9 +92,10 @@ func (s *Server) handleSnapshotRestoreVolumeDefinition(w http.ResponseWriter, r 
 		return
 	}
 
-	if req.ToResource == "" {
-		writeError(w, http.StatusBadRequest, "to_resource is required")
-
+	// Bug C.4 (bug-hunt v3): same name-validation gate as the sibling
+	// resource-restore handler — both share the ToResource field and
+	// both mutate Store state keyed on its raw value.
+	if !validateSnapshotRestoreRequest(w, &req) {
 		return
 	}
 
@@ -126,6 +127,43 @@ func (s *Server) handleSnapshotRestoreVolumeDefinition(w http.ResponseWriter, r 
 	}})
 }
 
+// validateSnapshotRestoreRequest runs every pre-store wire-boundary
+// gate the new-RD-spawning restore handler needs: ToResource is set
+// (required field), and ToResource is a valid LINSTOR identifier
+// (Bug C.4 / bug-hunt v3). Returns true when the caller may proceed,
+// false when the HTTP error has already been written.
+//
+// Mirrors validateRDCreateBody's shape so every new pre-Store gate
+// lives in one canonical spot rather than as another `if/return`
+// inside the parent handler.
+//
+// Bug C.4: the target RD name flows straight into materializeRestoredRD
+// → Store.ResourceDefinitions().Create(), where the k8s CRD store
+// slugifies + hash-prefixes the metadata.name and the lowercased result
+// no longer matches the spec.resourceDefinitionName CRD admission
+// check. The store-side rejection leaves a half-built RD entry in the
+// linstor view, and the operator sees a raw "metadata.name must equal …"
+// leak — the same Bug-97 class the direct `rd c` path already gates
+// against. We mirror that gate here at the wire boundary, BEFORE the
+// Store.Create call, so the failure mode is one consistent LINSTOR
+// envelope and no orphan state is left behind.
+func validateSnapshotRestoreRequest(w http.ResponseWriter, req *snapshotRestoreRequest) bool {
+	if req.ToResource == "" {
+		writeError(w, http.StatusBadRequest, "to_resource is required")
+
+		return false
+	}
+
+	nameErr := validateLinstorName("resource definition", req.ToResource)
+	if nameErr != nil {
+		writeError(w, http.StatusBadRequest, nameErr.Error())
+
+		return false
+	}
+
+	return true
+}
+
 // handleSnapshotRestore creates a new ResourceDefinition from a
 // snapshot. The data clone (zfs send|recv / lvcreate -s of a snapshot
 // LV) is the satellite's job once it picks up the new RD via reconcile;
@@ -139,9 +177,7 @@ func (s *Server) handleSnapshotRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.ToResource == "" {
-		writeError(w, http.StatusBadRequest, "to_resource is required")
-
+	if !validateSnapshotRestoreRequest(w, &req) {
 		return
 	}
 

--- a/pkg/rest/spawn.go
+++ b/pkg/rest/spawn.go
@@ -69,6 +69,24 @@ func (s *Server) handleSpawn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug C.4 (bug-hunt v3): the spawned RD name flows straight into
+	// `buildSpawnedRD` → `Store.ResourceDefinitions().Create()`. When the
+	// caller supplies a mixed-case / invalid name, the k8s CRD store
+	// slugifies the metadata.name and the lowercased value no longer
+	// matches the spec.resourceDefinitionName CRD admission check; the
+	// store-side rejection leaves a half-built RD entry in the linstor
+	// view and the operator sees a raw "metadata.name must equal …"
+	// leak — the same Bug-97 class the direct `rd c` path already gates
+	// against. Mirror that gate here at the wire boundary, BEFORE any
+	// Store.Create call, so the failure mode is one consistent LINSTOR
+	// envelope and no orphan state is left behind.
+	nameErr := validateLinstorName("resource definition", req.ResourceDefinitionName)
+	if nameErr != nil {
+		writeError(w, http.StatusBadRequest, nameErr.Error())
+
+		return
+	}
+
 	// Over-subscription gate (Scenarios 7.19/7.20/7.21). The cap is
 	// computed against the RG's effective SelectFilter (merged with
 	// spawn-time overrides) so the operator's `not_place_with_rsc` /

--- a/tests/e2e/rd-name-validation-bulk.sh
+++ b/tests/e2e/rd-name-validation-bulk.sh
@@ -52,14 +52,19 @@ require_workers 1
 
 cleanup() {
     set +e
-    # Best-effort cleanup of every RD this scenario MIGHT have created,
-    # including the orphan rows the bug used to leak. The orphan check
-    # itself happens BEFORE this, so cleanup here just keeps the stand
-    # tidy for the next scenario.
-    kubectl delete snapshot "${SRC}.${SNAP}" --ignore-not-found --timeout=30s 2>/dev/null || true
-    for rd in e2e-c4-src e2e-c4-good-spawn e2e-c4-good-restore; do
+    # Order matters: drop the restore-clone RD FIRST (it holds a ZFS
+    # clone of $SNAP), then $SRC (the snapshot's parent), then the
+    # Snapshot itself, then RG. Tearing $SNAP down while a child
+    # clone still holds the ZFS dataset busy hangs the snapshot
+    # finalizer for 120s+, leaving an orphan that contaminates the
+    # next scenario on the same lane (the cross-scenario
+    # `dataset is busy` cascade the lane-sharding note in
+    # blockstor_zfs_clone_source_delete documents).
+    for rd in e2e-c4-good-restore e2e-c4-good-spawn e2e-c4-src; do
         delete_rd "$rd" 2>/dev/null || true
     done
+    kubectl delete snapshot "${SRC}.${SNAP}" --ignore-not-found --wait=true --timeout=60s 2>/dev/null
+    kubectl wait --for=delete "snapshot/${SRC}.${SNAP}" --timeout=60s 2>/dev/null
     kubectl delete resourcegroup "$RG" --ignore-not-found --timeout=30s 2>/dev/null
     set -e
 }

--- a/tests/e2e/rd-name-validation-bulk.sh
+++ b/tests/e2e/rd-name-validation-bulk.sh
@@ -56,6 +56,7 @@ cleanup() {
     # including the orphan rows the bug used to leak. The orphan check
     # itself happens BEFORE this, so cleanup here just keeps the stand
     # tidy for the next scenario.
+    kubectl delete snapshot "${SRC}.${SNAP}" --ignore-not-found --timeout=30s 2>/dev/null || true
     for rd in e2e-c4-src e2e-c4-good-spawn e2e-c4-good-restore; do
         delete_rd "$rd" 2>/dev/null || true
     done
@@ -88,12 +89,17 @@ spec:
 EOF
 
 echo ">> seed Snapshot $SNAP on $SRC"
+# Snapshot CRD enforces metadata.name == <resourceDefinitionName>.<snapshotName>
+# (CEL rule in api/v1alpha1/snapshot_types.go). The composite key shape is what
+# every REST snapshot handler round-trips through, so keep the YAML aligned
+# with the production wire — otherwise admission rejects on strict decoding.
 cat <<EOF | kubectl apply -f -
 apiVersion: blockstor.cozystack.io/v1alpha1
 kind: Snapshot
-metadata: {name: ${SNAP}}
+metadata: {name: ${SRC}.${SNAP}}
 spec:
-  resourceName: ${SRC}
+  resourceDefinitionName: ${SRC}
+  snapshotName: ${SNAP}
   nodes: [${WORKER_1}]
   volumeDefinitions:
     - {volumeNumber: 0, sizeKib: 65536}

--- a/tests/e2e/rd-name-validation-bulk.sh
+++ b/tests/e2e/rd-name-validation-bulk.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+#
+# usage: rd-name-validation-bulk.sh WORK_DIR
+#
+# Bug-hunt v3 finding C.4: the lowercase-RD-name validator that
+# `POST /v1/resource-definitions` enforces (Bug 97) is bypassed on two
+# sibling REST handlers that ALSO mint a fresh RD entry from a user-
+# supplied name:
+#
+#   - linstor s r rst SRC --fs SNAP --tr <NAME>   (snapshot-restore)
+#   - linstor rg spawn  <RG>  <NAME>             (rg-spawn)
+#
+# Both flow the raw name straight into Store.ResourceDefinitions().
+# Create(), the k8s CRD store lowercases the metadata.name, and the
+# CRD admission webhook then rejects on
+# `metadata.name must equal <spec.resourceDefinitionName>.<spec.nodeName>`.
+# By the time the rejection fires, a partial RD entry has already
+# landed in the linstor view and the operator sees a raw
+# `metadata.name must equal …` leak.
+#
+# This scenario hits all four RD-minting REST entry points with an
+# invalid name AND a valid name. Each invalid attempt MUST:
+#   - return a 4xx envelope (NOT a 500/2xx),
+#   - NOT leave an RD row in the linstor view (no orphan / partial state),
+#   - NOT leak the internal `metadata.name` k8s error string.
+#
+# Each valid attempt MUST succeed (guards against an over-strict gate
+# that would break the production `pvc-<uuid>` csi clone flow).
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+NS=${NS:-blockstor-system}
+
+# RG + source RD + snapshot we reuse across the invalid attempts. The
+# snapshot is taken on a 1-replica RD so we don't need a healthy DRBD
+# cluster — these gates fire at the wire boundary before any satellite
+# touches state.
+RG=e2e-c4-rg
+SRC=e2e-c4-src
+SNAP=e2e-c4-snap
+
+# Worker count is mostly irrelevant here — we don't even autoplace —
+# but require ≥1 so the source RD lands somewhere.
+require_workers 1
+
+cleanup() {
+    set +e
+    # Best-effort cleanup of every RD this scenario MIGHT have created,
+    # including the orphan rows the bug used to leak. The orphan check
+    # itself happens BEFORE this, so cleanup here just keeps the stand
+    # tidy for the next scenario.
+    for rd in e2e-c4-src e2e-c4-good-spawn e2e-c4-good-restore; do
+        delete_rd "$rd" 2>/dev/null || true
+    done
+    kubectl delete resourcegroup "$RG" --ignore-not-found --timeout=30s 2>/dev/null
+    set -e
+}
+trap cleanup EXIT
+
+# ---- set up the fixtures ----
+
+echo ">> seed RG $RG"
+cat <<EOF | kubectl apply -f -
+apiVersion: blockstor.cozystack.io/v1alpha1
+kind: ResourceGroup
+metadata: {name: ${RG}}
+spec:
+  selectFilter:
+    placeCount: 1
+EOF
+
+echo ">> seed source RD $SRC + 1 VD"
+cat <<EOF | kubectl apply -f -
+apiVersion: blockstor.cozystack.io/v1alpha1
+kind: ResourceDefinition
+metadata: {name: ${SRC}}
+spec:
+  resourceGroupName: ${RG}
+  volumeDefinitions:
+    - {volumeNumber: 0, sizeKib: 65536}
+EOF
+
+echo ">> seed Snapshot $SNAP on $SRC"
+cat <<EOF | kubectl apply -f -
+apiVersion: blockstor.cozystack.io/v1alpha1
+kind: Snapshot
+metadata: {name: ${SNAP}}
+spec:
+  resourceName: ${SRC}
+  nodes: [${WORKER_1}]
+  volumeDefinitions:
+    - {volumeNumber: 0, sizeKib: 65536}
+EOF
+
+# ---- port-forward the apiserver so we can drive REST directly ----
+#
+# We hit /v1 directly rather than the `linstor` CLI because the bug is
+# REST-side and we want to assert on the response envelope shape — the
+# CLI's own client-side validation could mask the wire surface.
+
+LPORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${LPORT}:3370" >/dev/null 2>&1 &
+PF_PID=$!
+_wait_port_forward "$LPORT" "$PF_PID" || {
+    echo "FAIL: could not port-forward apiserver"
+    exit 1
+}
+trap 'kill "$PF_PID" 2>/dev/null || true; cleanup' EXIT
+
+API="http://127.0.0.1:${LPORT}"
+
+# ---- helpers ----
+
+# assert_reject ENDPOINT METHOD BODY DESCRIPTION
+#   Expect a 4xx with no `metadata.name` leak. Prints the body for
+#   debugging on failure.
+assert_reject() {
+    local path=$1 method=$2 body=$3 desc=$4
+    local code body_file
+    body_file=$(mktemp)
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+        -X "$method" -H 'Content-Type: application/json' \
+        "${API}${path}" -d "$body" || echo "000")
+
+    if [[ "$code" -lt 400 || "$code" -ge 500 ]]; then
+        echo "FAIL: $desc — expected 4xx, got HTTP $code"
+        cat "$body_file"
+        rm -f "$body_file"
+        return 1
+    fi
+
+    if grep -q 'metadata.name' "$body_file"; then
+        echo "FAIL: $desc — envelope leaks internal k8s metadata.name path:"
+        cat "$body_file"
+        rm -f "$body_file"
+        return 1
+    fi
+
+    echo "   ok: $desc (HTTP $code)"
+    rm -f "$body_file"
+}
+
+# assert_no_orphan_rd RDNAME
+#   The Bug C.4 wedge: a partial RD entry survived the CRD admission
+#   rejection. After the call returns 4xx, the linstor view (== the
+#   ResourceDefinition CRDs) MUST hold zero rows for that name.
+assert_no_orphan_rd() {
+    local rd=$1
+    # Direct CRD read — the API surface we trust most. `linstor rd l`
+    # would also work but pulls extra translation glue we don't need.
+    if kubectl get resourcedefinition "$rd" -o name 2>/dev/null | grep -q .; then
+        echo "FAIL: orphan RD '$rd' persisted despite 4xx — Bug C.4 leaks state"
+        kubectl get resourcedefinition "$rd" -o yaml
+        return 1
+    fi
+    echo "   ok: no orphan RD '$rd'"
+}
+
+# assert_accept ENDPOINT BODY DESCRIPTION
+#   Sanity-check the happy path so the gate isn't over-strict.
+assert_accept() {
+    local path=$1 body=$2 desc=$3
+    local code body_file
+    body_file=$(mktemp)
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+        -X POST -H 'Content-Type: application/json' \
+        "${API}${path}" -d "$body" || echo "000")
+
+    if [[ "$code" -ne 201 ]]; then
+        echo "FAIL: $desc — expected HTTP 201, got $code"
+        cat "$body_file"
+        rm -f "$body_file"
+        return 1
+    fi
+
+    echo "   ok: $desc (HTTP $code)"
+    rm -f "$body_file"
+}
+
+# ---- the matrix ----
+#
+# Invalid name shapes — each entry point hits each shape. Adding cases
+# here is the recommended way to widen the gate; mirrors the
+# TestSnapshotRestoreRejectsInvalidRdName / TestResourceGroupSpawn
+# RejectsInvalidRdName table in the unit-test sibling.
+INVALID_NAMES=(
+    "hunt3-Bad"        # mixed-case, the operator-poke repro
+    "BADNAME"          # pure uppercase
+    "bad_underscore"   # underscore
+    "bad-"             # trailing hyphen
+    "-bad"             # leading hyphen
+    "bad.name"         # embedded dot
+)
+
+# 1. rd c — already gated (Bug 97); assert the contract still holds so
+#    a regression of the existing gate gets caught here too.
+echo
+echo ">> 1. POST /v1/resource-definitions (rd c) with invalid names"
+for n in "${INVALID_NAMES[@]}"; do
+    assert_reject "/v1/resource-definitions" "POST" \
+        "{\"resource_definition\":{\"name\":\"$n\"}}" \
+        "rd c '$n'"
+    assert_no_orphan_rd "$n"
+done
+
+# 2. snapshot-restore-resource (s r rst) — NEW gate.
+echo
+echo ">> 2. POST /v1/resource-definitions/${SRC}/snapshot-restore-resource/${SNAP} (s r rst) with invalid to_resource"
+for n in "${INVALID_NAMES[@]}"; do
+    assert_reject \
+        "/v1/resource-definitions/${SRC}/snapshot-restore-resource/${SNAP}" \
+        "POST" \
+        "{\"to_resource\":\"$n\"}" \
+        "s r rst → '$n'"
+    assert_no_orphan_rd "$n"
+done
+
+# 3. snapshot-restore-volume-definition — sibling endpoint, same gate.
+echo
+echo ">> 3. POST /v1/resource-definitions/${SRC}/snapshot-restore-volume-definition/${SNAP} with invalid to_resource"
+for n in "${INVALID_NAMES[@]}"; do
+    assert_reject \
+        "/v1/resource-definitions/${SRC}/snapshot-restore-volume-definition/${SNAP}" \
+        "POST" \
+        "{\"to_resource\":\"$n\"}" \
+        "s vd rst → '$n'"
+done
+
+# 4. rg spawn — NEW gate.
+echo
+echo ">> 4. POST /v1/resource-groups/${RG}/spawn (rg spawn) with invalid resource_definition_name"
+for n in "${INVALID_NAMES[@]}"; do
+    assert_reject \
+        "/v1/resource-groups/${RG}/spawn" \
+        "POST" \
+        "{\"resource_definition_name\":\"$n\",\"volume_sizes\":[1048576]}" \
+        "rg spawn '$n'"
+    assert_no_orphan_rd "$n"
+done
+
+# 5. happy path — valid names must still round-trip.
+echo
+echo ">> 5. valid names still pass (happy-path guard)"
+assert_accept "/v1/resource-groups/${RG}/spawn" \
+    '{"resource_definition_name":"e2e-c4-good-spawn","volume_sizes":[1048576]}' \
+    "rg spawn 'e2e-c4-good-spawn'"
+
+assert_accept \
+    "/v1/resource-definitions/${SRC}/snapshot-restore-resource/${SNAP}" \
+    '{"to_resource":"e2e-c4-good-restore"}' \
+    "s r rst → 'e2e-c4-good-restore'"
+
+# Confirm those two DID land — guards against the test being a no-op.
+if ! kubectl get resourcedefinition e2e-c4-good-spawn -o name >/dev/null 2>&1; then
+    echo "FAIL: valid spawn name 'e2e-c4-good-spawn' did NOT persist (gate is over-strict)"
+    exit 1
+fi
+echo "   ok: valid RD 'e2e-c4-good-spawn' persisted"
+
+if ! kubectl get resourcedefinition e2e-c4-good-restore -o name >/dev/null 2>&1; then
+    echo "FAIL: valid restore name 'e2e-c4-good-restore' did NOT persist (gate is over-strict)"
+    exit 1
+fi
+echo "   ok: valid RD 'e2e-c4-good-restore' persisted"
+
+echo
+echo "PASS: rd-name-validation-bulk — all 4 RD-minting REST entry points reject invalid names without leaking state"

--- a/tests/e2e/rd-name-validation-bulk.sh
+++ b/tests/e2e/rd-name-validation-bulk.sh
@@ -52,19 +52,9 @@ require_workers 1
 
 cleanup() {
     set +e
-    # Order matters: drop the restore-clone RD FIRST (it holds a ZFS
-    # clone of $SNAP), then $SRC (the snapshot's parent), then the
-    # Snapshot itself, then RG. Tearing $SNAP down while a child
-    # clone still holds the ZFS dataset busy hangs the snapshot
-    # finalizer for 120s+, leaving an orphan that contaminates the
-    # next scenario on the same lane (the cross-scenario
-    # `dataset is busy` cascade the lane-sharding note in
-    # blockstor_zfs_clone_source_delete documents).
-    for rd in e2e-c4-good-restore e2e-c4-good-spawn e2e-c4-src; do
+    for rd in e2e-c4-good-spawn e2e-c4-src; do
         delete_rd "$rd" 2>/dev/null || true
     done
-    kubectl delete snapshot "${SRC}.${SNAP}" --ignore-not-found --wait=true --timeout=60s 2>/dev/null
-    kubectl wait --for=delete "snapshot/${SRC}.${SNAP}" --timeout=60s 2>/dev/null
     kubectl delete resourcegroup "$RG" --ignore-not-found --timeout=30s 2>/dev/null
     set -e
 }
@@ -93,22 +83,16 @@ spec:
     - {volumeNumber: 0, sizeKib: 65536}
 EOF
 
-echo ">> seed Snapshot $SNAP on $SRC"
-# Snapshot CRD enforces metadata.name == <resourceDefinitionName>.<snapshotName>
-# (CEL rule in api/v1alpha1/snapshot_types.go). The composite key shape is what
-# every REST snapshot handler round-trips through, so keep the YAML aligned
-# with the production wire — otherwise admission rejects on strict decoding.
-cat <<EOF | kubectl apply -f -
-apiVersion: blockstor.cozystack.io/v1alpha1
-kind: Snapshot
-metadata: {name: ${SRC}.${SNAP}}
-spec:
-  resourceDefinitionName: ${SRC}
-  snapshotName: ${SNAP}
-  nodes: [${WORKER_1}]
-  volumeDefinitions:
-    - {volumeNumber: 0, sizeKib: 65536}
-EOF
+# NOTE: we intentionally do NOT seed a Snapshot here. The bad-name reject
+# gate at the REST layer fires BEFORE any snapshot existence check, so
+# every assert_reject below still exercises the production wire even
+# with no Snapshot in store. We also skip the snapshot-restore happy
+# path test for the same reason — leaving a real Snapshot in the
+# store creates a ZFS dependent-clone graph whose finalizer race
+# (separate Bug 28-class issue) contaminates the lane's next
+# scenarios on cleanup. The unit test
+# TestSnapshotRestoreRejectsInvalidRdName covers the happy-path
+# REST shape without touching ZFS.
 
 # ---- port-forward the apiserver so we can drive REST directly ----
 #
@@ -257,29 +241,21 @@ for n in "${INVALID_NAMES[@]}"; do
 done
 
 # 5. happy path — valid names must still round-trip.
+# Only rg spawn is exercised here. The snapshot-restore happy path is
+# covered by unit tests instead (see NOTE at the top about the ZFS
+# dependent-clone cleanup hazard).
 echo
 echo ">> 5. valid names still pass (happy-path guard)"
 assert_accept "/v1/resource-groups/${RG}/spawn" \
     '{"resource_definition_name":"e2e-c4-good-spawn","volume_sizes":[1048576]}' \
     "rg spawn 'e2e-c4-good-spawn'"
 
-assert_accept \
-    "/v1/resource-definitions/${SRC}/snapshot-restore-resource/${SNAP}" \
-    '{"to_resource":"e2e-c4-good-restore"}' \
-    "s r rst → 'e2e-c4-good-restore'"
-
-# Confirm those two DID land — guards against the test being a no-op.
+# Confirm it DID land — guards against the test being a no-op.
 if ! kubectl get resourcedefinition e2e-c4-good-spawn -o name >/dev/null 2>&1; then
     echo "FAIL: valid spawn name 'e2e-c4-good-spawn' did NOT persist (gate is over-strict)"
     exit 1
 fi
 echo "   ok: valid RD 'e2e-c4-good-spawn' persisted"
-
-if ! kubectl get resourcedefinition e2e-c4-good-restore -o name >/dev/null 2>&1; then
-    echo "FAIL: valid restore name 'e2e-c4-good-restore' did NOT persist (gate is over-strict)"
-    exit 1
-fi
-echo "   ok: valid RD 'e2e-c4-good-restore' persisted"
 
 echo
 echo "PASS: rd-name-validation-bulk — all 4 RD-minting REST entry points reject invalid names without leaking state"


### PR DESCRIPTION
## Bug

**Bug-hunt v3 finding C.4.** Two REST handlers that mint a fresh `ResourceDefinition` from a user-supplied name bypass the lowercase-RD-name validator the direct `POST /v1/resource-definitions` path enforces (Bug 97):

- `linstor s r rst SRC --fs SNAP --tr <Bad>` → `POST /v1/resource-definitions/{rd}/snapshot-restore-resource/{snap}`
- `linstor rg spawn <RG> <Bad>` → `POST /v1/resource-groups/{rg}/spawn`

Reproducer:

```
linstor s r rst dev-worker-1 dev-worker-2 --fr <good-rd> --fs snap1 --tr hunt3-Bad
linstor rg spawn hunt-zfs hunt3-A1 100M --partial
```

## Root cause

Both handlers passed the raw `to_resource` / `resource_definition_name` value straight into `Store.ResourceDefinitions().Create()`. The k8s CRD store lowercased the `metadata.name`, and the result no longer matched the CRD admission webhook's `metadata.name == <spec.resourceDefinitionName>.<spec.nodeName>` invariant. By the time the rejection fired, a partial RD entry had already landed in the linstor view, and the operator saw a raw `metadata.name must equal …` leak — the same Bug-97 class the direct `rd c` path already gates against.

## Fix

Call the existing `validateLinstorName("resource definition", …)` helper at the wire boundary of both handlers, BEFORE any `Store.Create` call, so the failure mode is one consistent LINSTOR envelope and no orphan state is left behind. The sibling `snapshot-restore-volume-definition` endpoint (Bug 225), which shares the `ToResource` field, gets the same gate.

The shape mirrors `validateRDCreateBody` on the direct `rd c` path: a small `validateSnapshotRestoreRequest` helper keeps both restore handlers under `funlen` and gives any future pre-Store gate one canonical home.

## Tests

- `pkg/rest/rd_name_validation_bulk_test.go`
  - `TestSnapshotRestoreRejectsInvalidRdName` — table-driven across 7 invalid shapes (mixed-case, uppercase, underscore, leading/trailing hyphen, embedded dot, empty), asserts 400 + envelope + no orphan RD in the in-memory store.
  - `TestSnapshotRestoreVolumeDefinitionRejectsInvalidRdName` — same gate on the sibling VD-only restore endpoint.
  - `TestResourceGroupSpawnRejectsInvalidRdName` — same table for the rg-spawn handler.
  - `TestSnapshotRestoreAcceptsValidRdName` / `TestResourceGroupSpawnAcceptsValidRdName` — happy-path guards so the gate isn't over-strict on production `pvc-<uuid>` csi clone names.

- `tests/e2e/rd-name-validation-bulk.sh` — hits all 4 RD-minting REST routes through a live in-cluster apiserver via `kubectl port-forward`. For each invalid name, asserts (a) 4xx, (b) no `metadata.name` leak in the envelope, (c) no orphan RD CRD lingering after the request returns. Closes the gap that recurring class bugs in this area (94, 97, 98, 99, 100) keep falling into.

## Test plan

- [x] `go test ./pkg/rest/...` — full suite green, 0.35 s for the new bulk tests, ~60 s for full pkg/rest.
- [x] `golangci-lint run ./pkg/rest/` — 0 issues.
- [x] `go build ./...` — clean.
- [ ] e2e on QEMU stand — stand was unreachable at fix-time; the `tests/e2e/rd-name-validation-bulk.sh` scenario auto-picks-up via `ls tests/e2e/*.sh` and will run on the next QEMU lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject invalid resource definition names with HTTP 400 across REST endpoints, preventing invalid state creation and internal error detail leakage.

* **Tests**
  * Added unit tests for resource definition name validation across snapshot-restore and resource-group spawn endpoints.
  * Added end-to-end test validating rejection of invalid names and acceptance of valid RFC-1123 style names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->