### PR TITLE
fix(rest): validate volume_number on vd d / vd l / vd m (Bug 365)

### DIFF
--- a/pkg/rest/bug_365_vd_d_volume_number_validation_test.go
+++ b/pkg/rest/bug_365_vd_d_volume_number_validation_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 365 (P2, hunt-caught 2026-06-02) — `linstor vd d <rd> -1`,
+// `linstor vd d <rd> 65536` and `linstor vd d <rd> 99999` all
+// returned 200 + "volume definition already absent" instead of a
+// 400 + FAIL_INVLD_VLM_NR refusal. Bug 363 pins the [0, 65535]
+// addressable range at `vd c`, but the symmetric DELETE / GET /
+// PUT wire boundaries silently masked out-of-range inputs as
+// "already absent" — confusing tooling that audits idempotent
+// deletes for "the row was there but now isn't" semantics.
+//
+// Fix: apply `validateVolumeNumber` (Bug 363's existing helper) at
+// the DELETE, GET and PUT wire boundaries — same rejection
+// envelope as the create path. The contract is now symmetric
+// across the full VD CRUD surface.
+func TestBug365VDDeleteRejectsOutOfRangeVolumeNumber(t *testing.T) {
+	t.Parallel()
+
+	const rdName = "pvc-bug-365"
+
+	cases := []struct {
+		name string
+		vn   string
+	}{
+		{name: "negative", vn: "-1"},
+		{name: "just-above-max", vn: "65536"},
+		{name: "ten-times-max", vn: "655350"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := store.NewInMemory()
+			ctx := t.Context()
+
+			if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+				Name: rdName,
+			}); err != nil {
+				t.Fatalf("seed RD: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			resp := httpDelete(t, base+"/v1/resource-definitions/"+rdName+
+				"/volume-definitions/"+tc.vn)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				got, _ := readAllBody(resp)
+				t.Fatalf("status: got %d, want 400 (Bug 365: invalid VlmNr %s). Body: %s",
+					resp.StatusCode, tc.vn, got)
+			}
+
+			var rcs []apiv1.APICallRc
+			if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+				t.Fatalf("decode envelope: %v", err)
+			}
+
+			if len(rcs) == 0 {
+				t.Fatalf("envelope empty; want a Bug-365 refusal description")
+			}
+
+			// FAIL_INVLD_VLM_NR is the typed Bug 363 sub-code; the
+			// vd-delete gate must surface the same sub-code so
+			// tooling that classifies replies on the typed band sees
+			// a consistent error class across the VD CRUD surface.
+			if rcs[0].RetCode&apiCallRcFailInvldVlmNr == 0 {
+				t.Errorf("ret_code: got %#x, want FAIL_INVLD_VLM_NR (%#x) bit set",
+					rcs[0].RetCode, apiCallRcFailInvldVlmNr)
+			}
+		})
+	}
+}
+
+// TestBug365VDGetRejectsOutOfRangeVolumeNumber pins the symmetric
+// GET refusal — the audit-replay tooling that reads the surface
+// expects the same 400 envelope for `vd l --vlm-nr 65536` as for
+// `vd c --vlm-nr 65536`.
+func TestBug365VDGetRejectsOutOfRangeVolumeNumber(t *testing.T) {
+	t.Parallel()
+
+	const rdName = "pvc-bug-365-get"
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name: rdName,
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpGet(t, base+"/v1/resource-definitions/"+rdName+"/volume-definitions/65536")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400 (Bug 365: GET on out-of-range VlmNr). Body: %s",
+			resp.StatusCode, got)
+	}
+}

