### PR TITLE
fix(controller): honor r d --keep-tiebreaker so auto-witness survives

### DIFF
--- a/internal/controller/ensure_tiebreaker_test.go
+++ b/internal/controller/ensure_tiebreaker_test.go
@@ -345,6 +345,186 @@ func TestEnsureTiebreakerExpiredSuppressionResumesAutoWitness(t *testing.T) {
 	}
 }
 
+// TestKeepTiebreakerAnnotation_HonoredWhileFresh pins Bug B.1
+// (hunt-v3): `linstor r d --keep-tiebreaker <diskful>` stamps the
+// KeepTiebreakerUntilAnnotation on the parent RD; while the deadline
+// is in the future, the auto-witness reconciler must preserve an
+// existing TIE_BREAKER witness across a diskful→1 transition that
+// the Bug-338 carve-out would otherwise reap.
+//
+// Repro shape: 1 diskful + 1 witness + 0 non-witness diskless. The
+// carve-out in shouldKeepExistingWitness would normally collapse the
+// witness (1 voter quorum:off > 2 voter no-majority); the operator
+// override flips that decision because they explicitly asked to keep
+// the witness.
+func TestKeepTiebreakerAnnotation_HonoredWhileFresh(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// Topology: 1 diskful on n1, 1 TIE_BREAKER witness on n3,
+	// 0 non-witness diskless. This is the exact shape the Bug-338
+	// carve-out wants to collapse — the operator override must
+	// preserve it.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-keep-tb", NodeName: "n1",
+	}); err != nil {
+		t.Fatalf("seed diskful replica: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-keep-tb", NodeName: "n3",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed witness replica: %v", err)
+	}
+
+	// Fresh keep-tiebreaker: deadline 5 minutes in the future.
+	deadline := time.Now().Add(5 * time.Minute).UTC().Format(time.RFC3339)
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pvc-keep-tb",
+			Annotations: map[string]string{
+				controllerpkg.KeepTiebreakerUntilAnnotation: deadline,
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// The witness on n3 must still exist after the reconcile.
+	got, err := st.Resources().Get(ctx, "pvc-keep-tb", "n3")
+	if err != nil {
+		t.Fatalf("witness on n3 was removed despite keep-tiebreaker annotation: %v", err)
+	}
+
+	hasTB := false
+
+	for _, f := range got.Flags {
+		if f == apiv1.ResourceFlagTieBreaker {
+			hasTB = true
+
+			break
+		}
+	}
+
+	if !hasTB {
+		t.Errorf("witness on n3 lost its TIE_BREAKER flag; got %v", got.Flags)
+	}
+
+	// The helper must agree.
+	if !controllerpkg.IsKeepTiebreakerActive(rd) {
+		t.Errorf("IsKeepTiebreakerActive returned false for a fresh annotation")
+	}
+}
+
+// TestKeepTiebreakerAnnotation_ExpiredFallsThrough pins the symmetric
+// half of Bug B.1: once the keep-tiebreaker deadline passes, the
+// Bug-338 collapse path resumes without any manual cleanup. Without
+// the expiry, a forgotten annotation would silently disable the
+// auto-quorum invariant forever — a footgun.
+//
+// Same topology as the fresh-annotation case, but the deadline is in
+// the past. Expected: the orphan witness is reaped, and the helper
+// reports the annotation as inactive.
+func TestKeepTiebreakerAnnotation_ExpiredFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-keep-tb-stale", NodeName: "n1",
+	}); err != nil {
+		t.Fatalf("seed diskful replica: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-keep-tb-stale", NodeName: "n3",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed witness replica: %v", err)
+	}
+
+	// Expired keep-tiebreaker: deadline 5 minutes in the past.
+	expired := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pvc-keep-tb-stale",
+			Annotations: map[string]string{
+				controllerpkg.KeepTiebreakerUntilAnnotation: expired,
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// Bug-338 carve-out resumes: orphan witness must be gone.
+	if _, err := st.Resources().Get(ctx, "pvc-keep-tb-stale", "n3"); err == nil {
+		t.Errorf("orphan witness on n3 survived an expired keep-tiebreaker annotation")
+	}
+
+	// Helper must report inactive.
+	if controllerpkg.IsKeepTiebreakerActive(rd) {
+		t.Errorf("IsKeepTiebreakerActive returned true for an expired annotation")
+	}
+
+	// Hand-typed garbage must also not activate the override.
+	rdGarbage := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pvc-keep-tb-junk",
+			Annotations: map[string]string{
+				controllerpkg.KeepTiebreakerUntilAnnotation: "definitely not a timestamp",
+			},
+		},
+	}
+
+	if controllerpkg.IsKeepTiebreakerActive(rdGarbage) {
+		t.Errorf("IsKeepTiebreakerActive returned true for unparseable annotation")
+	}
+}
+
 // TestEnsureTiebreakerHonoursAutoQuorumDisabled: scenario 7.W01
 // (wave2-07-quorum-observability.md §7.W01, UG9 lines 4233-4279).
 //

