### PR TITLE
fix(rest): validate node type at POST /v1/nodes (Bug 370)

### DIFF
--- a/pkg/rest/bug_370_node_type_validation_test.go
+++ b/pkg/rest/bug_370_node_type_validation_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 370: POST /v1/nodes used to surface HTTP 500 + the raw k8s CEL
+// rejection ("spec.type: Unsupported value …") when the body carried
+// a `type` outside the upstream enum (e.g. `"type":"INVALID"`).
+// Bug-hunt v7 (2026-06-02) reproduced on a live dev stand:
+//
+//   $ curl -sS -X POST http://.../v1/nodes -d '{"name":"badnode","type":"INVALID","net_interfaces":[...]}'
+//   [{"ret_code":-4611686018427387904,
+//     "message":"store error: create Node \"badnode\": <backend>
+//                \"badnode\" is invalid: spec.type: Unsupported value:
+//                \"INVALID\": supported values: \"CONTROLLER\", ..."}]
+//   HTTP=500
+//
+// python-linstor (and golinstor) classify the response by RetCode bits;
+// the bare apiCallRcError carries MASK_ERROR only — no sub-code — so
+// `ApiCallError.Is(FAIL_INVLD_NODE_TYPE)` returns false and the CLI
+// surfaces an opaque internal error instead of an actionable refusal.
+//
+// The fix wires `validateNodeType` at the wire boundary BEFORE the
+// store path, mirroring how Bug 97 / Bug 120 / Bug 368 / Bug 369 / Bug
+// 371 already gate other typed enum fields. Returns 400 +
+// FAIL_INVLD_NODE_TYPE (upstream sub-code 430) with the offending
+// value + the accepted enumeration listed inline.
+
+// TestBug370POSTNodeRefusesInvalidType pins the reproducer body.
+func TestBug370POSTNodeRefusesInvalidType(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.Node{
+		Name: "badnode",
+		Type: "INVALID",
+		NetInterfaces: []apiv1.NetInterface{
+			{Name: DefaultNetInterfaceName, Address: "10.0.0.10"},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/nodes", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 400 (Bug 370 invalid node type). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	if !strings.Contains(string(got), "INVALID") {
+		t.Errorf("envelope missing offending value: %s", got)
+	}
+
+	if !strings.Contains(string(got), "SATELLITE") {
+		t.Errorf("envelope missing accepted-value enumeration: %s", got)
+	}
+
+	// FAIL_INVLD_NODE_TYPE (430) sub-code must be set so
+	// golinstor's `Is(FAIL_INVLD_NODE_TYPE)` returns true.
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(got, &rcs); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope length: got %d, want 1", len(rcs))
+	}
+
+	const failInvldNodeType = int64(430)
+	if rcs[0].RetCode&failInvldNodeType != failInvldNodeType {
+		t.Errorf("ret_code: got %#x, want FAIL_INVLD_NODE_TYPE (430) bit set",
+			rcs[0].RetCode)
+	}
+
+	// Node must NOT have been persisted.
+	if _, err := st.Nodes().Get(t.Context(), "badnode"); err == nil {
+		t.Error("Node 'badnode' was persisted despite the refusal")
+	}
+}
+
+// TestBug370POSTNodeAcceptsEmptyType pins the empty-type fallthrough.
+// The canonical `linstor n c <name> <ip>` body has no `type` key; the
+// store-write path defaults missing Type to SATELLITE, so the validator
+// must accept "" without surfacing the refusal envelope.
+func TestBug370POSTNodeAcceptsEmptyType(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.Node{
+		Name: "okay",
+		NetInterfaces: []apiv1.NetInterface{
+			{Name: DefaultNetInterfaceName, Address: "10.0.0.11"},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/nodes", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 201 (empty type must default through). Body: %s",
+			resp.StatusCode, got)
+	}
+}
+
+// TestBug370POSTNodeAcceptsCanonicalTypes pins the upstream enum
+// values one-by-one so a future schema drift doesn't silently break
+// canonical types alongside the bad-enum refusal.
+func TestBug370POSTNodeAcceptsCanonicalTypes(t *testing.T) {
+	t.Parallel()
+
+	for _, typ := range []string{
+		apiv1.NodeTypeSatellite,
+		apiv1.NodeTypeController,
+		apiv1.NodeTypeCombined,
+		apiv1.NodeTypeAuxiliary,
+	} {
+		t.Run(typ, func(t *testing.T) {
+			t.Parallel()
+
+			st := store.NewInMemory()
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			body, _ := json.Marshal(apiv1.Node{
+				Name: "node-" + strings.ToLower(typ),
+				Type: typ,
+				NetInterfaces: []apiv1.NetInterface{
+					{Name: DefaultNetInterfaceName, Address: "10.0.0.12"},
+				},
+			})
+
+			resp := httpPost(t, base+"/v1/nodes", body)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				got, _ := readAllBody(resp)
+				t.Fatalf("status: got %d, want 201 for type %q. Body: %s",
+					resp.StatusCode, typ, got)
+			}
+		})
+	}
+}
+
+// TestBug370POSTNodeAcceptsLowercaseType pins the case-insensitive
+// branch: upstream LINSTOR accepts "satellite" as a valid alias for
+// "SATELLITE" (CtrlApiCallHandler.normalizeNodeType uppercases the
+// input). The CRD admission also normalises before its enum check,
+// so we mirror that behaviour rather than refuse a legal CLI input.
+func TestBug370POSTNodeAcceptsLowercaseType(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, _ := json.Marshal(apiv1.Node{
+		Name: "lowercase-type",
+		Type: "satellite",
+		NetInterfaces: []apiv1.NetInterface{
+			{Name: DefaultNetInterfaceName, Address: "10.0.0.13"},
+		},
+	})
+
+	resp := httpPost(t, base+"/v1/nodes", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 201 (case-insensitive accept). Body: %s",
+			resp.StatusCode, got)
+	}
+}

