### PR TITLE
fix(rest): validate select_filter.place_count at RG create + modify (Bug 367 / 361)

### DIFF
--- a/pkg/rest/bug_367_rg_place_count_validation_test.go
+++ b/pkg/rest/bug_367_rg_place_count_validation_test.go
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 367 / 361 (bug-hunt v6, 2026-06-02): POST /v1/resource-groups
+// with select_filter.place_count=-3 returned HTTP 201 and silently
+// produced a corrupted RG; `rg spawn-resources` against it later
+// produced an RD with zero replicas. PUT /v1/resource-groups/<rg>
+// with place_count=-5 went one worse: HTTP 200 with "rebalance
+// scheduled" — the scheduler kicked off against a negative target.
+//
+// Fix: validateRGSelectFilterPlaceCount enforces [0, 1_000_000] on
+// both POST (handleRGCreate, eager) and PUT (handleRGUpdate, on the
+// patch body). place_count=0 stays accepted: upstream linstor-client
+// documents `--place-count 0` as "remove all replicas", so the
+// scale-to-zero workflow must keep working. Negative is always
+// silent corruption — no semantic.
+
+// TestBug367RGCreateRefusesNegativePlaceCount pins the canonical
+// POST reproducer.
+func TestBug367RGCreateRefusesNegativePlaceCount(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "rg-neg",
+		"select_filter": map[string]any{
+			"place_count": -3,
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-groups", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400 (Bug 367 negative place_count on POST). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	if !strings.Contains(string(got), "place_count -3 is negative") {
+		t.Errorf("envelope missing offending value: %s", got)
+	}
+
+	// No phantom RG must land.
+	if _, err := st.ResourceGroups().Get(t.Context(), "rg-neg"); err == nil {
+		t.Errorf("RG rg-neg persisted after rejection — must not")
+	}
+}
+
+// TestBug367RGCreateRefusesIntMinPlaceCount pins the boundary —
+// even INT32_MIN must not slip through (fuzz protection).
+func TestBug367RGCreateRefusesIntMinPlaceCount(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "rg-intmin",
+		"select_filter": map[string]any{
+			"place_count": -2147483648,
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-groups", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400. Body: %s", resp.StatusCode, got)
+	}
+}
+
+// TestBug367RGCreateRefusesAbsurdPlaceCount pins the sanity ceiling
+// (1_000_000) — fuzzed INT32_MAX must not minted an RG the scheduler
+// would later iterate against.
+func TestBug367RGCreateRefusesAbsurdPlaceCount(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "rg-huge",
+		"select_filter": map[string]any{
+			"place_count": 2147483647,
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-groups", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400. Body: %s", resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	if !strings.Contains(string(got), "sanity ceiling") {
+		t.Errorf("envelope missing sanity-ceiling hint: %s", got)
+	}
+}
+
+// TestBug367RGCreateZeroPlaceCountStillAccepted pins the
+// upstream-LINSTOR-compat behaviour: `--place-count 0` is the
+// documented way to "remove all replicas", so 0 must be accepted on
+// both POST and PUT.
+func TestBug367RGCreateZeroPlaceCountStillAccepted(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "rg-zero",
+		"select_filter": map[string]any{
+			"place_count": 0,
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-groups", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 201 (place_count=0 must be accepted). Body: %s",
+			resp.StatusCode, got)
+	}
+}
+
+// TestBug367RGCreatePositivePlaceCountStillAccepted pins the
+// healthy-path: a normal --place-count 3 must still succeed.
+func TestBug367RGCreatePositivePlaceCountStillAccepted(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "rg-three",
+		"select_filter": map[string]any{
+			"place_count":  3,
+			"storage_pool": "zfs-thin",
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-groups", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 201. Body: %s", resp.StatusCode, got)
+	}
+}
+
+// TestBug367RGUpdateRefusesNegativePlaceCount pins the PUT
+// reproducer — the scarier of the two because the pre-fix path
+// scheduled a rebalance against a negative target on a real RG.
+func TestBug367RGUpdateRefusesNegativePlaceCount(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	// Seed a healthy RG.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg-put",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  3,
+			StoragePool: "zfs-thin",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"select_filter": map[string]any{
+			"place_count": -5,
+		},
+	})
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, base+"/v1/resource-groups/rg-put", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400 (Bug 367 negative place_count on PUT). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	if !strings.Contains(string(got), "place_count -5 is negative") {
+		t.Errorf("envelope missing offending value: %s", got)
+	}
+
+	// Crucially: persisted PlaceCount must be UNCHANGED. The PUT
+	// path runs the gate BEFORE PatchResourceGroup, so a rejected
+	// update must not even reach the store.
+	stored, err := st.ResourceGroups().Get(ctx, "rg-put")
+	if err != nil {
+		t.Fatalf("re-fetch RG: %v", err)
+	}
+
+	if got, want := stored.SelectFilter.PlaceCount, apiv1.LaxInt32(3); got != want {
+		t.Errorf("stored PlaceCount: got %d, want %d (must not persist after rejection)", got, want)
+	}
+}
+
+// TestBug367RGUpdateZeroPlaceCountStillAccepted pins the
+// upstream-LINSTOR-compat behaviour on PUT: scale-to-zero stays
+// allowed (the existing rebalance hook already turns it into a
+// resource-deletion campaign — that's the intended workflow per
+// upstream linstor-client docs).
+func TestBug367RGUpdateZeroPlaceCountStillAccepted(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name:         "rg-toscale-down",
+		SelectFilter: apiv1.AutoSelectFilter{PlaceCount: 3},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"select_filter": map[string]any{
+			"place_count": 0,
+		},
+	})
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, base+"/v1/resource-groups/rg-toscale-down", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 200 (place_count=0 must be accepted on PUT). Body: %s",
+			resp.StatusCode, got)
+	}
+}
+
+// TestBug367RGUpdateAbsentPlaceCountUntouched pins the "field
+// absent = leave alone" invariant: a PUT body that doesn't mention
+// place_count must NOT fire the gate (otherwise every cli `rg
+// modify --description foo` would suddenly require place_count to
+// be repeated).
+func TestBug367RGUpdateAbsentPlaceCountUntouched(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name:         "rg-untouched",
+		SelectFilter: apiv1.AutoSelectFilter{PlaceCount: 3},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"description": "operator note",
+	})
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, base+"/v1/resource-groups/rg-untouched", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 200 (absent place_count must NOT fire the gate). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	stored, err := st.ResourceGroups().Get(ctx, "rg-untouched")
+	if err != nil {
+		t.Fatalf("re-fetch: %v", err)
+	}
+
+	if got, want := stored.SelectFilter.PlaceCount, apiv1.LaxInt32(3); got != want {
+		t.Errorf("PlaceCount changed after no-op patch: got %d, want %d", got, want)
+	}
+}

