### PR TITLE
fix(rest): validate explicit volume_number in [0, 65535] at wire

### DIFF
--- a/pkg/rest/api_call_rc.go
+++ b/pkg/rest/api_call_rc.go
@@ -278,6 +278,17 @@ const apiCallRcFailInUse int64 = 997
 // `--force`).
 const apiCallRcFailInvldVlmSize int64 = 206
 
+// apiCallRcFailInvldVlmNr mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_INVLD_VLM_NR` (205). Emitted by the Bug 363
+// volume-number-out-of-bounds refusal at `POST /v1/resource-
+// definitions/{rd}/volume-definitions` when the explicit
+// `volume_number` lies outside DRBD-9's addressable [0, 65535] range.
+// Choosing 205 (rather than a fresh sub-code in our 996+ range) keeps
+// the wire shape consistent with upstream LINSTOR's reply on the same
+// input — alongside FAIL_INVLD_VLM_SIZE (206) which already lives in
+// this file.
+const apiCallRcFailInvldVlmNr int64 = 205
+
 // apiCallRcFailExistsVlmDfn mirrors upstream LINSTOR's
 // `ApiConsts.FAIL_EXISTS_VLM_DFN` (502). Emitted by `POST
 // /v1/resource-definitions/{rd}/volume-definitions` when the

--- a/pkg/rest/volume_definitions.go
+++ b/pkg/rest/volume_definitions.go
@@ -282,19 +282,8 @@ func (s *Server) handleVDCreate(w http.ResponseWriter, r *http.Request) {
 
 	vd := envelope.VolumeDefinition
 
-	// Bug 191: distinguish "client omitted volume_number" (auto-assign)
-	// from "client sent volume_number=0" (explicit zero). The typed
-	// decode above can't tell them apart because the wire field is a
-	// plain int32 — both shapes deserialise to VolumeNumber=0.
-	if !vdCreateVolumeNumberExplicit(rawBody) {
-		assigned, assignErr := s.autoAssignVolumeNumber(r.Context(), rd)
-		if assignErr != nil {
-			writeStoreError(w, assignErr)
-
-			return
-		}
-
-		vd.VolumeNumber = assigned
+	if !s.resolveVolumeNumber(w, r, rd, rawBody, &vd) {
+		return
 	}
 
 	// Bug 155: refuse out-of-bounds sizes at the REST boundary so the
@@ -338,6 +327,49 @@ func (s *Server) handleVDCreate(w http.ResponseWriter, r *http.Request) {
 		RetCode: maskInfo,
 		Message: "volume definition created",
 	}})
+}
+
+// resolveVolumeNumber folds the auto-assign + explicit-VlmNr
+// validation branches out of handleVDCreate so the parent stays under
+// the funlen threshold. Returns true on success (vd.VolumeNumber is
+// populated and within bounds) and false when an envelope was already
+// written to w (the caller must return immediately).
+//
+// Bug 191: auto-assign fires when the raw POST body does NOT carry an
+// explicit `volume_number` key — Go's int32 zero would otherwise
+// silently collide with VlmNr=0 on the second `vd c` against the
+// same RD. Bug 363: when the caller DOES specify a volume_number, it
+// must lie inside DRBD-9's addressable [0, 65535] range; out-of-bound
+// values would otherwise hang the satellite in "waiting for DRBD-ID
+// allocation" because no positive minor can be derived from them.
+func (s *Server) resolveVolumeNumber(
+	w http.ResponseWriter,
+	r *http.Request,
+	rd string,
+	rawBody []byte,
+	vd *apiv1.VolumeDefinition,
+) bool {
+	if !vdCreateVolumeNumberExplicit(rawBody) {
+		assigned, assignErr := s.autoAssignVolumeNumber(r.Context(), rd)
+		if assignErr != nil {
+			writeStoreError(w, assignErr)
+
+			return false
+		}
+
+		vd.VolumeNumber = assigned
+
+		return true
+	}
+
+	nrErr := validateVolumeNumber(vd.VolumeNumber)
+	if nrErr != nil {
+		writeVDNumberRejection(w, rd, vd.VolumeNumber, nrErr)
+
+		return false
+	}
+
+	return true
 }
 
 // vdCreateVolumeNumberExplicit reports whether the raw POST body
@@ -450,6 +482,82 @@ const minVolumeDefinitionSizeKib int64 = 4 * 1024
 // operator a typed error envelope instead of an opaque satellite
 // retry loop.
 const maxVolumeDefinitionSizeKib int64 = 16 * 1024 * 1024 * 1024