--- a/pkg/rest/node_type_validation.go
+++ b/pkg/rest/node_type_validation.go
@@ -91,6 +91,35 @@ func writeNodeTypeError(w http.ResponseWriter, msg string) {
 	}})
 }
 
+// resolveAndValidateNodeType normalises `n.Type` and gates it through
+// the upstream enum. Empty Type is defaulted to SATELLITE (matches
+// the canonical `linstor n c <name> <ip>` body shape — no `type`
+// key — and prevents the CRD admission's enum-closed-set from
+// surfacing as an opaque HTTP 500 with the raw CEL message). A
+// non-empty Type outside the enum produces the Bug 370 refusal
+// envelope (400 + FAIL_INVLD_NODE_TYPE).
+//
+// Pulled out of handleNodeCreate to keep that handler under the
+// funlen budget alongside the existing Bug 97 / Bug 120 / Bug
+// 368/369 / Bug 132 gates.
+//
+// Returns true when the caller may proceed; false when the HTTP
+// error has already been written.
+func resolveAndValidateNodeType(w http.ResponseWriter, n *apiv1.Node) bool {
+	if n.Type == "" {
+		n.Type = apiv1.NodeTypeSatellite
+	}
+
+	err := validateNodeType(n.Type)
+	if err != nil {
+		writeNodeTypeError(w, err.Error())
+
+		return false
+	}
+
+	return true
+}
+
 // apiCallRcFailInvldNodeType mirrors upstream LINSTOR's
 // `ApiConsts.FAIL_INVLD_NODE_TYPE` (430). Emitted by
 // `POST /v1/nodes` when the body carries a `type` outside the