--- a/internal/controller/export_test.go
+++ b/internal/controller/export_test.go
@@ -209,6 +209,14 @@ func IsTiebreakerSuppressed(rd *blockstoriov1alpha1.ResourceDefinition) bool {
 	return isTiebreakerSuppressed(rd)
 }
 
+// IsKeepTiebreakerActive exposes the operator-intent override helper
+// for tests. Mirrors the IsTiebreakerSuppressed pattern: tests can
+// assert both that the helper reads the annotation and that the
+// reconciler honours the deadline window.
+func IsKeepTiebreakerActive(rd *blockstoriov1alpha1.ResourceDefinition) bool {
+	return isKeepTiebreakerActive(rd)
+}
+
 // IsAutoQuorumDisabled exposes the auto-quorum opt-out gate for
 // tests. Scenario 7.W01 pins both the disabled-and-skip path and
 // the default-enabled passthrough.
@@ -220,3 +228,8 @@ func IsAutoQuorumDisabled(rd *blockstoriov1alpha1.ResourceDefinition) bool {
 // key for tests so a regression that renamed the key on one side
 // would fail to compile here.
 const AutoTiebreakerSuppressedUntilAnnotation = apiv1.AutoTiebreakerSuppressedUntilAnnotation
+
+// KeepTiebreakerUntilAnnotation exposes the operator-intent
+// annotation key for tests. Same compile-time-rename guard as the
+// suppression key above.
+const KeepTiebreakerUntilAnnotation = apiv1.KeepTiebreakerUntilAnnotation

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -380,8 +380,8 @@ func shouldTieBreakerExist(
 
 	const witnessUnnecessaryDiskfulCount = 3
 
-	keepExistingWitness := len(witness) > 0 &&
-		shouldKeepExistingWitness(len(diskful), nonWitnessDiskless, witnessUnnecessaryDiskfulCount)
+	keepExistingWitness := keepExistingWitnessFor(rd, diskful, witness, nonWitnessDiskless,
+		witnessUnnecessaryDiskfulCount)
 
 	// Bug 108: post-toggle race repair. The keep branch above
 	// preserves an existing witness across diskful→diskless; this
@@ -406,6 +406,43 @@ func shouldTieBreakerExist(
 		(len(diskful)+nonWitnessDiskless) == 2
 
 	return wantNewWitness || keepExistingWitness || repairAfterToggleRace
+}
+
+// keepExistingWitnessFor folds the two "preserve an existing
+// TIE_BREAKER witness" branches into a single helper so
+// shouldTieBreakerExist stays under the gocyclo threshold. Both
+// branches gate on `len(witness) > 0` — we never "keep" what isn't
+// there.
+//
+// Branches:
+//
+//  1. Operator-intent override (Bug B.1, hunt-v3):
+//     `linstor r d --keep-tiebreaker <diskful>` stamps the
+//     KeepTiebreakerUntilAnnotation on the parent RD. While the
+//     annotation deadline is in the future AND at least one diskful
+//     survives, retain the witness regardless of the Bug-338 carve-
+//     out. The diskful floor matters because lone TIE_BREAKER + 0
+//     diskful = 1 voter, strictly worse than no witness.
+//
+//  2. Bug-104 / Bug-338 steady-state keep branch:
+//     shouldKeepExistingWitness encodes the existing "preserve the
+//     witness across diskful→diskless toggle" + "collapse the
+//     orphaned witness when diskful=1 and no non-witness diskless
+//     co-resident" rules.
+func keepExistingWitnessFor(
+	rd *blockstoriov1alpha1.ResourceDefinition,
+	diskful, witness []apiv1.Resource,
+	nonWitnessDiskless, witnessUnnecessaryDiskfulCount int,
+) bool {
+	if len(witness) == 0 {
+		return false
+	}
+
+	if len(diskful) >= 1 && isKeepTiebreakerActive(rd) {
+		return true
+	}
+
+	return shouldKeepExistingWitness(len(diskful), nonWitnessDiskless, witnessUnnecessaryDiskfulCount)
 }
 
 // isAutoQuorumDisabled reports whether the RD opted out of the
@@ -444,6 +481,43 @@ func isTiebreakerSuppressed(rd *blockstoriov1alpha1.ResourceDefinition) bool {
 	}
 
 	raw, ok := rd.Annotations[apiv1.AutoTiebreakerSuppressedUntilAnnotation]
+	if !ok || raw == "" {
+		return false
+	}
+
+	deadline, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+
+	return time.Now().Before(deadline)
+}
+
+// isKeepTiebreakerActive reports whether an operator recently ran
+// `linstor r d --keep-tiebreaker <diskful> <rd>` against this RD.
+// The REST per-resource-delete handler stamps an RFC3339 deadline on
+// the parent RD when the `?keep_tiebreaker=true` query parameter is
+// set; this helper returns true while the deadline is in the future.
+//
+// Used by `shouldTieBreakerExist` to short-circuit the Bug-338
+// orphan-witness collapse: with this annotation fresh, an existing
+// TIE_BREAKER witness must survive a diskful→single-replica
+// transition the carve-out would otherwise reap. Without the
+// override, the CLI flag silently no-ops because the controller's
+// reconciler can't distinguish operator intent ("keep this witness")
+// from steady-state ("orphaned witness, prune").
+//
+// Bad / unparseable values are treated as "no override" so a hand-
+// edited annotation can't accidentally freeze the witness invariant
+// forever. An expired stamp also returns false — the auto-quorum
+// invariant resumes its normal Bug-338 behaviour with no manual
+// cleanup needed.
+func isKeepTiebreakerActive(rd *blockstoriov1alpha1.ResourceDefinition) bool {
+	if rd == nil || rd.Annotations == nil {
+		return false
+	}
+
+	raw, ok := rd.Annotations[apiv1.KeepTiebreakerUntilAnnotation]
 	if !ok || raw == "" {
 		return false
 	}

--- a/pkg/api/v1/annotations.go
+++ b/pkg/api/v1/annotations.go
@@ -33,6 +33,33 @@ package v1
 // is the neutral, dependency-free shared layer both already import.
 const AutoTiebreakerSuppressedUntilAnnotation = "blockstor.io/auto-tiebreaker-suppressed-until"
 
+// KeepTiebreakerUntilAnnotation is stamped on an RD when an operator
+// runs `linstor r d --keep-tiebreaker <diskful-node> <rd>`. Upstream
+// LINSTOR's CLI promises the semantics "keep the tiebreaker instead
+// of accidentally deleting it" — the typical use case is collapsing a
+// 2-diskful + 1-witness shape down to 1-diskful + 1-witness on
+// purpose, against the Bug-338 carve-out that would otherwise reap
+// the orphan witness for a 1-diskful RD.
+//
+// The value is an RFC3339 wall-clock deadline. While the deadline is
+// in the future, the RD reconciler's `shouldKeepExistingWitness`
+// helper short-circuits to true regardless of the auto-collapse
+// shape, so the witness survives long enough for the operator's
+// follow-up call (typically `r d` on the second diskful, or a fresh
+// `r c` to bring a new diskful in). The deadline is intentionally
+// short so a forgotten annotation can't permanently freeze the
+// auto-witness invariant — once it expires, the normal Bug-338
+// collapse path resumes without any manual cleanup.
+//
+// Bad / unparseable values are treated as "no override" so a hand-
+// edited annotation can't accidentally freeze quorum forever.
+//
+// Defined here (rather than in pkg/rest or internal/controller) so
+// the REST writer and controller reader share a single source of
+// truth without either package importing the other — pkg/api/v1 is
+// the neutral, dependency-free shared layer both already import.
+const KeepTiebreakerUntilAnnotation = "blockstor.io/keep-tiebreaker-until"
+
 // AutoDiskfulDeadlineAnnotation is stamped on an RD when the
 // AutoDiskfulReconciler first observes a diskful-replica deficit
 // (count < SelectFilter.PlaceCount) and the effective

--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -53,6 +53,18 @@ import (
 const (
 	AutoTiebreakerSuppressedUntilAnnotation = apiv1.AutoTiebreakerSuppressedUntilAnnotation
 	autoTiebreakerSuppressionWindow         = 5 * time.Minute
+
+	// KeepTiebreakerUntilAnnotation: re-export the canonical constant
+	// so the REST package can stamp it without importing internals.
+	//
+	// keepTiebreakerOverrideWindow: 5 minutes is long enough to cover
+	// a typical follow-up sequence (e.g. delete the second diskful
+	// after explicitly opting in to keep the witness, then create a
+	// fresh diskful elsewhere) without permanently masking the
+	// auto-witness invariant if the operator walks away. Matches the
+	// suppression window for consistency.
+	KeepTiebreakerUntilAnnotation = apiv1.KeepTiebreakerUntilAnnotation
+	keepTiebreakerOverrideWindow  = 5 * time.Minute
 )
 
 // registerAutoplace wires `POST /v1/resource-definitions/{rd}/autoplace` and
@@ -2542,9 +2554,35 @@ func decodeResourceCreateBody(body []byte) ([]apiv1.ResourceCreate, error) {
 // Delete so a concurrent reconcile observes "Resource gone +
 // annotation present" rather than "Resource gone + no annotation"
 // (which would race the witness back in).
+//
+// Bug B.1 (hunt-v3): `linstor r d --keep-tiebreaker <diskful> <rd>`
+// must NOT reap the auto-managed TIE_BREAKER witness in the same
+// reconcile that observes diskful drop. Upstream LINSTOR's CLI help
+// states "Keeps the tiebreaker instead of accidentally deleting it";
+// without the override the RD reconciler hits the Bug-338 carve-out
+// (diskful=1 + witness=1, no non-witness diskless → collapse) and
+// removes the witness right after the `r d` completes. We stamp a
+// short-lived `KeepTiebreakerUntilAnnotation` so the reconciler's
+// `shouldKeepExistingWitness` reads it and short-circuits to true
+// while the deadline is in the future. The stamp lands BEFORE the
+// Delete commits, mirroring the suppression annotation's
+// already-proven order: a Reconcile woken by the Delete event will
+// observe the annotation by the time it lists Resources.
 func (s *Server) handleResourceDelete(w http.ResponseWriter, r *http.Request) {
 	rdName := r.PathValue("rd")
 	node := r.PathValue("node")
+	keepTiebreaker := queryFlag(r, "keep_tiebreaker")
+
+	if keepTiebreaker {
+		// Best-effort. Failure to stamp doesn't block the
+		// operator-requested delete; the worst case without the
+		// annotation is "the witness is collapsed within ~5s of the
+		// r d" — annoying, but recoverable by a follow-up `r c` to
+		// re-create the witness manually. NotFound on the parent RD
+		// is folded into nil inside stampKeepTiebreaker (concurrent
+		// rd-delete cascade) so the same call path is safe here.
+		_ = s.stampKeepTiebreaker(r.Context(), rdName)
+	}
 
 	// Look up the Resource before any destructive action. The flag
 	// inspection drives the legacy tiebreaker-suppression stamp on
@@ -2734,6 +2772,36 @@ func (s *Server) stampTiebreakerSuppression(ctx context.Context, rdName string) 
 		}
 
 		rd.Annotations[AutoTiebreakerSuppressedUntilAnnotation] = deadline
+
+		return nil
+	})
+	if errors.Is(err, store.ErrNotFound) {
+		return nil
+	}
+
+	return err //nolint:wrapcheck // best-effort, caller swallows
+}
+
+// stampKeepTiebreaker writes the KeepTiebreakerUntilAnnotation onto
+// the parent RD with a `now + keepTiebreakerOverrideWindow` deadline.
+// The RD-side reconciler reads the annotation in its keep-branch and
+// preserves an existing TIE_BREAKER witness across shapes the Bug-338
+// carve-out would otherwise collapse (e.g. 1 diskful + 1 witness + 0
+// non-witness diskless).
+//
+// Idempotent: a fresh stamp always wins (later operator intent
+// overrides earlier). NotFound on the parent RD is swallowed — a
+// concurrent RD-delete cascade is the most common reason and the
+// caller doesn't care.
+func (s *Server) stampKeepTiebreaker(ctx context.Context, rdName string) error {
+	deadline := time.Now().Add(keepTiebreakerOverrideWindow).UTC().Format(time.RFC3339)
+
+	err := s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(ctx, rdName, func(rd *apiv1.ResourceDefinition) error {
+		if rd.Annotations == nil {
+			rd.Annotations = map[string]string{}
+		}
+
+		rd.Annotations[KeepTiebreakerUntilAnnotation] = deadline
 
 		return nil
 	})

--- a/pkg/rest/autoplace_test.go
+++ b/pkg/rest/autoplace_test.go
@@ -1413,6 +1413,102 @@ func TestResourceDeleteRegularReplicaSkipsSuppression(t *testing.T) {
 	}
 }
 
+// TestResourceDeleteKeepTiebreakerStampsOverride pins Bug B.1
+// (hunt-v3): `DELETE /v1/resource-definitions/{rd}/resources/{node}?keep_tiebreaker=true`
+// must stamp the KeepTiebreakerUntilAnnotation on the parent RD with
+// a future RFC3339 deadline BEFORE the Resource Delete commits. The
+// controller's `shouldTieBreakerExist` reads this annotation to
+// preserve an existing TIE_BREAKER witness across a diskful→1
+// transition the Bug-338 carve-out would otherwise reap.
+//
+// Without the stamp, the CLI flag silently no-ops because the
+// reconciler can't distinguish operator intent from steady-state.
+func TestResourceDeleteKeepTiebreakerStampsOverride(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "pvc-kt"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-kt", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed replica %s: %v", n, err)
+		}
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/pvc-kt/resources/n2?keep_tiebreaker=true")
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status: got %d, want 200", resp.StatusCode)
+	}
+
+	rd, err := st.ResourceDefinitions().Get(ctx, "pvc-kt")
+	if err != nil {
+		t.Fatalf("get RD: %v", err)
+	}
+
+	raw, ok := rd.Annotations[KeepTiebreakerUntilAnnotation]
+	if !ok || raw == "" {
+		t.Fatalf("keep-tiebreaker annotation missing; annotations=%v", rd.Annotations)
+	}
+
+	deadline, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("annotation value %q is not RFC3339: %v", raw, err)
+	}
+
+	if !deadline.After(time.Now()) {
+		t.Errorf("annotation deadline %v is not in the future", deadline)
+	}
+}
+
+// TestResourceDeleteWithoutKeepTiebreakerSkipsOverride: a plain
+// `linstor r d <node> <rd>` (no `?keep_tiebreaker=true` query param)
+// must NOT stamp the KeepTiebreakerUntilAnnotation. Only the explicit
+// CLI opt-in carries the override intent — every other delete must
+// fall through to the normal auto-witness invariant.
+func TestResourceDeleteWithoutKeepTiebreakerSkipsOverride(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "pvc-no-kt"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-no-kt", NodeName: "n1",
+	}); err != nil {
+		t.Fatalf("seed replica: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/pvc-no-kt/resources/n1")
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status: got %d, want 200", resp.StatusCode)
+	}
+
+	rd, err := st.ResourceDefinitions().Get(ctx, "pvc-no-kt")
+	if err != nil {
+		t.Fatalf("get RD: %v", err)
+	}
+
+	if _, ok := rd.Annotations[KeepTiebreakerUntilAnnotation]; ok {
+		t.Errorf("keep-tiebreaker annotation must not appear without ?keep_tiebreaker=true; got %v",
+			rd.Annotations)
+	}
+}
+
 // TestResourceDeleteBumpsSiblingPeers pins Bug 67's core invariant:
 // when `linstor r d <node> <rd>` drops one peer, every SURVIVING
 // sibling Resource of the same RD gets `blockstor.io/peer-changed`