+
+// minVolumeNumber is the smallest accepted explicit volume_number on
+// `POST /v1/resource-definitions/{rd}/volume-definitions` (Bug 363).
+// DRBD volume numbers are unsigned; the wire-side int32 was leaking
+// negative values straight through, leaving the satellite stuck in
+// "waiting for DRBD-ID allocation" because no positive minor can be
+// derived from a negative VlmNr.
+const minVolumeNumber int32 = 0
+
+// maxVolumeNumber is the largest accepted explicit volume_number (Bug
+// 363). DRBD-9 caps the per-resource volume namespace at 16 bits
+// (0..65535) — values above that fail at `drbdadm adjust` time with
+// "vol-XXXXX not addressable", which manifests as the same stuck
+// satellite "waiting for DRBD-ID allocation" symptom.
+const maxVolumeNumber int32 = 65535
+
+// ErrVolumeNumberBelowMinimum is the sentinel for the negative-VlmNr
+// rejection (volume_number < 0). Wrapped with %w + bound detail by
+// validateVolumeNumber; static-error requirement is err113.
+var ErrVolumeNumberBelowMinimum = errors.New("volume_number below minimum")
+
+// ErrVolumeNumberAboveMaximum is the sentinel for the out-of-range-
+// VlmNr rejection (volume_number > 65535). See
+// ErrVolumeNumberBelowMinimum for the rationale.
+var ErrVolumeNumberAboveMaximum = errors.New("volume_number above maximum")
+
+// validateVolumeNumber returns nil when the requested explicit
+// VolumeNumber is within DRBD-9's addressable range
+// [minVolumeNumber, maxVolumeNumber] (Bug 363). Otherwise it returns a
+// human-readable rejection reason the caller formats into the LINSTOR
+// envelope. The auto-assign path (no explicit volume_number in the
+// POST body) is always valid by construction and bypasses this gate.
+func validateVolumeNumber(vn int32) error {
+	if vn < minVolumeNumber {
+		return fmt.Errorf(
+			"%w: volume_number=%d below minimum %d (DRBD volume numbers are unsigned)",
+			ErrVolumeNumberBelowMinimum, vn, minVolumeNumber,
+		)
+	}
+
+	if vn > maxVolumeNumber {
+		return fmt.Errorf(
+			"%w: volume_number=%d above maximum %d (DRBD-9 caps the per-resource "+
+				"volume namespace at 16 bits)",
+			ErrVolumeNumberAboveMaximum, vn, maxVolumeNumber,
+		)
+	}
+
+	return nil
+}
+
+// writeVDNumberRejection emits the Bug 363 volume-number-out-of-bounds
+// refusal envelope. 400 + FAIL_INVLD_VLM_NR keeps the wire shape
+// consistent with the Bug 155 size-rejection path; the inner
+// cause/correction names the addressable range so the operator can
+// pick a fresh VlmNr without re-reading the spec.
+func writeVDNumberRejection(w http.ResponseWriter, rd string, vn int32, reason error) {
+	writeJSON(w, http.StatusBadRequest, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInvldVlmNr,
+		Message: fmt.Sprintf("invalid volume definition number for %q vlm=%d: %s",
+			rd, vn, reason.Error()),
+		Cause: fmt.Sprintf(
+			"volume_number must be in [%d, %d]; the satellite reconciler "+
+				"would hang in 'waiting for DRBD-ID allocation' otherwise",
+			minVolumeNumber, maxVolumeNumber,
+		),
+		Correc: fmt.Sprintf(
+			"pick a volume_number between %d and %d and re-issue `linstor vd c`",
+			minVolumeNumber, maxVolumeNumber,
+		),
+		ObjRefs: map[string]string{
+			objRefRscDfn: rd,
+			objRefVlmNr:  strconv.FormatInt(int64(vn), 10),
+		},
+	}})
+}
 
 // ErrVolumeSizeBelowMinimum is the sentinel for Bug 155's lower-bound
 // rejection (size_kib < minVolumeDefinitionSizeKib). Wrapped with

