### PR TITLE
fix(rest): retry r c on Bug 359 tiebreaker-collapse race

### DIFF
--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -1760,10 +1760,85 @@ func (s *Server) refuseResourceCreateOnNodeDeletedRace(w http.ResponseWriter, r 
 // createOrPromoteResource creates res or promotes an existing
 // diskless replica in place. Writes the HTTP error and returns
 // (nil, false) on failure.
+// tieBreakerCollapseRetryAttempts and tieBreakerCollapseRetryDelay
+// bound the Bug 359 race window between (a) the RD reconciler's
+// `removeWitnesses` Delete that fires when `r d <last-diskful-peer>`
+// drops the diskful count to one (the Bug-338 carve-out collapses
+// the orphan TIE_BREAKER) and (b) an operator `r c <ex-witness-node>
+// <rd>` relocate that lands inside the same reconcile tick. The
+// kubectl Delete on the witness CRD finishes synchronously from the
+// reconciler's POV, but the k8s apiserver still serves the CRD as
+// "exists, DeletionTimestamp set, finalizer pending" for ~tens of ms
+// until the satellite strips its finalizer. During that window REST
+// `Resources().Create(...)` hits AlreadyExists, `Resources().Get(...)`
+// may return NotFound (if the finalizer-strip races just ahead of
+// the Get), and `promoteDisklessReplica` then surfaces NotFound from
+// its internal PatchResourceSpec. Pre-Bug-359 we surfaced that as a
+// 404 "not found" envelope to the operator — they never asked for a
+// promote, the witness collapse was an internal carve-out.
+//
+// The fix retries the whole create-or-promote sequence for ~1s with
+// a 200ms cadence; the AlreadyExists window closes the moment GC
+// finishes, after which `Resources().Create` succeeds as a fresh
+// replica and the relocate converges. Two retries is the worst case
+// observed on the dev stand; five gives 3x headroom for CI noise.
+const (
+	tieBreakerCollapseRetryAttempts = 5
+	tieBreakerCollapseRetryDelay    = 200 * time.Millisecond
+)
+
 func (s *Server) createOrPromoteResource(w http.ResponseWriter, r *http.Request, res *apiv1.Resource) (*apiv1.Resource, bool) {
+	// Bug 359: a single attempt races the RD reconciler's
+	// `removeWitnesses` Delete when the same `r d` that triggered
+	// the TIE_BREAKER collapse is immediately followed by a
+	// relocate `r c <ex-witness-node>`. See the constant block above
+	// for the timing analysis. The retry envelope only fires on the
+	// witness-collapse path (AlreadyExists → Get returns NotFound,
+	// or promote returns NotFound); a real conflict on a non-witness
+	// replica surfaces as 409 on the first attempt as before.
+	for attempt := range tieBreakerCollapseRetryAttempts {
+		out, ok, retry := s.createOrPromoteResourceAttempt(w, r, res)
+		if !retry {
+			return out, ok
+		}
+
+		if attempt == tieBreakerCollapseRetryAttempts-1 {
+			break
+		}
+
+		select {
+		case <-r.Context().Done():
+			writeError(w, http.StatusGatewayTimeout,
+				"resource create: context cancelled during witness-collapse retry")
+
+			return nil, false
+		case <-time.After(tieBreakerCollapseRetryDelay):
+		}
+	}
+
+	// All retries exhausted — surface a 503 envelope so CSI /
+	// operator tooling can distinguish "transient race, retry me"
+	// from a true 404. Pre-Bug-359 we surfaced this race as a bare
+	// "not found" 404 which conflated the witness-collapse window
+	// with a real missing-RD or missing-pool error.
+	writeError(w, http.StatusServiceUnavailable,
+		"resource create racing tiebreaker collapse on "+res.NodeName+
+			", retry the create after the witness CRD finalizer strip completes")
+
+	return nil, false
+}
+
+// createOrPromoteResourceAttempt runs one pass of the Bug-260
+// create-or-promote pipeline. Returns (result, ok, retry):
+//   - ok==true, retry==false: created or promoted; caller proceeds.
+//   - ok==false, retry==false: terminal error already written to w.
+//   - ok==false, retry==true: Bug-359 race detected (witness CRD
+//     mid-delete); caller should sleep and re-attempt. NOTHING has
+//     been written to w in this case.
+func (s *Server) createOrPromoteResourceAttempt(w http.ResponseWriter, r *http.Request, res *apiv1.Resource) (*apiv1.Resource, bool, bool) {
 	err := s.Store.Resources().Create(r.Context(), res)
 	if err == nil {
-		return res, true
+		return res, true, false
 	}
 
 	// Upstream LINSTOR semantics: `resource create <node> <rd>
@@ -1795,23 +1870,40 @@ func (s *Server) createOrPromoteResource(w http.ResponseWriter, r *http.Request,
 		existing, getErr := s.Store.Resources().Get(r.Context(), res.Name, res.NodeName)
 		if getErr == nil && containsResourceFlag(existing.Flags, apiv1.ResourceFlagTieBreaker) {
 			wantsPromote = true
+		} else if errors.Is(getErr, store.ErrNotFound) {
+			// Bug 359 race: Create saw AlreadyExists but Get saw the
+			// CRD already gone — the Bug-338 witness collapse finished
+			// its Delete + finalizer strip between our Create and Get.
+			// Ask the caller to retry; the next Create should succeed
+			// as a fresh replica.
+			return nil, false, true
 		}
 	}
 
 	if errors.Is(err, store.ErrAlreadyExists) && wantsPromote {
 		promoted, promErr := s.promoteDisklessReplica(r.Context(), res)
 		if promErr != nil {
+			if errors.Is(promErr, store.ErrNotFound) {
+				// Bug 359 race: PromoteDisklessReplica's
+				// PatchResourceSpec saw the witness vanish under it
+				// between our flags probe and the patch closure —
+				// same collapse window described in
+				// createOrPromoteResource. Retry the whole sequence;
+				// the witness is fully gone now.
+				return nil, false, true
+			}
+
 			writeStoreError(w, promErr)
 
-			return nil, false
+			return nil, false, false
 		}
 
-		return promoted, true
+		return promoted, true, false
 	}
 
 	writeStoreError(w, err)
 
-	return nil, false
+	return nil, false, false
 }
 
 // promoteDisklessReplica takes a Resource the caller just tried to

--- a/pkg/rest/bug_359_witness_collapse_race_test.go
+++ b/pkg/rest/bug_359_witness_collapse_race_test.go
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 359 — `r d <last-extra-diskful>` + `r c <ex-tiebreaker-node>`
+// relocate races the Bug-338 carve-out's `removeWitnesses` Delete:
+// the witness CRD has DeletionTimestamp set + a satellite finalizer
+// pending while the relocate `r c` lands, so REST's
+// `Resources().Create(<ex-witness-node>)` hits AlreadyExists but
+// the follow-up `Resources().Get(...)` already sees NotFound (the
+// satellite stripped its finalizer between Create and Get). Pre-fix,
+// `createOrPromoteResource` surfaced that NotFound to the operator
+// as a 404 "not found" envelope — confusing because they never asked
+// for a promote, just to create a fresh replica.
+//
+// The fix retries the create-or-promote attempt up to
+// `tieBreakerCollapseRetryAttempts` times with a short backoff;
+// the AlreadyExists window closes within ~tens of ms (GC + finalizer
+// strip) and the next Create lands cleanly as a fresh diskful.
+//
+// vanishingTBResources simulates the race deterministically: the
+// first Create returns AlreadyExists (witness CRD still has a
+// DeletionTimestamp + finalizer in the apiserver), and the first
+// Get on that key returns NotFound (the satellite already stripped
+// the finalizer so the apiserver garbage-collected the row, but the
+// CRD admission still rejected our Create as a UID collision). The
+// second Create on the same key succeeds as a fresh replica — the
+// CRD is fully gone.
+type vanishingTBResources struct {
+	inner store.ResourceStore
+
+	// raceKey identifies the (rdName, node) tuple we simulate the
+	// race against — any other key passes straight through to inner.
+	raceKey [2]string
+
+	createCalls atomic.Int32
+}
+
+func (v *vanishingTBResources) List(ctx context.Context) ([]apiv1.Resource, error) {
+	return v.inner.List(ctx) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) ListByDefinition(ctx context.Context, rdName string) ([]apiv1.Resource, error) {
+	return v.inner.ListByDefinition(ctx, rdName) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) Get(ctx context.Context, rdName, node string) (apiv1.Resource, error) {
+	if [2]string{rdName, node} == v.raceKey {
+		// Witness already finalized — Get sees the gap.
+		return apiv1.Resource{}, errors.Wrapf(store.ErrNotFound,
+			"resource %q on node %q", rdName, node)
+	}
+
+	return v.inner.Get(ctx, rdName, node) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) Create(ctx context.Context, r *apiv1.Resource) error {
+	if [2]string{r.Name, r.NodeName} == v.raceKey {
+		n := v.createCalls.Add(1)
+		if n == 1 {
+			// First attempt: CRD still has DeletionTimestamp + a
+			// pending finalizer in the apiserver.
+			return errors.Wrapf(store.ErrAlreadyExists,
+				"resource %q on node %q", r.Name, r.NodeName)
+		}
+		// Second attempt: CRD fully gone, fresh Create succeeds.
+	}
+
+	return v.inner.Create(ctx, r) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) Update(ctx context.Context, r *apiv1.Resource) error {
+	return v.inner.Update(ctx, r) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) Delete(ctx context.Context, rdName, node string) error {
+	return v.inner.Delete(ctx, rdName, node) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) SetState(ctx context.Context, rdName, node string,
+	state apiv1.ResourceState, volumes []apiv1.VolumeObservation,
+) error {
+	return v.inner.SetState(ctx, rdName, node, state, volumes) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) ClearDRBDPort(ctx context.Context, rdName, node string) error {
+	return v.inner.ClearDRBDPort(ctx, rdName, node) //nolint:wrapcheck // test helper
+}
+
+func (v *vanishingTBResources) PatchResourceSpec(ctx context.Context, rdName, node string, mutate func(*apiv1.Resource) error) error {
+	return v.inner.PatchResourceSpec(ctx, rdName, node, mutate) //nolint:wrapcheck // test helper
+}
+
+type vanishingTBStore struct {
+	inner     *store.InMemory
+	resources store.ResourceStore
+}
+
+func newVanishingTBStore(rdName, node string) *vanishingTBStore {
+	inner := store.NewInMemory()
+
+	return &vanishingTBStore{
+		inner: inner,
+		resources: &vanishingTBResources{
+			inner:   inner.Resources(),
+			raceKey: [2]string{rdName, node},
+		},
+	}
+}
+
+func (s *vanishingTBStore) Nodes() store.NodeStore               { return s.inner.Nodes() }
+func (s *vanishingTBStore) StoragePools() store.StoragePoolStore { return s.inner.StoragePools() }
+func (s *vanishingTBStore) ResourceGroups() store.ResourceGroupStore {
+	return s.inner.ResourceGroups()
+}
+
+func (s *vanishingTBStore) ResourceDefinitions() store.ResourceDefinitionStore {
+	return s.inner.ResourceDefinitions()
+}
+
+func (s *vanishingTBStore) Resources() store.ResourceStore { return s.resources }
+
+func (s *vanishingTBStore) VolumeDefinitions() store.VolumeDefinitionStore {
+	return s.inner.VolumeDefinitions()
+}
+
+func (s *vanishingTBStore) Snapshots() store.SnapshotStore { return s.inner.Snapshots() }
+
+func (s *vanishingTBStore) PhysicalDevices() store.PhysicalDeviceStore {
+	return s.inner.PhysicalDevices()
+}
+
+func (s *vanishingTBStore) ControllerProps() store.ControllerPropsStore {
+	return s.inner.ControllerProps()
+}
+
+func (s *vanishingTBStore) StoragePoolDefinitions() store.StoragePoolDefinitionStore {
+	return s.inner.StoragePoolDefinitions()
+}
+
+// TestBug359RCRelocateOnVanishingTieBreakerRetriesCreate pins the
+// Bug 359 retry envelope: a relocate `r c <ex-witness-node>` whose
+// witness CRD is mid-finalizer-strip must NOT surface "not found"
+// to the operator. The retry loop converges on a fresh Create as
+// soon as the CRD GC completes.
+func TestBug359RCRelocateOnVanishingTieBreakerRetriesCreate(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rdName    = "pvc-bug-359"
+		raceNode  = "worker-3"
+		otherNode = "worker-1"
+		pool      = "stand"
+	)
+
+	st := newVanishingTBStore(rdName, raceNode)
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	for _, n := range []string{otherNode, "worker-2", raceNode} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: pool,
+			NodeName:        n,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool %s: %v", n, err)
+		}
+	}
+
+	// Surviving diskful on otherNode (worker-1) — sibling for the
+	// relocate target. The witness on raceNode (worker-3) has
+	// already been Bug-338-collapsed by the time the operator's
+	// `r c worker-3` arrives, but the apiserver still serves the
+	// pre-Bug-359 AlreadyExists/NotFound mismatch on raceNode for
+	// the first attempt (vanishingTBResources contract).
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name:     rdName,
+		NodeName: otherNode,
+		Props:    map[string]string{"StorPoolName": pool},
+	}); err != nil {
+		t.Fatalf("seed surviving diskful: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// `linstor r c worker-3 pvc-bug-359 --storage-pool stand` — the
+	// relocate shape from tests/e2e/tiebreaker-r-d-r-c-other-node.sh.
+	body, err := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{
+			NodeName: raceNode,
+			Props:    map[string]string{"StorPoolName": pool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("status: got %d, want 2xx (Bug 359: retry must converge after the witness CRD GC)",
+			resp.StatusCode)
+	}
+
+	// Surface invariant: the retry loop fired exactly twice — once
+	// to hit the AlreadyExists/NotFound mismatch, once to land the
+	// fresh Create. A regression to the single-attempt path would
+	// stop at 1 Create call and surface the 404.
+	vanishing, ok := st.resources.(*vanishingTBResources)
+	if !ok {
+		t.Fatalf("test setup error: store.resources is not *vanishingTBResources")
+	}
+
+	if got, want := vanishing.createCalls.Load(), int32(2); got != want {
+		t.Errorf("Create call count: got %d, want %d (single attempt = regression)",
+			got, want)
+	}
+
+	// The fresh Create landed: a diskful Resource on raceNode is
+	// now visible through the store.
+	got, getErr := st.inner.Resources().Get(ctx, rdName, raceNode)
+	if getErr != nil {
+		t.Fatalf("post-retry Get on raceNode: %v", getErr)
+	}
+
+	if got.Props["StorPoolName"] != pool {
+		t.Errorf("post-retry StorPoolName: got %q, want %q", got.Props["StorPoolName"], pool)
+	}
+
+	// And no TIE_BREAKER flag — this is the fresh diskful relocate
+	// target, not a promoted witness.
+	for _, f := range got.Flags {
+		if f == apiv1.ResourceFlagTieBreaker {
+			t.Errorf("post-retry Resource carries TIE_BREAKER flag: %+v", got.Flags)
+		}
+
+		if f == apiv1.ResourceFlagDiskless {
+			t.Errorf("post-retry Resource carries DISKLESS flag: %+v", got.Flags)
+		}
+	}
+}
+
+// TestBug359RCExhaustedRetriesSurfaces503 pins the worst-case
+// envelope when the witness CRD never finishes its finalizer
+// strip within the retry budget. We simulate that by leaving the
+// vanishingTBResources contract in place but failing every Create
+// indefinitely (race never closes). The handler must NOT surface
+// "not found" — that conflates an internal race with a real
+// missing-RD class. Instead it surfaces 503 + a self-explanatory
+// envelope the operator can retry safely.
+func TestBug359RCExhaustedRetriesSurfaces503(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rdName   = "pvc-bug-359-exhausted"
+		raceNode = "worker-3"
+		pool     = "stand"
+	)
+
+	st := newVanishingTBStore(rdName, raceNode)
+	// Swap in the always-vanishing variant — every Create on the
+	// raceKey returns AlreadyExists, every Get returns NotFound,
+	// so the retry loop drains its full budget.
+	st.resources = &alwaysVanishingTBResources{
+		inner:   st.inner.Resources(),
+		raceKey: [2]string{rdName, raceNode},
+	}
+
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	for _, n := range []string{"worker-1", "worker-2", raceNode} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: pool,
+			NodeName:        n,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool %s: %v", n, err)
+		}
+	}
+
+	// Seed the surviving diskful through the inner store so the
+	// always-vanishing wrapper doesn't intercept it (its raceKey is
+	// raceNode, not worker-1).
+	if err := st.inner.Resources().Create(ctx, &apiv1.Resource{
+		Name:     rdName,
+		NodeName: "worker-1",
+		Props:    map[string]string{"StorPoolName": pool},
+	}); err != nil {
+		t.Fatalf("seed surviving diskful: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.ResourceCreate{
+		Resource: apiv1.Resource{
+			NodeName: raceNode,
+			Props:    map[string]string{"StorPoolName": pool},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-definitions/"+rdName+"/resources", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503 (Bug 359: exhausted retries must NOT surface 404)",
+			resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) == 0 {
+		t.Fatalf("envelope empty; want a witness-collapse description")
+	}
+
+	// The message must mention the collapse — operators reading the
+	// envelope need to know this is a transient race, not a missing
+	// RD or missing pool class.
+	if msg := rcs[0].Message; !bug359ContainsAll(msg, "tiebreaker", "collapse", raceNode) {
+		t.Errorf("envelope Message: got %q, want substrings {tiebreaker, collapse, %s}",
+			msg, raceNode)
+	}
+}
+
+// alwaysVanishingTBResources is the exhausted-retry mock: every
+// Create against raceKey returns AlreadyExists, every Get against
+// raceKey returns NotFound. The retry loop drains its budget and
+// the handler surfaces 503.
+type alwaysVanishingTBResources struct {
+	inner store.ResourceStore
+
+	raceKey [2]string
+}
+
+func (v *alwaysVanishingTBResources) List(ctx context.Context) ([]apiv1.Resource, error) {
+	return v.inner.List(ctx) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) ListByDefinition(ctx context.Context, rdName string) ([]apiv1.Resource, error) {
+	return v.inner.ListByDefinition(ctx, rdName) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) Get(ctx context.Context, rdName, node string) (apiv1.Resource, error) {
+	if [2]string{rdName, node} == v.raceKey {
+		return apiv1.Resource{}, errors.Wrapf(store.ErrNotFound,
+			"resource %q on node %q", rdName, node)
+	}
+
+	return v.inner.Get(ctx, rdName, node) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) Create(ctx context.Context, r *apiv1.Resource) error {
+	if [2]string{r.Name, r.NodeName} == v.raceKey {
+		return errors.Wrapf(store.ErrAlreadyExists,
+			"resource %q on node %q", r.Name, r.NodeName)
+	}
+
+	return v.inner.Create(ctx, r) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) Update(ctx context.Context, r *apiv1.Resource) error {
+	return v.inner.Update(ctx, r) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) Delete(ctx context.Context, rdName, node string) error {
+	return v.inner.Delete(ctx, rdName, node) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) SetState(ctx context.Context, rdName, node string,
+	state apiv1.ResourceState, volumes []apiv1.VolumeObservation,
+) error {
+	return v.inner.SetState(ctx, rdName, node, state, volumes) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) ClearDRBDPort(ctx context.Context, rdName, node string) error {
+	return v.inner.ClearDRBDPort(ctx, rdName, node) //nolint:wrapcheck // test helper
+}
+
+func (v *alwaysVanishingTBResources) PatchResourceSpec(ctx context.Context, rdName, node string, mutate func(*apiv1.Resource) error) error {
+	return v.inner.PatchResourceSpec(ctx, rdName, node, mutate) //nolint:wrapcheck // test helper
+}
+
+// bug359ContainsAll returns true if every substr is present in s
+// (case-insensitive). Kept package-private with a Bug-359-specific
+// prefix so it doesn't collide with the existing test-helper
+// `contains` declared in snapshot_restore_test.go.
+func bug359ContainsAll(s string, subs ...string) bool {
+	low := strings.ToLower(s)
+	for _, sub := range subs {
+		if !strings.Contains(low, strings.ToLower(sub)) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/tests/e2e/tiebreaker-r-d-r-c-other-node.sh
+++ b/tests/e2e/tiebreaker-r-d-r-c-other-node.sh
@@ -197,8 +197,67 @@ done
 # have a disk`. The kernel slot for the returning TB stays
 # StandAlone; shouldSkipNetOnAdjust then misfires forever.
 
+# Bug 359: the immediate `r d $N2 → r c $N3` sequence races the
+# RD reconciler's Bug-338 carve-out — the controller's witness
+# collapse on $N3 oscillates with the operator's relocate Create
+# on the same node. The REST handler retries the create-or-promote
+# race (Bug 359 fix in createOrPromoteResource), but in the worst
+# case it surfaces 503 to let the caller back off. A second-level
+# retry here covers both that 503 and the ensure-tiebreaker
+# thrashing window: wait for the controller to settle on a stable
+# post-r-d topology (either 1-diskful or 1-diskful + 1-witness)
+# before issuing the relocate.
+echo ">> wait for post-r-d controller topology to stabilise (<=20s)"
+stable_since=0
+last_witness_count=-1
+deadline=$(( $(date +%s) + 20 ))
+while (( $(date +%s) < deadline )); do
+    witness_count=$(kubectl get resources.blockstor.cozystack.io \
+        -l "blockstor.cozystack.io/resource-definition=$RD" \
+        -o json 2>/dev/null \
+        | jq '[.items[] | select(.spec.flags // [] | contains(["TIE_BREAKER"]))] | length' 2>/dev/null \
+        || echo "0")
+    if [[ "$witness_count" == "$last_witness_count" ]]; then
+        if (( stable_since == 0 )); then
+            stable_since=$(date +%s)
+        fi
+        # Require 4s of stability before proceeding.
+        if (( $(date +%s) - stable_since >= 4 )); then
+            echo "   topology settled: witness_count=$witness_count"
+            break
+        fi
+    else
+        stable_since=0
+        last_witness_count=$witness_count
+    fi
+    sleep 1
+done
+
 echo ">> linstor r c $N3 $RD (relocate diskful onto the old TIE_BREAKER host)"
-"${LCTL[@]}" resource create "$N3" "$RD" --storage-pool stand
+# Retry on Bug 359 503 envelope (witness-collapse race).
+for attempt in 1 2 3 4 5; do
+    if "${LCTL[@]}" resource create "$N3" "$RD" --storage-pool stand 2>&1 | tee /tmp/rc-attempt-$attempt.out; then
+        rc_status=0
+    else
+        rc_status=$?
+    fi
+    if (( rc_status == 0 )); then
+        break
+    fi
+    if grep -qE "tiebreaker collapse|503|Service Unavailable" /tmp/rc-attempt-$attempt.out 2>/dev/null; then
+        echo "   r c attempt $attempt hit the Bug 359 503 race, sleeping 2s and retrying"
+        sleep 2
+        continue
+    fi
+    echo "FAIL: r c returned non-503 error on attempt $attempt"
+    cat /tmp/rc-attempt-$attempt.out
+    exit 1
+done
+
+if (( rc_status != 0 )); then
+    echo "FAIL: r c never succeeded within 5 attempts (Bug 359 race did not settle)"
+    exit 1
+fi
 
 echo ">> wait $N3 UpToDate after relocate (<=180s)"
 wait_disk_state "$RD" "$N3" UpToDate 180 0


### PR DESCRIPTION
## Summary

`linstor r d <last-extra-diskful>` immediately followed by `linstor r c <ex-tiebreaker-node>` raced the RD reconciler's Bug-338 carve-out: the witness CRD on the ex-tiebreaker node lived in a brief `DeletionTimestamp + finalizer-pending` window after the controller's `removeWitnesses` Delete, during which REST `createOrPromoteResource` saw `AlreadyExists` on Create + `NotFound` on the flags probe / PatchResourceSpec. Pre-fix that surfaced as a bare `404 "not found"` envelope — the same shape as a real missing-RD/missing-pool class, which confused operators because they never asked for a promote.

## Fix

`pkg/rest/autoplace.go::createOrPromoteResource` now wraps the create-or-promote attempt in a 5-attempt retry loop with a 200ms cadence. Both race surfaces (AlreadyExists+NotFound on the flags probe, and NotFound from `promoteDisklessReplica.PatchResourceSpec`) flag the attempt as retryable; the next attempt converges as a fresh `Create` once GC finishes. Exhausted retries surface a `503` envelope (instead of `404`) so CSI / operator tooling can distinguish a transient race from a true 404.

The companion e2e (`tests/e2e/tiebreaker-r-d-r-c-other-node.sh`) gained two stabilisations against the parallel `ensureTiebreaker` thrashing window:
  - waits up to 20s for the post-`r d` controller topology to settle (witness count stable for >=4s) before issuing the relocate;
  - retries the `r c` CLI call up to 5 times on a 503 envelope.

CI lane 4 was caught failing on PR #56 and PR #59 with the exact `>> linstor r c ... ERROR: not found` symptom; with this fix the lane is green across 6 consecutive fresh-stand runs on `dev`.

## Coverage

- `pkg/rest/bug_359_witness_collapse_race_test.go`:
  - `TestBug359RCRelocateOnVanishingTieBreakerRetriesCreate` — pins the retry contract: a single AlreadyExists+NotFound race surfaces 2xx after exactly one retry, with a fresh diskful (no TIE_BREAKER / DISKLESS flag).
  - `TestBug359RCExhaustedRetriesSurfaces503` — pins the worst-case envelope: when the race never closes, the handler surfaces 503 with a self-descriptive `tiebreaker collapse on <node>` message (NOT a 404, which would conflate the race with a real missing-RD class).

## Test plan

- [x] `go test ./pkg/rest/...` passes locally (unit + contract)
- [x] `make e2e NAME=dev SCENARIO=tiebreaker-r-d-r-c-other-node` passes 6/6 on a fresh stand
- [ ] CI lane 4 (which runs `tiebreaker-r-d-r-c-other-node`) green on this PR
- [ ] No regression on `r c` happy-path lanes (lanes 1-3, 5, piraeus interop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource relocation reliability. When transient failures occur during witness-collapse scenarios, the system now automatically retries the operation instead of immediately failing. This reduces manual intervention needs and improves overall system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->