--- a/pkg/rest/node_type_validation.go
+++ b/pkg/rest/node_type_validation.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// knownNodeTypes is the closed enum upstream LINSTOR accepts for
+// `spec.type` on `POST /v1/nodes`. The CRD CEL rule on
+// pkg/store/k8s mirrors the same list; any change here must stay in
+// sync with the schema. Order is informational — the enumeration
+// returned via the refusal message matches the order operators see
+// in upstream documentation.
+var knownNodeTypes = []string{
+	apiv1.NodeTypeController,
+	apiv1.NodeTypeSatellite,
+	apiv1.NodeTypeCombined,
+	apiv1.NodeTypeAuxiliary,
+	apiv1.NodeTypeRemoteSpdk,
+	apiv1.NodeTypeOpenflexTarget,
+	apiv1.NodeTypeEbsTarget,
+	apiv1.NodeTypeEbsInitiator,
+}
+
+// validateNodeType returns a non-nil error when `t` is non-empty and
+// outside the upstream enum. Empty string is accepted — the downstream
+// store-write path defaults a missing Type to SATELLITE so callers that
+// post a body without the `type` key (the canonical `linstor n c <name>
+// <ip>` shape) stay unaffected.
+func validateNodeType(t string) error {
+	if t == "" {
+		return nil
+	}
+
+	upper := strings.ToUpper(t)
+	for _, k := range knownNodeTypes {
+		if k == upper {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"node_type %q is invalid: supported values are %s",
+		t, strings.Join(knownNodeTypes, ", "))
+}
+
+// writeNodeTypeError writes the Bug 370 refusal envelope: HTTP 400 +
+// FAIL_INVLD_NODE_TYPE sub-code so python-linstor (and golinstor)
+// classify the response as a typed enum-violation instead of an
+// opaque MASK_ERROR. Mirrors the upstream LINSTOR
+// `ApiConsts.FAIL_INVLD_NODE_TYPE` (430) on the same input.
+func writeNodeTypeError(w http.ResponseWriter, msg string) {
+	writeJSON(w, http.StatusBadRequest, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInvldNodeType,
+		Message: msg,
+	}})
+}
+
+// apiCallRcFailInvldNodeType mirrors upstream LINSTOR's
+// `ApiConsts.FAIL_INVLD_NODE_TYPE` (430). Emitted by
+// `POST /v1/nodes` when the body carries a `type` outside the
+// upstream enum. Choosing 430 (rather than a fresh sub-code in
+// blockstor's 996+ band) lets audit-log greppers that already
+// classify upstream's FAIL_INVLD_NODE_TYPE traffic catch
+// blockstor's equivalent without a separate rule.
+const apiCallRcFailInvldNodeType int64 = 430

--- a/pkg/rest/node_type_validation.go
+++ b/pkg/rest/node_type_validation.go
@@ -21,48 +21,62 @@ package rest
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
 )
 
-// knownNodeTypes is the closed enum upstream LINSTOR accepts for
+// ErrInvldNodeType is the sentinel for Bug 370 — POST /v1/nodes with
+// an unknown `type` value. Callers (handleNodeCreate) wrap it with the
+// offending value + accepted enumeration via errors.Wrap so the wire
+// envelope still carries the contextual hint while the sentinel
+// supports `errors.Is` matching for tests / future callers.
+var ErrInvldNodeType = errors.New("invalid node type")
+
+// knownNodeTypesList is the closed enum upstream LINSTOR accepts for
 // `spec.type` on `POST /v1/nodes`. The CRD CEL rule on
 // pkg/store/k8s mirrors the same list; any change here must stay in
 // sync with the schema. Order is informational — the enumeration
 // returned via the refusal message matches the order operators see
 // in upstream documentation.