--- a/pkg/rest/volume_definitions_bug_363_test.go
+++ b/pkg/rest/volume_definitions_bug_363_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 363: `linstor vd c -n <out-of-bound>` (e.g. -1 or 100000) was
+// accepted by the REST surface, persisted in the store, and then hung
+// the satellite reconciler in
+//
+//	{"msg":"waiting for controller-side DRBD-ID allocation",
+//	 "resource":"<rd>.<node>","nodeID":0,"port":20000,"minor":null}
+//
+// indefinitely because no positive DRBD minor can be derived from a
+// negative VlmNr (and DRBD-9 caps the per-resource volume namespace at
+// 16 bits — values above 65535 trigger the same DRBD-ID stall).
+//
+// Reproduction on dev stand (HEAD 6f69c5678, 2026-06-01):
+// `vd c -n -1 <rd> 64M` returned SUCCESS; the follow-up `r c ... <rd>
+// --storage-pool stand` also returned SUCCESS; `r l -r <rd>` then
+// printed `Unknown` state forever while the satellite logged
+// `waiting for controller-side DRBD-ID allocation` indefinitely
+// (no positive minor can be derived from a negative VlmNr).
+//
+// Fix: validate explicit `volume_number` is in [0, 65535] at the REST
+// wire boundary, before any partial state lands. The auto-assign path
+// (no `-n` flag) is always valid by construction and bypasses the
+// gate.
+
+// TestBug363VDCreateRefusedOnNegativeVolumeNumber covers the headline
+// regression: `vd c -n -1 <rd>` must be refused with a 400 envelope,
+// no VD persisted.
+func TestBug363VDCreateRefusedOnNegativeVolumeNumber(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-bug363"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.VolumeDefinitionCreate{
+		VolumeDefinition: apiv1.VolumeDefinition{
+			VolumeNumber: -1,
+			SizeKib:      65536,
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/rd-bug363/volume-definitions", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400 for VlmNr=-1. Body: %s", resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	gotStr := string(got)
+
+	if !strings.Contains(gotStr, "below minimum") {
+		t.Errorf("envelope should name the rule (below minimum); got %s", gotStr)
+	}
+
+	// No VD persisted = no zombie RD entry.
+	vds, _ := st.VolumeDefinitions().List(ctx, "rd-bug363")
+	if len(vds) != 0 {
+		t.Errorf("VD must NOT be persisted on refusal; got %d entries", len(vds))
+	}
+}
+
+// TestBug363VDCreateRefusedOnOversizedVolumeNumber pins the upper
+// bound: `vd c -n 65536` and `vd c -n 100000` must both be refused.
+// Upstream DRBD-9 indexes volumes with a 16-bit field; anything above
+// 65535 trips the same satellite stall as a negative VlmNr.
+func TestBug363VDCreateRefusedOnOversizedVolumeNumber(t *testing.T) {
+	t.Parallel()
+
+	cases := []int32{65536, 100000, 2147483647}
+
+	for _, vn := range cases {
+		t.Run(strings.ReplaceAll(http.StatusText(int(vn%256)), " ", "-"), func(t *testing.T) {
+			t.Parallel()
+
+			st := store.NewInMemory()
+			ctx := t.Context()
+
+			if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-bug363-hi"}); err != nil {
+				t.Fatalf("seed RD: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			body, _ := json.Marshal(apiv1.VolumeDefinitionCreate{
+				VolumeDefinition: apiv1.VolumeDefinition{
+					VolumeNumber: vn,
+					SizeKib:      65536,
+				},
+			})
+
+			resp := httpPost(t, base+"/v1/resource-definitions/rd-bug363-hi/volume-definitions", body)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				got, _ := readAllBody(resp)
+				t.Fatalf("status: got %d, want 400 for VlmNr=%d. Body: %s",
+					resp.StatusCode, vn, got)
+			}
+
+			got, _ := readAllBody(resp)
+			gotStr := string(got)
+
+			if !strings.Contains(gotStr, "above maximum") {
+				t.Errorf("envelope should name the rule (above maximum) for VlmNr=%d; got %s",
+					vn, gotStr)
+			}
+
+			vds, _ := st.VolumeDefinitions().List(ctx, "rd-bug363-hi")
+			if len(vds) != 0 {
+				t.Errorf("VD must NOT be persisted on refusal for VlmNr=%d; got %d entries",
+					vn, len(vds))
+			}
+		})
+	}
+}
+
+// TestBug363VDCreateAcceptedAtBoundaries pins both bounds: VlmNr=0
+// (the auto-assign zero value, also the explicit lower bound) and
+// VlmNr=65535 (the DRBD-9 upper bound) must both be accepted. Guards
+// against the gate being one-off in either direction.
+func TestBug363VDCreateAcceptedAtBoundaries(t *testing.T) {
+	t.Parallel()
+
+	cases := []int32{0, 1, 65535}
+
+	for _, vn := range cases {
+		t.Run(http.StatusText(http.StatusOK), func(t *testing.T) {
+			t.Parallel()
+
+			st := store.NewInMemory()
+			ctx := t.Context()
+
+			if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-bug363-bnd"}); err != nil {
+				t.Fatalf("seed RD: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			body, _ := json.Marshal(apiv1.VolumeDefinitionCreate{
+				VolumeDefinition: apiv1.VolumeDefinition{
+					VolumeNumber: vn,
+					SizeKib:      65536,
+				},
+			})
+
+			resp := httpPost(t, base+"/v1/resource-definitions/rd-bug363-bnd/volume-definitions", body)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				got, _ := readAllBody(resp)
+				t.Fatalf("status: got %d, want 200 for VlmNr=%d. Body: %s",
+					resp.StatusCode, vn, got)
+			}
+		})
+	}
+}
+
+// TestBug363VDCreateAutoAssignBypassesGate covers the Bug 191 happy
+// path: when the body omits `volume_number`, the auto-assign branch
+// fires and the gate is bypassed entirely (the assigned value is
+// guaranteed to be in range by construction).
+func TestBug363VDCreateAutoAssignBypassesGate(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-bug363-auto"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Bare body without `volume_number` field — Bug 191 wire shape.
+	body := []byte(`{"volume_definition":{"size_kib":65536}}`)
+
+	resp := httpPost(t, base+"/v1/resource-definitions/rd-bug363-auto/volume-definitions", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 200. Body: %s", resp.StatusCode, got)
+	}
+
+	vds, _ := st.VolumeDefinitions().List(ctx, "rd-bug363-auto")
+	if len(vds) != 1 {
+		t.Fatalf("want 1 VD, got %d", len(vds))
+	}
+
+	if vds[0].VolumeNumber != 0 {
+		t.Errorf("auto-assign on empty RD should pick VlmNr=0, got %d", vds[0].VolumeNumber)
+	}
+}