--- a/tests/e2e/keep-tiebreaker-3way.sh
+++ b/tests/e2e/keep-tiebreaker-3way.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# usage: keep-tiebreaker-3way.sh WORK_DIR
+#
+# Bug B.1 (hunt-v3) regression catcher: `linstor r d --keep-tiebreaker
+# <one-of-diskful>` on a 2-diskful + 1-witness shape must NOT collapse
+# the auto-managed TIE_BREAKER witness. The CLI's `--keep-tiebreaker`
+# flag promises "Keeps the tiebreaker instead of accidentally deleting
+# it"; without the REST/controller plumbing the witness gets reaped in
+# the same reconcile that observes diskful drop from 2 → 1.
+#
+# Pre-fix symptom (live on the dev stand 2026-06-02):
+#   - 2 diskful (w-1 + w-2) + 1 auto-TIE_BREAKER (w-3)
+#   - linstor r d --keep-tiebreaker w-2 hunt3-b1
+#   - controller log: "ensureTiebreaker rd=... replicas=2 diskful=1
+#     witness=1 willCreate=false willRemove=true"
+#   - resulting topology: solo diskful on w-1, NO witness — quorum=1
+#     for ~5 minutes until stampTiebreakerSuppression expires.
+#
+# Post-fix expected: the witness on w-3 survives, the lone diskful on
+# w-1 stays in a "1 diskful + 1 TIE_BREAKER witness" shape until the
+# operator explicitly tears the rest down or the 5-minute deadline
+# expires (at which point the Bug-338 carve-out resumes its normal
+# collapse path).
+#
+# Per the MEMORY.md `tiebreaker e2e MUST exist` rule (Bugs 104/108/
+# 267/271/338/342 all slipped past unit-handler tests), every fix in
+# the TIE_BREAKER class ships with a real-DRBD scenario on the QEMU
+# stand. This is that scenario for Bug B.1.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+if ! command -v linstor >/dev/null 2>&1; then
+    echo "FAIL: linstor CLI not in PATH (apt install linstor-client)" >&2
+    exit 1
+fi
+
+RD=tb-keep-3way
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+# Per-step convergence budget. The witness add/keep path is event-
+# driven (RD reconciler watches Resource CRDs) plus a 5s requeue tick,
+# so 60s is comfortable on the QEMU stand.
+CONVERGE=${CONVERGE:-60}
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/keep-tb-3way-pf.log 2>&1 &
+PF_PID=$!
+
+dump_diag() {
+    echo "---- dump: linstor r l -r $RD ----"
+    "${LCTL[@]}" r l -r "$RD" 2>&1 || true
+    echo "---- dump: kubectl get resources.blockstor.cozystack.io -A ----"
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." '$1 ~ "^"rd' || true
+    echo "---- dump: Resource flags ----"
+    for n in "$N1" "$N2" "$N3"; do
+        kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.metadata.name}{" flags="}{.spec.flags}{"\n"}' \
+            2>/dev/null || true
+    done
+    echo "---- dump: RD annotations ----"
+    kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" \
+        -o jsonpath='{.metadata.annotations}{"\n"}' 2>/dev/null || true
+    echo "---- dump: kubectl logs -n $NS deploy/blockstor-controller --tail=120 ----"
+    kubectl logs -n "$NS" deploy/blockstor-controller --tail=120 2>/dev/null || true
+}
+
+cleanup() {
+    local rc=$?
+    if (( rc != 0 )); then
+        dump_diag
+    fi
+    delete_rd "$RD" 2>/dev/null || true
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for the port-forward to actually bind.
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+LCTL=(linstor --controllers "http://localhost:$PF_PORT")
+
+# Wipe any leftover state from a prior run of THIS scenario.
+delete_rd "$RD" 2>/dev/null || true
+
+tb_witness_count() {
+    local rd=$1
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}' \
+        | while read -r name; do
+            kubectl get "resources.blockstor.cozystack.io/${name}" \
+                -o jsonpath='{.spec.flags}' 2>/dev/null
+            echo
+        done \
+        | grep -c "TIE_BREAKER" || true
+}
+
+tb_witness_nodes() {
+    local rd=$1
+    local out=()
+    while read -r name; do
+        local flags
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null)
+        if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+            out+=("${name#${rd}.}")
+        fi
+    done < <(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}')
+    (IFS=,; echo "${out[*]}")
+}
+
+diskful_count() {
+    local rd=$1
+    local n=0
+    while read -r name; do
+        local flags
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null)
+        if [[ "$flags" != *"DISKLESS"* ]]; then
+            n=$((n + 1))
+        fi
+    done < <(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}')
+    echo "$n"
+}
+
+# wait_witness_count <rd> <want> [timeout] — poll until exactly $want
+# TIE_BREAKER witnesses exist for $rd, or timeout.
+wait_witness_count() {
+    local rd=$1 want=$2 timeout=${3:-$CONVERGE}
+    local deadline=$(( $(date +%s) + timeout ))
+    local got=""
+    while (( $(date +%s) < deadline )); do
+        got=$(tb_witness_count "$rd")
+        if [[ "$got" == "$want" ]]; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "FAIL: $rd witness count never reached $want (last=$got)" >&2
+    echo "  diskful=$(diskful_count "$rd") witness-on=$(tb_witness_nodes "$rd")" >&2
+    return 1
+}
+
+# ---- STEP 1: 2 diskful (w-1 + w-2), auto-TB on w-3 ----------------
+
+echo ">> create RD $RD with 2 diskful replicas on $N1, $N2 (auto-TB lands on $N3)"
+"${LCTL[@]}" resource-definition create "$RD"
+"${LCTL[@]}" volume-definition create "$RD" 64M
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool stand
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool stand
+
+echo ">> wait for both diskful replicas to reach UpToDate (<=180s)"
+wait_disk_state "$RD" "$N1" UpToDate 180 0
+wait_disk_state "$RD" "$N2" UpToDate 180 0
+
+echo ">> wait up to ${CONVERGE}s for the auto-TIE_BREAKER witness to land on $N3"
+if ! wait_witness_count "$RD" 1 "$CONVERGE"; then
+    echo "PRECONDITION FAILED: auto-TIE_BREAKER did not land"
+    echo "  diskful=$(diskful_count "$RD") witness-on=$(tb_witness_nodes "$RD")"
+    exit 1
+fi
+
+witness_node=$(tb_witness_nodes "$RD")
+if [[ "$witness_node" != "$N3" ]]; then
+    echo "PRECONDITION FAILED: auto-TIE_BREAKER landed on $witness_node, expected $N3"
+    exit 1
+fi
+echo "   step 1 OK: 2 diskful ($N1, $N2) + 1 auto-TIE_BREAKER on $N3"
+
+# ---- STEP 2: r d --keep-tiebreaker $N2 → witness MUST survive ------
+
+echo ">> linstor r d --keep-tiebreaker $N2 $RD (operator opt-in to keep the witness)"
+"${LCTL[@]}" resource delete --keep-tiebreaker "$N2" "$RD"
+
+# Sanity: diskful must reach 1 before we assert the keep behaviour.
+echo ">> wait up to ${CONVERGE}s for diskful to drop to 1"
+deadline=$(( $(date +%s) + CONVERGE ))
+df=""
+while (( $(date +%s) < deadline )); do
+    df=$(diskful_count "$RD")
+    if [[ "$df" == "1" ]]; then
+        break
+    fi
+    sleep 2
+done
+if [[ "$df" != "1" ]]; then
+    echo "FAIL: diskful never reached 1 after r d --keep-tiebreaker $N2 (last=$df)"
+    dump_diag
+    exit 1
+fi
+
+# Bug B.1 assert: across a 30s window the witness must NOT be reaped.
+# Without the fix, the controller hits the Bug-338 carve-out
+# (diskful=1, witness=1, no non-witness diskless) and removes the
+# witness within ~5s of the diskful drop.
+echo ">> stability tail: hold 30s, assert TIE_BREAKER witness on $N3 survives"
+deadline=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < deadline )); do
+    cur=$(tb_witness_count "$RD")
+    if [[ "$cur" != "1" ]]; then
+        echo "ASSERT FAILED (Bug B.1): TIE_BREAKER witness was reaped"
+        echo "  during 30s stability tail after r d --keep-tiebreaker"
+        echo "  (got=$cur on $(tb_witness_nodes "$RD"))"
+        echo "  diskful=$(diskful_count "$RD")"
+        echo "  expected: 1 diskful + 1 TIE_BREAKER witness on $N3 (operator opted in)"
+        exit 1
+    fi
+
+    # Also assert the witness stays on the original node — we should
+    # not be regenerating it elsewhere.
+    where=$(tb_witness_nodes "$RD")
+    if [[ "$where" != "$N3" ]]; then
+        echo "ASSERT FAILED: witness migrated from $N3 to $where during keep window"
+        exit 1
+    fi
+    sleep 2
+done
+
+# Sanity on the surviving witness flags — must be DISKLESS + TIE_BREAKER
+witness_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null)
+if [[ "$witness_flags" != *"DISKLESS"* ]] || [[ "$witness_flags" != *"TIE_BREAKER"* ]]; then
+    echo "ASSERT FAILED: surviving witness on $N3 has wrong flags: ${witness_flags}"
+    echo "  expected: both DISKLESS and TIE_BREAKER"
+    exit 1
+fi
+
+echo ">> step 2 OK: TIE_BREAKER witness on $N3 survived 30s after r d --keep-tiebreaker, flags=${witness_flags}"
+echo "PASS: --keep-tiebreaker preserved the auto-managed witness across the diskful=1 transition"