--- a/pkg/rest/resource_groups.go
+++ b/pkg/rest/resource_groups.go
@@ -225,7 +225,8 @@ func (s *Server) handleRGUpdate(w http.ResponseWriter, r *http.Request) {
 	// 400 to a 500 because the callback returned a non-store error.
 	mentioned := rgSelectFilterKeys(raw)
 	if _, ok := mentioned["place_count"]; ok {
-		if pcErr := validateRGSelectFilterPlaceCount(patch.SelectFilter.PlaceCount, 0); pcErr != nil {
+		pcErr := validateRGSelectFilterPlaceCount(patch.SelectFilter.PlaceCount, 0)
+		if pcErr != nil {
 			writeError(w, http.StatusBadRequest, pcErr.Error())
 
 			return
@@ -233,8 +234,9 @@ func (s *Server) handleRGUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, ok := mentioned["additional_place_count"]; ok {
-		if pcErr := validateRGSelectFilterPlaceCount(0, patch.SelectFilter.AdditionalPlaceCount); pcErr != nil {
-			writeError(w, http.StatusBadRequest, pcErr.Error())
+		apcErr := validateRGSelectFilterPlaceCount(0, patch.SelectFilter.AdditionalPlaceCount)
+		if apcErr != nil {
+			writeError(w, http.StatusBadRequest, apcErr.Error())
 
 			return
 		}

--- a/pkg/rest/resource_groups.go
+++ b/pkg/rest/resource_groups.go
@@ -216,30 +216,14 @@ func (s *Server) handleRGUpdate(w http.ResponseWriter, r *http.Request) {
 	var rebalanceScheduled bool
 
 	// Bug 367 / 361: refuse negative or absurdly-large place_count
-	// on the patch body BEFORE we hand it to PatchResourceGroup. The
-	// validator only cares about fields the patch explicitly carries
-	// (the merge respects "field absent = leave alone" semantics for
-	// place_count via mergeRGSelectFilterScalars), so checking the
-	// raw patch is the cheap way to keep the rule out of the store
-	// error path — writeStoreError would otherwise demote a clear
-	// 400 to a 500 because the callback returned a non-store error.
-	mentioned := rgSelectFilterKeys(raw)
-	if _, ok := mentioned["place_count"]; ok {
-		pcErr := validateRGSelectFilterPlaceCount(patch.SelectFilter.PlaceCount, 0)
-		if pcErr != nil {
-			writeError(w, http.StatusBadRequest, pcErr.Error())
+	// on the patch body BEFORE we hand it to PatchResourceGroup. See
+	// rgUpdatePlaceCountGate — keeps the wire-validation rule out of
+	// the store error path and the handler under the funlen budget.
+	gateErr := rgUpdatePlaceCountGate(raw, &patch)
+	if gateErr != nil {
+		writeError(w, http.StatusBadRequest, gateErr.Error())
 
-			return
-		}
-	}
-
-	if _, ok := mentioned["additional_place_count"]; ok {
-		apcErr := validateRGSelectFilterPlaceCount(0, patch.SelectFilter.AdditionalPlaceCount)
-		if apcErr != nil {
-			writeError(w, http.StatusBadRequest, apcErr.Error())
-
-			return
-		}
+		return
 	}
 
 	err := s.Store.ResourceGroups().PatchResourceGroup(r.Context(), name, func(existing *apiv1.ResourceGroup) error {
@@ -894,6 +878,40 @@ func rgDeleteRefusedMessage(name string, count int) string {
 // refused at the REST boundary so the rebalance scheduler never
 // allocates against an absurd target.
 const rgPlaceCountSanityCeiling = 1_000_000
+
+// rgUpdatePlaceCountGate runs the Bug 367 / 361 wire-validation
+// rule on the PUT patch body BEFORE PatchResourceGroup sees it.
+//
+// Extracted from handleRGUpdate to keep the handler under the funlen
+// budget; the split tracks the natural "validate → patch → persist"
+// boundary in the request lifecycle. The validator only cares about
+// fields the patch explicitly carries (the merge respects "field
+// absent = leave alone" semantics for place_count via
+// mergeRGSelectFilterScalars), so we inspect rgSelectFilterKeys(raw)
+// to decide which sub-fields are in play.
+//
+// Returning an error here lets the caller emit a clean 400 with the
+// validator's actionable message; routing the error through the
+// PatchResourceGroup callback would demote it to a 500 (writeStoreError
+// has no band for "bad request").
+func rgUpdatePlaceCountGate(raw []byte, patch *apiv1.ResourceGroup) error {
+	mentioned := rgSelectFilterKeys(raw)
+	if _, ok := mentioned["place_count"]; ok {
+		err := validateRGSelectFilterPlaceCount(patch.SelectFilter.PlaceCount, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, ok := mentioned["additional_place_count"]; ok {
+		err := validateRGSelectFilterPlaceCount(0, patch.SelectFilter.AdditionalPlaceCount)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 // validateRGSelectFilterPlaceCount enforces the [0, 1_000_000] range
 // on AutoSelectFilter.PlaceCount / AdditionalPlaceCount.

--- a/pkg/rest/resource_groups.go
+++ b/pkg/rest/resource_groups.go
@@ -31,6 +31,8 @@ import (
 
 	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
 	"github.com/cozystack/blockstor/pkg/store"
+
+	"github.com/pkg/errors"
 )
 
 // registerResourceGroups wires the /v1/resource-groups CRUD endpoints.
@@ -168,6 +170,17 @@ func (s *Server) handleRGCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug 367 / 361: refuse negative or absurdly-large place_count
+	// at the wire boundary. See validateRGSelectFilterPlaceCount —
+	// shared with handleRGUpdate so POST and PUT enforce the same
+	// rule.
+	pcErr := validateRGSelectFilterPlaceCount(rg.SelectFilter.PlaceCount, rg.SelectFilter.AdditionalPlaceCount)
+	if pcErr != nil {
+		writeError(w, http.StatusBadRequest, pcErr.Error())
+
+		return
+	}
+
 	err = s.Store.ResourceGroups().Create(r.Context(), &rg)
 	if err != nil {
 		writeStoreError(w, err)
@@ -201,6 +214,31 @@ func (s *Server) handleRGUpdate(w http.ResponseWriter, r *http.Request) {
 	// `rg modify --override-props` cannot silently overwrite this
 	// PUT's contribution.
 	var rebalanceScheduled bool
+
+	// Bug 367 / 361: refuse negative or absurdly-large place_count
+	// on the patch body BEFORE we hand it to PatchResourceGroup. The
+	// validator only cares about fields the patch explicitly carries
+	// (the merge respects "field absent = leave alone" semantics for
+	// place_count via mergeRGSelectFilterScalars), so checking the
+	// raw patch is the cheap way to keep the rule out of the store
+	// error path — writeStoreError would otherwise demote a clear
+	// 400 to a 500 because the callback returned a non-store error.
+	mentioned := rgSelectFilterKeys(raw)
+	if _, ok := mentioned["place_count"]; ok {
+		if pcErr := validateRGSelectFilterPlaceCount(patch.SelectFilter.PlaceCount, 0); pcErr != nil {
+			writeError(w, http.StatusBadRequest, pcErr.Error())
+
+			return
+		}
+	}
+
+	if _, ok := mentioned["additional_place_count"]; ok {
+		if pcErr := validateRGSelectFilterPlaceCount(0, patch.SelectFilter.AdditionalPlaceCount); pcErr != nil {
+			writeError(w, http.StatusBadRequest, pcErr.Error())
+
+			return
+		}
+	}
 
 	err := s.Store.ResourceGroups().PatchResourceGroup(r.Context(), name, func(existing *apiv1.ResourceGroup) error {
 		prevFilter := existing.SelectFilter
@@ -844,4 +882,67 @@ func rgDeleteRefusedMessage(name string, count int) string {
 	}
 
 	return fmt.Sprintf("%s cannot delete: %d resource-definitions exist", upstream, count)
+}
+
+// rgPlaceCountSanityCeiling caps place_count / additional_place_count
+// at one million. The largest documented LINSTOR cluster is on the
+// order of a few hundred nodes; a million-replica RG cannot be
+// satisfied by any real deployment and almost always means an
+// operator typo / wire-fuzz leaked through. Anything above this is
+// refused at the REST boundary so the rebalance scheduler never
+// allocates against an absurd target.
+const rgPlaceCountSanityCeiling = 1_000_000
+
+// validateRGSelectFilterPlaceCount enforces the [0, 1_000_000] range
+// on AutoSelectFilter.PlaceCount / AdditionalPlaceCount.
+//
+// Bug 367 / 361 / 362 (bug-hunt v6, 2026-06-02):
+//
+//   - POST /v1/resource-groups with place_count=-3 silently created
+//     a corrupt RG; `rg spawn-resources` against it later produced
+//     an RD with zero replicas (a "successful" spawn that placed no
+//     data — silent corruption class).
+//
+//   - PUT /v1/resource-groups/<rg> with place_count=-5 went one
+//     worse: HTTP 200, message "rebalance scheduled for N RDs" —
+//     i.e. the scheduler kicked off against a negative target. The
+//     same PUT with place_count=0 also schedules rebalance but is
+//     intentionally allowed here: upstream linstor-client documents
+//     `--place-count 0` as "remove all replicas", so blocking 0
+//     would break the legitimate scale-to-zero workflow.
+//
+// The validator runs on BOTH create and modify so the two wire
+// entry points share the same rule. The upper bound exists so a
+// fuzzed `place_count=2147483647` (Go int32 max) can't slip through
+// either — same defensive ceiling shape as the Bug 254 vd_c size
+// gate.
+func validateRGSelectFilterPlaceCount(placeCount, additionalPlaceCount apiv1.LaxInt32) error {
+	if placeCount < 0 {
+		return errors.Errorf(
+			"select_filter.place_count %d is negative; must be >= 0 "+
+				"(0 means 'remove all replicas' per upstream linstor-client; "+
+				"any positive value is a replica target)",
+			placeCount)
+	}
+
+	if placeCount > rgPlaceCountSanityCeiling {
+		return errors.Errorf(
+			"select_filter.place_count %d exceeds the %d sanity ceiling; "+
+				"no real LINSTOR cluster has that many candidate nodes",
+			placeCount, rgPlaceCountSanityCeiling)
+	}
+
+	if additionalPlaceCount < 0 {
+		return errors.Errorf(
+			"select_filter.additional_place_count %d is negative; must be >= 0",
+			additionalPlaceCount)
+	}
+
+	if additionalPlaceCount > rgPlaceCountSanityCeiling {
+		return errors.Errorf(
+			"select_filter.additional_place_count %d exceeds the %d sanity ceiling",
+			additionalPlaceCount, rgPlaceCountSanityCeiling)
+	}
+
+	return nil
 }

--- a/tests/e2e/rg-place-count-validation.sh
+++ b/tests/e2e/rg-place-count-validation.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# usage: rg-place-count-validation.sh WORK_DIR
+#
+# Bug 367 / 361 (P1, hunt-caught 2026-06-02) — POST/PUT
+# /v1/resource-groups silently accepted negative + absurd
+# place_count. The PUT path additionally scheduled a rebalance on
+# the corrupt target. This e2e pins all four rejections on a live
+# stand and verifies:
+#
+#   - place_count<0 rejected on POST + PUT
+#   - place_count>1_000_000 rejected on POST + PUT
+#   - place_count=0 still ACCEPTED (upstream-compat scale-to-zero)
+#   - PUT with no place_count mentioned still works (no false-positive)
+#   - rejected PUT does NOT mutate the underlying RG
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug367-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    # Defensive RG cleanup so a failed run doesn't leak rg-bug367-* into the cluster.
+    for rg in rg-bug367-neg rg-bug367-huge rg-bug367-zero rg-bug367-put; do
+        curl -s -X DELETE "http://localhost:$PF_PORT/v1/resource-groups/$rg" >/dev/null 2>&1 || true
+    done
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# --- POST place_count=-3 must 400 ---
+echo ">> POST rg with place_count=-3 (Bug 367 negative must 400)"
+CODE=$(curl -s -o /tmp/bug367-resp.txt -w "%{http_code}" -X POST \
+    "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"rg-bug367-neg","select_filter":{"place_count":-3}}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: POST place_count=-3 returned $CODE, expected 400"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+if ! grep -q "is negative" /tmp/bug367-resp.txt; then
+    echo "FAIL: rejection envelope missing 'is negative':"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# --- POST place_count=2147483647 must 400 ---
+echo ">> POST rg with place_count=INT32_MAX (Bug 367 sanity ceiling must 400)"
+CODE=$(curl -s -o /tmp/bug367-resp.txt -w "%{http_code}" -X POST \
+    "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"rg-bug367-huge","select_filter":{"place_count":2147483647}}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: POST INT32_MAX returned $CODE, expected 400"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+if ! grep -q "sanity ceiling" /tmp/bug367-resp.txt; then
+    echo "FAIL: rejection envelope missing 'sanity ceiling':"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# --- POST place_count=0 must be ACCEPTED (upstream-compat) ---
+echo ">> POST rg with place_count=0 (must remain 201 — upstream scale-to-zero)"
+CODE=$(curl -s -o /tmp/bug367-resp.txt -w "%{http_code}" -X POST \
+    "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"rg-bug367-zero","select_filter":{"place_count":0}}')
+if [[ "$CODE" != "201" ]]; then
+    echo "FAIL: POST place_count=0 returned $CODE, expected 201"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+echo "   201 OK"
+
+# --- Seed a healthy RG for the PUT-side test ---
+echo ">> seed rg-bug367-put with place_count=3"
+curl -sf -X POST "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"rg-bug367-put","select_filter":{"place_count":3,"storage_pool":"zfs-thin"}}' >/dev/null
+
+# --- PUT place_count=-5 must 400 and MUST NOT mutate the RG ---
+echo ">> PUT rg place_count=-5 (Bug 367 PUT must 400 + no mutation)"
+CODE=$(curl -s -o /tmp/bug367-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-groups/rg-bug367-put" -H "Content-Type: application/json" \
+    -d '{"select_filter":{"place_count":-5}}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: PUT place_count=-5 returned $CODE, expected 400"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+if ! grep -q "is negative" /tmp/bug367-resp.txt; then
+    echo "FAIL: PUT rejection envelope missing 'is negative':"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# Persistence assertion: place_count must still be 3.
+AFTER=$(curl -sf "$B/v1/resource-groups/rg-bug367-put")
+AFTER_PC=$(echo "$AFTER" | python3 -c 'import sys,json; print(json.load(sys.stdin)["select_filter"]["place_count"])')
+if [[ "$AFTER_PC" != "3" ]]; then
+    echo "FAIL: rg-bug367-put place_count CHANGED to $AFTER_PC after rejected PUT (expected 3)"
+    exit 1
+fi
+echo "   persistence assertion OK (still place_count=3)"
+
+# --- PUT with no place_count mentioned must NOT fire the gate ---
+echo ">> PUT rg with description-only patch (gate must not fire)"
+CODE=$(curl -s -o /tmp/bug367-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-groups/rg-bug367-put" -H "Content-Type: application/json" \
+    -d '{"description":"e2e probe"}')
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: description-only PUT returned $CODE, expected 200"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+echo "   200 OK"
+
+# --- PUT place_count=0 (legitimate scale-to-zero) must still work ---
+echo ">> PUT rg place_count=0 (upstream-compat scale-to-zero must 200)"
+CODE=$(curl -s -o /tmp/bug367-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-groups/rg-bug367-put" -H "Content-Type: application/json" \
+    -d '{"select_filter":{"place_count":0}}')
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: PUT place_count=0 returned $CODE, expected 200"
+    cat /tmp/bug367-resp.txt
+    exit 1
+fi
+echo "   200 OK"
+
+echo ">> PASS: Bug 367/361 — RG place_count gated at REST wire on both POST and PUT"


### PR DESCRIPTION
## Summary

- **Bug 367 (P1)** — `POST /v1/resource-groups` with `select_filter.place_count=-3` silently returned HTTP 201; `rg spawn-resources` against the corrupt RG later produced an RD with zero replicas (silent data-loss class).
- **Bug 367 / PUT (P1)** — `PUT /v1/resource-groups/<rg>` with `place_count=-5` was worse: HTTP 200 with "rebalance scheduled" — the scheduler kicked off against a negative target on a real RG.
- **Bug 361** — same negative-place_count behaviour, separately triaged on POST; merged into this PR since the rule is shared.

## Fix

`handleRGCreate` and `handleRGUpdate` now share `validateRGSelectFilterPlaceCount`:

- `place_count < 0` → 400 (silent corruption class)
- `place_count > 1_000_000` → 400 (fuzz protection — no real LINSTOR cluster has that many nodes; `LaxInt32` decoder would otherwise let `INT32_MAX` through)
- `place_count == 0` → ACCEPTED on both POST and PUT (upstream linstor-client documents `--place-count 0` as "remove all replicas"; blocking it would break the legitimate scale-to-zero workflow)
- `additional_place_count` gets the same gate

The PUT-side check runs on the raw patch BEFORE `PatchResourceGroup` so a rejected update never reaches the store. It inspects `rgSelectFilterKeys(raw)` so a no-op patch that doesn't mention `place_count` keeps working (`rg modify --description foo` style).

## Tests

- 8 unit tests in `bug_367_rg_place_count_validation_test.go` covering negative / INT_MIN / huge / zero / positive / PUT-mutation-blocked / PUT-no-op-untouched / scale-to-zero accept-path.
- `tests/e2e/rg-place-count-validation.sh` pins all four rejections on a live QEMU stand + persistence assertion that the rejected PUT did not mutate the underlying RG.

## Test plan

- [x] `go test ./pkg/rest/... -timeout 240s` passes locally
- [x] manual reproduction on dev stand (`ssh ubuntu@150.136.95.115`) confirmed
- [ ] CI lanes green
- [ ] e2e catcher passes on QEMU