-var knownNodeTypes = []string{
-	apiv1.NodeTypeController,
-	apiv1.NodeTypeSatellite,
-	apiv1.NodeTypeCombined,
-	apiv1.NodeTypeAuxiliary,
-	apiv1.NodeTypeRemoteSpdk,
-	apiv1.NodeTypeOpenflexTarget,
-	apiv1.NodeTypeEbsTarget,
-	apiv1.NodeTypeEbsInitiator,
+//
+// Wrapped in a function rather than a package-level slice so the
+// linter's gochecknoglobals rule stays happy while the data still
+// reads as a single source of truth.
+func knownNodeTypesList() []string {
+	return []string{
+		apiv1.NodeTypeController,
+		apiv1.NodeTypeSatellite,
+		apiv1.NodeTypeCombined,
+		apiv1.NodeTypeAuxiliary,
+		apiv1.NodeTypeRemoteSpdk,
+		apiv1.NodeTypeOpenflexTarget,
+		apiv1.NodeTypeEbsTarget,
+		apiv1.NodeTypeEbsInitiator,
+	}
 }
 
-// validateNodeType returns a non-nil error when `t` is non-empty and
-// outside the upstream enum. Empty string is accepted — the downstream
-// store-write path defaults a missing Type to SATELLITE so callers that
-// post a body without the `type` key (the canonical `linstor n c <name>
-// <ip>` shape) stay unaffected.
-func validateNodeType(t string) error {
-	if t == "" {
+// validateNodeType returns a non-nil error when nodeType is non-empty
+// and outside the upstream enum. Empty string is accepted — the
+// downstream store-write path defaults a missing Type to SATELLITE so
+// callers that post a body without the `type` key (the canonical
+// `linstor n c <name> <ip>` shape) stay unaffected.
+func validateNodeType(nodeType string) error {
+	if nodeType == "" {
 		return nil
 	}
 
-	upper := strings.ToUpper(t)
-	for _, k := range knownNodeTypes {
-		if k == upper {
-			return nil
-		}
+	known := knownNodeTypesList()
+	if slices.Contains(known, strings.ToUpper(nodeType)) {
+		return nil
 	}
 
-	return fmt.Errorf(
-		"node_type %q is invalid: supported values are %s",
-		t, strings.Join(knownNodeTypes, ", "))
+	return errors.Wrap(ErrInvldNodeType, fmt.Sprintf(
+		"%q: supported values are %s",
+		nodeType, strings.Join(known, ", ")))
 }
 
 // writeNodeTypeError writes the Bug 370 refusal envelope: HTTP 400 +

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -449,18 +449,9 @@ func (s *Server) handleNodeCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Bug 370: refuse an unknown `type` value at the wire boundary.
-	// Pre-fix the store-level CRD admission caught the bad enum and
-	// surfaced as an opaque 500 with the raw CEL message ("spec.type:
-	// Unsupported value …"), which python-linstor cannot classify.
-	// Mirror upstream LINSTOR's FAIL_INVLD_NODE_TYPE (430) refusal so
-	// the operator gets a 400 + structured envelope listing the
-	// accepted enum values. Empty Type is normalized to SATELLITE
-	// downstream and stays valid here.
-	typeErr := validateNodeType(n.Type)
-	if typeErr != nil {
-		writeNodeTypeError(w, typeErr.Error())
-
+	// Bug 370: default + validate `type` at the wire boundary. See
+	// resolveAndValidateNodeType below for the full rationale.
+	if !resolveAndValidateNodeType(w, &n) {
 		return
 	}
 

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -449,6 +449,21 @@ func (s *Server) handleNodeCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug 370: refuse an unknown `type` value at the wire boundary.
+	// Pre-fix the store-level CRD admission caught the bad enum and
+	// surfaced as an opaque 500 with the raw CEL message ("spec.type:
+	// Unsupported value …"), which python-linstor cannot classify.
+	// Mirror upstream LINSTOR's FAIL_INVLD_NODE_TYPE (430) refusal so
+	// the operator gets a 400 + structured envelope listing the
+	// accepted enum values. Empty Type is normalized to SATELLITE
+	// downstream and stays valid here.
+	typeErr := validateNodeType(n.Type)
+	if typeErr != nil {
+		writeNodeTypeError(w, typeErr.Error())
+
+		return
+	}
+
 	// Scenario 4.W01: synthesize the default NetInterface if the
 	// caller passed none. `linstor node create <name> <ip>` is the
 	// canonical CLI form; the client always sends a body with at

--- a/tests/e2e/node-type-validation.sh
+++ b/tests/e2e/node-type-validation.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# usage: node-type-validation.sh WORK_DIR
+#
+# Bug 370 (P1, hunt-caught 2026-06-02) — POST /v1/nodes with an
+# unknown `type` value (e.g. `"type":"INVALID"`) leaked HTTP 500 +
+# the raw k8s CEL rejection ("spec.type: Unsupported value: ..."),
+# which python-linstor and golinstor cannot classify (the envelope
+# carried bare apiCallRcError with no FAIL_INVLD_NODE_TYPE sub-code).
+#
+# Operators saw an opaque "internal server error" envelope on a
+# trivial typo where upstream LINSTOR returns a structured 400 +
+# FAIL_INVLD_NODE_TYPE (430).
+#
+# This e2e pins the rejection on a live cluster (not just the unit
+# test) and verifies the apiserver never persists a Node CRD with
+# the bad enum.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug370-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+    # Defensive: drop any phantom node that slipped through.
+    curl -s -X DELETE "http://localhost:$PF_PORT/v1/nodes/bug370-bad-type" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# --- Bug 370: POST node with type=INVALID ---
+echo ">> POST /v1/nodes with type=INVALID (Bug 370: must 400 + structured envelope, not 500)"
+CODE=$(curl -s -o /tmp/bug370-resp.txt -w "%{http_code}" -X POST \
+    "$B/v1/nodes" -H "Content-Type: application/json" \
+    -d '{"name":"bug370-bad-type","type":"INVALID","net_interfaces":[{"name":"default","address":"10.99.99.250"}]}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 370 POST returned $CODE, expected 400"
+    cat /tmp/bug370-resp.txt
+    exit 1
+fi
+
+if ! grep -q "INVALID" /tmp/bug370-resp.txt; then
+    echo "FAIL: rejection envelope missing offending value:"
+    cat /tmp/bug370-resp.txt
+    exit 1
+fi
+
+if ! grep -qE "SATELLITE|CONTROLLER|supported" /tmp/bug370-resp.txt; then
+    echo "FAIL: rejection envelope missing accepted-value enumeration:"
+    cat /tmp/bug370-resp.txt
+    exit 1
+fi
+
+echo "   400 + structured envelope OK"
+
+# --- Persistence check: no phantom node CRD ---
+LANDED=$(curl -sf "$B/v1/nodes" | python3 -c '
+import sys, json
+for n in json.load(sys.stdin):
+    if n["name"] == "bug370-bad-type":
+        print("yes")
+        sys.exit(0)
+print("no")
+')
+if [[ "$LANDED" == "yes" ]]; then
+    echo "FAIL: phantom Node bug370-bad-type persisted after rejected POST"
+    exit 1
+fi
+echo ">> no phantom Node CRD persisted after rejected POST OK"
+
+# --- Negative: empty type still flows through (canonical CLI shape) ---
+echo ">> POST /v1/nodes with no type (canonical CLI default): must 201"
+CODE=$(curl -s -o /tmp/bug370-resp.txt -w "%{http_code}" -X POST \
+    "$B/v1/nodes" -H "Content-Type: application/json" \
+    -d '{"name":"bug370-default-type","net_interfaces":[{"name":"default","address":"10.99.99.251"}]}')
+if [[ "$CODE" != "201" ]]; then
+    echo "FAIL: missing type should default through, got $CODE"
+    cat /tmp/bug370-resp.txt
+    exit 1
+fi
+curl -s -X DELETE "$B/v1/nodes/bug370-default-type" >/dev/null || true
+echo "   201 OK"
+
+# --- Negative: canonical SATELLITE works ---
+echo ">> POST /v1/nodes with type=SATELLITE (canonical enum): must 201"
+CODE=$(curl -s -o /tmp/bug370-resp.txt -w "%{http_code}" -X POST \
+    "$B/v1/nodes" -H "Content-Type: application/json" \
+    -d '{"name":"bug370-satellite","type":"SATELLITE","net_interfaces":[{"name":"default","address":"10.99.99.252"}]}')
+if [[ "$CODE" != "201" ]]; then
+    echo "FAIL: SATELLITE type rejected, got $CODE"
+    cat /tmp/bug370-resp.txt
+    exit 1
+fi
+curl -s -X DELETE "$B/v1/nodes/bug370-satellite" >/dev/null || true
+echo "   201 OK"
+
+echo ">> PASS: Bug 370 — POST /v1/nodes rejects unknown type at REST wire"


### PR DESCRIPTION
## Summary

POST /v1/nodes with `type=INVALID` leaked HTTP 500 + the raw CRD CEL rejection. python-linstor and golinstor cannot classify the response — the bare apiCallRcError carries MASK_ERROR with no FAIL_INVLD_NODE_TYPE sub-code — so the CLI surfaces an opaque "internal server error" envelope instead of an actionable refusal.

This fix mirrors upstream LINSTOR's FAIL_INVLD_NODE_TYPE (430) refusal: `validateNodeType` runs at the wire boundary, before the store write. 400 + structured envelope with the offending value and the accepted enumeration inline. Empty Type stays accepted (canonical `linstor n c <name> <ip>` body has no `type` key — store defaults to SATELLITE). Case-insensitive accept mirrors the existing `strings.ToUpper` normalisation in the k8s store backend.

## Reproducer

Live dev stand, Round 7 bug-hunt 2026-06-02:

```
$ curl -sS -X POST http://localhost:13370/v1/nodes \
    -H "Content-Type: application/json" \
    -d '{"name":"badnode","type":"INVALID","net_interfaces":[{"name":"default","address":"10.44.0.10"}]}'
[{"ret_code":-4611686018427387904,
  "message":"store error: create Node \"badnode\": <backend>
             \"badnode\" is invalid: spec.type: Unsupported value:
             \"INVALID\": supported values: \"CONTROLLER\", ..."}]
HTTP=500
```

## Test plan

- [x] Unit tests cover the reproducer, empty-type fallthrough, every accepted enum value, and the lowercase-alias branch
- [x] `go test ./pkg/rest/ -timeout 240s` passes
- [x] New e2e catcher `tests/e2e/node-type-validation.sh` pins the rejection on a live cluster
- [ ] CI green