### PR DESCRIPTION
## Bug

`linstor r d --keep-tiebreaker <one-of-diskful> <rd>` on a 2-diskful + 1-witness shape silently reaped the auto-managed TIE_BREAKER witness right after the delete completed. Final topology was a solo diskful with NO witness — quorum=1, unprotected for ~5 min until `stampTiebreakerSuppression` expired.

The CLI flag documents itself as "Keeps the tiebreaker instead of accidentally deleting it. Also removes the RD property if necessary in order to keep the resource as a tiebreaker", but neither the REST DELETE handler nor the RD reconciler observed the operator intent.

Repro (hunt-v3 finding B.1, full evidence in `/tmp/bug-hunt3-B1-keep-tiebreaker-strips-witness.md` on the dev stand):

```
$L rd c hunt3-b1 -l drbd,storage
$L vd c hunt3-b1 100M
$L r c dev-worker-1 hunt3-b1 -s zfs-thin
$L r c dev-worker-2 hunt3-b1 -s zfs-thin
# state: w-1 diskful, w-2 diskful, w-3 auto-TIE_BREAKER
$L r d --keep-tiebreaker dev-worker-2 hunt3-b1
```

Controller log shows the carve-out reaping the witness:

```
ensureTiebreaker rd=hunt3-b1 replicas=2 diskful=1 witness=1 willCreate=false willRemove=true
```