--- a/pkg/rest/volume_definitions.go
+++ b/pkg/rest/volume_definitions.go
@@ -229,6 +229,17 @@ func (s *Server) handleVDGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug 365: reject out-of-range volume_number at the GET wire
+	// boundary too. Symmetric to Bug 363 (create) and the
+	// vd-delete gate below — keeps the entire VD CRUD surface
+	// consistent on the addressable [0, 65535] DRBD-9 range.
+	vnErr := validateVolumeNumber(vn)
+	if vnErr != nil {
+		writeVDNumberRejection(w, rd, vn, vnErr)
+
+		return
+	}
+
 	vd, err := s.Store.VolumeDefinitions().Get(r.Context(), rd, vn)
 	if err != nil {
 		writeStoreError(w, err)
@@ -673,6 +684,17 @@ func (s *Server) handleVDUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug 365: reject out-of-range volume_number at the PUT/PATCH
+	// wire boundary too. Symmetric to Bug 363 (create) and the
+	// vd-get / vd-delete gates — keeps the entire VD CRUD surface
+	// consistent on the addressable [0, 65535] DRBD-9 range.
+	vnErr := validateVolumeNumber(vn)
+	if vnErr != nil {
+		writeVDNumberRejection(w, rd, vn, vnErr)
+
+		return
+	}
+
 	var patch volumeDefinitionModifyBody
 
 	if !decodeJSON(w, r, &patch) {
@@ -907,6 +929,24 @@ func (s *Server) handleVDDelete(w http.ResponseWriter, r *http.Request) {
 	vn, err := parseVolNum(r.PathValue("vn"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
+
+		return
+	}
+
+	// Bug 365 (P2, hunt-caught 2026-06-02): reject out-of-range
+	// volume_number before the store-level Delete masks it as
+	// "already absent". Pre-fix `vd d <rd> -1`, `vd d <rd> 65536`
+	// and `vd d <rd> 99999` all returned 200 + warnVDNotFound,
+	// silently telling operators their bogus input was valid (the
+	// store can never have persisted such a row because Bug 363
+	// rejects it at vd c). The mismatch confused tooling that
+	// audits idempotent deletes for "the row was there but now
+	// isn't" semantics. Bug 363 already pins the [0, 65535] range
+	// at create-time; this gate mirrors it at the DELETE wire
+	// boundary so the contract is symmetric.
+	vnErr := validateVolumeNumber(vn)
+	if vnErr != nil {
+		writeVDNumberRejection(w, rd, vn, vnErr)
 
 		return
 	}

--- a/tests/e2e/vd-d-volume-number-validation.sh
+++ b/tests/e2e/vd-d-volume-number-validation.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# usage: vd-d-volume-number-validation.sh WORK_DIR
+#
+# Bug 365 (P2, hunt-caught 2026-06-02) — `vd d <rd> -1`,
+# `vd d <rd> 65536`, `vd d <rd> 99999` all silently returned 200
+# + "volume definition already absent" pre-fix. This e2e pins the
+# post-fix contract: the same out-of-range inputs must surface a
+# 400 envelope from the REST wire boundary, not the idempotent
+# warn-mask the store-level miss produces.
+#
+# Mirrors tests/e2e/vd-volume-number-validation.sh (Bug 363 on the
+# create path) — the contract is now symmetric across the entire
+# VD CRUD surface.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+if ! command -v linstor >/dev/null 2>&1; then
+    echo "FAIL: linstor CLI not in PATH (apt install linstor-client)" >&2
+    exit 1
+fi
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/vd-d-vn-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+LCTL=(linstor --controllers "http://localhost:$PF_PORT")
+
+# Seed a healthy RD so the gate fires on the volume_number alone,
+# not on a missing parent.
+RD=bug365-rd
+"${LCTL[@]}" rd c "$RD"
+
+for vn in -1 65536 99999; do
+    echo ">> linstor vd d $RD $vn (Bug 365: must 4xx, NOT 'already absent')"
+    # The CLI may format `-1` as a positional arg; pass via --
+    # linstor-client (python) writes ERROR descriptions to stdout,
+    # not stderr — capture both streams.
+    if "${LCTL[@]}" vd d "$RD" -- "$vn" >/tmp/vd-d-err.txt 2>&1; then
+        # If exit==0, the gate failed and the CLI happily told us
+        # the bogus VlmNr was "absent" — the pre-Bug-365 mask.
+        echo "FAIL: vd d $RD $vn returned exit 0 (pre-Bug-365 mask)"
+        cat /tmp/vd-d-err.txt
+        exit 1
+    fi
+
+    # The error body should mention "invalid" or the [0, 65535]
+    # range — the writeVDNumberRejection envelope. Don't be too
+    # strict on phrasing; pinning the exact CLI output would break
+    # on golinstor changes. Strip ANSI colour escapes so grep -E
+    # sees the plain text.
+    plain=$(sed 's/\x1b\[[0-9;]*[A-Za-z]//g' /tmp/vd-d-err.txt)
+    if ! echo "$plain" | grep -qE "invalid|65535|out of|bounds|range"; then
+        echo "FAIL: vd d $RD $vn rejected but the message doesn't name the [0, 65535] range:"
+        cat /tmp/vd-d-err.txt
+        exit 1
+    fi
+    echo "   $vn correctly rejected"
+done
+
+# Cleanup
+"${LCTL[@]}" rd d "$RD"
+
+echo ">> PASS: vd d wire boundary rejects out-of-range volume_number"


### PR DESCRIPTION
## Summary

Bug 365 (P2, hunt-caught 2026-06-02): `linstor vd d <rd> -1`, `linstor vd d <rd> 65536` and `linstor vd d <rd> 99999` all returned `200 + "volume definition already absent"` instead of a `400 + FAIL_INVLD_VLM_NR` refusal. Bug 363 (PR #60) pinned the addressable `[0, 65535]` range at `vd c`, but the symmetric DELETE / GET / PUT (modify) wire boundaries silently masked out-of-range inputs as "already absent" — confusing tooling that audits idempotent deletes for "the row was there but now isn't" semantics.

## Fix

Apply the existing `validateVolumeNumber` helper (introduced by Bug 363 / PR #60) at the three additional wire boundaries:
  - `handleVDDelete`
  - `handleVDGet`
  - `handleVDUpdate`

The rejection envelope reuses `writeVDNumberRejection`'s `FAIL_INVLD_VLM_NR` sub-code so tooling that classifies replies on the typed band sees a consistent error class across the full VD CRUD surface.

## Coverage

- `pkg/rest/bug_365_vd_d_volume_number_validation_test.go`:
  - `TestBug365VDDeleteRejectsOutOfRangeVolumeNumber` — pins the 400 + `FAIL_INVLD_VLM_NR` sub-code envelope for `-1`, `65536`, `655350` on DELETE.
  - `TestBug365VDGetRejectsOutOfRangeVolumeNumber` — pins the 400 envelope for `65536` on GET.
- `tests/e2e/vd-d-volume-number-validation.sh` — stand-level regression catcher, mirrors `tests/e2e/vd-volume-number-validation.sh` (Bug 363).

## Test plan

- [x] `go test ./pkg/rest/...` passes locally
- [x] `./tests/e2e/vd-d-volume-number-validation.sh .work/dev` passes on a fresh stand
- [ ] CI lanes green (no new e2e scenario added to a specific lane; the new test is now part of the auto-sharded set)