--- a/tests/e2e/vd-volume-number-validation.sh
+++ b/tests/e2e/vd-volume-number-validation.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# usage: vd-volume-number-validation.sh WORK_DIR
+#
+# Bug 363 (hunt-v4) regression catcher: an explicit `volume_number`
+# outside DRBD-9's addressable [0, 65535] range slipped past the
+# wire-side decode and persisted in the store. The follow-up `r c`
+# succeeded too, but the satellite reconciler then hung in
+#
+#   waiting for controller-side DRBD-ID allocation
+#     resource=<rd>.<node> nodeID=0 port=20000 minor=null
+#
+# indefinitely because no positive minor can be derived from a
+# negative VlmNr (and DRBD-9 caps the per-resource volume namespace
+# at 16 bits — values above 65535 trigger the same stall).
+#
+# Reproduction on dev stand (HEAD 6f69c5678, 2026-06-01):
+#
+#   $ linstor vd c -n -1 probe-bug363 64M
+#   SUCCESS: volume definition created
+#   $ linstor r c dev-worker-1 probe-bug363 --storage-pool stand
+#   SUCCESS: resource(s) created on resource-definition: probe-bug363
+#   $ linstor r l -r probe-bug363
+#     probe-bug363 | dev-worker-1 | DRBD,STORAGE | Unused | | Unknown
+#
+# Fix: validate explicit volume_number is in [0, 65535] at the REST
+# wire boundary, before any partial state lands.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+NS=${NS:-blockstor-system}
+
+require_workers 1
+
+# ---- port-forward the apiserver ----
+
+LPORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "${LPORT}:3370" >/dev/null 2>&1 &
+PF_PID=$!
+_wait_port_forward "$LPORT" "$PF_PID" || {
+    echo "FAIL: could not port-forward apiserver"
+    exit 1
+}
+
+RD=e2e-bug363-rd
+
+cleanup() {
+    set +e
+    kill "$PF_PID" 2>/dev/null || true
+    delete_rd "$RD" 2>/dev/null || true
+    set -e
+}
+trap cleanup EXIT
+
+API="http://127.0.0.1:${LPORT}"
+
+echo ">> seed RD $RD"
+kubectl apply -f - >/dev/null <<EOF
+apiVersion: blockstor.cozystack.io/v1alpha1
+kind: ResourceDefinition
+metadata: {name: ${RD}}
+spec: {}
+EOF
+
+# assert_reject VLMNR DESC
+#   POST vd-create with `volume_number=VLMNR`; expect 400 envelope
+#   that names the rule. Asserts no VD landed in the store.
+assert_reject() {
+    local vn=$1 desc=$2
+    local code body_file body
+    body_file=$(mktemp)
+
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+        -X POST -H 'Content-Type: application/json' \
+        "${API}/v1/resource-definitions/${RD}/volume-definitions" \
+        -d "{\"volume_definition\":{\"volume_number\":${vn},\"size_kib\":65536}}" || echo "000")
+
+    body=$(cat "$body_file")
+    rm -f "$body_file"
+
+    if [[ "$code" -ne 400 ]]; then
+        echo "FAIL: $desc — expected 400, got HTTP $code"
+        echo "$body"
+        return 1
+    fi
+
+    if ! grep -qE 'minimum|maximum' <<<"$body"; then
+        echo "FAIL: $desc — envelope must name the rule (minimum/maximum); got:"
+        echo "$body"
+        return 1
+    fi
+
+    echo "   ok: $desc refused (HTTP $code)"
+}
+
+# assert_accept VLMNR DESC
+#   POST vd-create with `volume_number=VLMNR`; expect 200. Removes
+#   the VD afterwards so subsequent asserts can reuse the parent RD.
+assert_accept() {
+    local vn=$1 desc=$2
+    local code body_file body
+    body_file=$(mktemp)
+
+    code=$(curl -sS -o "$body_file" -w "%{http_code}" \
+        -X POST -H 'Content-Type: application/json' \
+        "${API}/v1/resource-definitions/${RD}/volume-definitions" \
+        -d "{\"volume_definition\":{\"volume_number\":${vn},\"size_kib\":65536}}" || echo "000")
+
+    body=$(cat "$body_file")
+    rm -f "$body_file"
+
+    if [[ "$code" -ne 200 ]]; then
+        echo "FAIL: $desc — expected 200, got HTTP $code"
+        echo "$body"
+        return 1
+    fi
+
+    # Drop the VD so the next assert can reuse the RD.
+    curl -sS -X DELETE \
+        "${API}/v1/resource-definitions/${RD}/volume-definitions/${vn}" >/dev/null
+
+    echo "   ok: $desc accepted (HTTP $code)"
+}
+
+echo ">> Bug 363: refuse VlmNr outside DRBD-9 [0, 65535]"
+assert_reject -1         "VlmNr=-1 (signed-int32 leak)"
+assert_reject 65536      "VlmNr=65536 (above DRBD-9 16-bit cap)"
+assert_reject 100000     "VlmNr=100000"
+assert_reject 2147483647 "VlmNr=int32-max"
+
+echo ">> Bug 363: accept VlmNr at the [0, 65535] boundaries"
+assert_accept 0     "VlmNr=0"
+assert_accept 1     "VlmNr=1"
+assert_accept 65535 "VlmNr=65535 (upper boundary)"
+
+echo ">> BUG-363 OK: explicit volume_number is gated at the wire"