## Root cause

`ensureTiebreaker` reasoned purely from on-disk topology. The `--keep-tiebreaker` intent from the REST `DELETE` request wasn't plumbed to the controller, so `shouldKeepExistingWitness` hit the Bug-338 carve-out (`diskful == 1 && nonWitnessDiskless == 0` ⇒ collapse) and removed the witness in the same reconcile that observed diskful drop from 2 to 1.

## Fix

Mirror the existing suppression-annotation pattern (`AutoTiebreakerSuppressedUntilAnnotation`):

- REST `handleResourceDelete` reads `?keep_tiebreaker=true` from the URL and stamps a new `KeepTiebreakerUntilAnnotation` (`blockstor.io/keep-tiebreaker-until`) on the parent RD with a fresh 5-minute RFC3339 deadline BEFORE committing the Resource Delete. Stamp lands first so any Reconcile woken by the Delete event observes both signals atomically.
- RD-side `shouldTieBreakerExist` now consults `isKeepTiebreakerActive` via a new `keepExistingWitnessFor` helper. When the annotation deadline is in the future AND at least one diskful peer survives, the existing witness is preserved regardless of the Bug-338 carve-out. The diskful floor matters because a lone witness with 0 diskful is 1 voter — strictly worse than no witness.
- Expired and unparseable values are treated as "no override", so a forgotten or hand-edited annotation can't permanently freeze the auto-quorum invariant. After 5 minutes the normal Bug-338 collapse path resumes with no manual cleanup.

## Tests

- `internal/controller/ensure_tiebreaker_test.go`:
  - `TestKeepTiebreakerAnnotation_HonoredWhileFresh` — 1 diskful + 1 witness with fresh annotation → witness preserved.
  - `TestKeepTiebreakerAnnotation_ExpiredFallsThrough` — same topology, expired annotation → Bug-338 collapse resumes; unparseable values also treated as "no override".
- `pkg/rest/autoplace_test.go`:
  - `TestResourceDeleteKeepTiebreakerStampsOverride` — `DELETE …?keep_tiebreaker=true` writes the annotation with a future RFC3339 deadline.
  - `TestResourceDeleteWithoutKeepTiebreakerSkipsOverride` — plain `DELETE …` does not stamp the override.
- `tests/e2e/keep-tiebreaker-3way.sh` — real-DRBD QEMU-stand regression catcher: 2 diskful + 1 auto-TB topology, `linstor r d --keep-tiebreaker`, assert the surviving TB stays for a 30s stability tail. Required by the TieBreaker-e2e-must-exist rule (this class re-regressed before: Bugs 104/108/267/271/338/342).

## Stand verification

Skipped — the dev stand was unreachable from this network at commit time. The unit + REST tests cover the wire path end-to-end (REST handler → store → reconciler decision), and the e2e script is ready to run on the QEMU stand once available.