### PR DESCRIPTION
## Bug 363 (hunt-v4)

`linstor vd c -n <out-of-bound>` was accepted by the REST surface, persisted in the store, and the follow-up `r c` also returned SUCCESS — but the satellite reconciler then hung indefinitely in:

```
{"msg":"waiting for controller-side DRBD-ID allocation",
 "resource":"<rd>.<node>","nodeID":0,"port":20000,"minor":null}
```

because no positive DRBD minor can be derived from a negative VlmNr (DRBD-9 caps the per-resource volume namespace at 16 bits, so values above 65535 trigger the same stall).

### Reproduction on dev stand (HEAD `6f69c5678`)

```
$ linstor vd c -n -1 probe-bug363 64M
SUCCESS: volume definition created
$ linstor r c dev-worker-1 probe-bug363 --storage-pool stand
SUCCESS: resource(s) created on resource-definition: probe-bug363
$ linstor r l -r probe-bug363
  probe-bug363 | dev-worker-1 | DRBD,STORAGE | Unused | | Unknown
```

### Fix

Validate explicit `volume_number` is in [0, 65535] at the REST wire boundary before any partial state lands. The auto-assign path (Bug 191, no `-n` flag) is always valid by construction and bypasses the gate. Uses `FAIL_INVLD_VLM_NR` (205) — wire-compatible with upstream LINSTOR's catalogue, alongside the existing `FAIL_INVLD_VLM_SIZE` (206).

### Tests

- Unit: `pkg/rest/volume_definitions_bug_363_test.go` — refusal matrix [-1, 65536, 100000, int32-max], [0, 1, 65535] boundary acceptance, auto-assign bypass.
- E2E: `tests/e2e/vd-volume-number-validation.sh` — drives the live REST surface against the dev stand. Verified locally on the dev stand.