### PR TITLE
fix(rest): validate resource_group at PUT /v1/resource-definitions/{rd} (Bug 372)

### DIFF
--- a/pkg/rest/bug_232_test.go
+++ b/pkg/rest/bug_232_test.go
@@ -152,6 +152,14 @@ func TestBug232RDModifyAcceptsDstRscGrp(t *testing.T) {
 	st := store.NewInMemory()
 	ctx := t.Context()
 
+	// Bug 372 follow-up: refuseRDUpdateOnUnknownRG now gates the
+	// modify shape; seed `rg-new` so the cross-RG move resolves
+	// against a real RG instead of tripping the dangling-reference
+	// refusal.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg-new"}); err != nil {
+		t.Fatalf("seed rg-new: %v", err)
+	}
+
 	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
 		Name:              "rd1",
 		ResourceGroupName: "rg-old",

--- a/pkg/rest/bug_372_rd_update_rg_validation_test.go
+++ b/pkg/rest/bug_372_rd_update_rg_validation_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 372 (P1, hunt-caught 2026-06-02): PUT /v1/resource-definitions/
+// {rd} with a body `{"resource_group":"nonexistent-rg-xyz"}` returned
+// HTTP 200 + "resource definition modified", silently stamping the
+// bogus name onto `RD.Spec.ResourceGroupName`. The RD then lived on
+// with a dangling reference: `linstor rd l` rendered the RD fine,
+// but the placer's Controller→RG→RD prop-inheritance walk silently
+// dropped the RG tier, and `rg query-size-info`, auto-place, auto-
+// diskful, place_count observability, and the RGRebalanceReconciler
+// all started seeing a phantom RD with no parent.
+//
+// Bug-hunt v7 (2026-06-02) reproduced on a live dev stand:
+//
+//   $ curl -sS -X PUT http://.../v1/resource-definitions/testrd \
+//       -d '{"resource_group":"nonexistent-rg-xyz"}'
+//   [{"ret_code":4294967296,"message":"resource definition modified: testrd"}]
+//   HTTP=200
+//   $ curl -sS http://.../v1/resource-definitions/testrd | jq .resource_group_name
+//   "nonexistent-rg-xyz"
+//
+// Sibling Bug 134 closed the same hole on RD create; this is the
+// symmetric gap on `rd modify --resource-group`.
+//
+// The fix routes through the existing `refuseRDCreateOnUnknownRG`
+// helper: 404 + LINSTOR envelope naming the missing RG; no spec
+// mutation persists when the gate rejects.
+
+// TestBug372PUTRDRefusesNonexistentRG pins the canonical reproducer.
+func TestBug372PUTRDRefusesNonexistentRG(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "okrg"}); err != nil {
+		t.Fatalf("seed okrg: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "testrd",
+		ResourceGroupName: "okrg",
+	}); err != nil {
+		t.Fatalf("seed testrd: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPut(t, base+"/v1/resource-definitions/testrd",
+		[]byte(`{"resource_group":"nonexistent-rg-xyz"}`))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 404 (Bug 372). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	got, _ := readAllBody(resp)
+	if !strings.Contains(string(got), "nonexistent-rg-xyz") {
+		t.Errorf("envelope missing offending RG name: %s", got)
+	}
+
+	if !strings.Contains(string(got), "resource group") {
+		t.Errorf("envelope missing 'resource group' label: %s", got)
+	}
+
+	// RD must NOT have its RG reference rewritten.
+	rd, err := st.ResourceDefinitions().Get(ctx, "testrd")
+	if err != nil {
+		t.Fatalf("re-fetch rd: %v", err)
+	}
+
+	if got, want := rd.ResourceGroupName, "okrg"; got != want {
+		t.Errorf("stored resource_group_name: got %q, want %q (must not persist after rejection)",
+			got, want)
+	}
+}
+
+// TestBug372PUTRDAcceptsExistingRG pins the positive path so the
+// gate doesn't block legitimate `rd modify --resource-group` calls
+// against a real RG.
+func TestBug372PUTRDAcceptsExistingRG(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg-a"}); err != nil {
+		t.Fatalf("seed rg-a: %v", err)
+	}
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg-b"}); err != nil {
+		t.Fatalf("seed rg-b: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "testrd",
+		ResourceGroupName: "rg-a",
+	}); err != nil {
+		t.Fatalf("seed rd: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPut(t, base+"/v1/resource-definitions/testrd",
+		[]byte(`{"resource_group":"rg-b"}`))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 200 (valid RG move). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	rd, err := st.ResourceDefinitions().Get(ctx, "testrd")
+	if err != nil {
+		t.Fatalf("re-fetch rd: %v", err)
+	}
+
+	if got, want := rd.ResourceGroupName, "rg-b"; got != want {
+		t.Errorf("stored resource_group_name: got %q, want %q (move did not stamp)",
+			got, want)
+	}
+}
+
+// TestBug372PUTRDPropsOnlyDoesNotTriggerRGGate pins the canonical
+// `rd set-property` shape (no resource_group key in the body): the
+// gate must NOT fire and the props merge runs normally.
+func TestBug372PUTRDPropsOnlyDoesNotTriggerRGGate(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg-a"}); err != nil {
+		t.Fatalf("seed rg-a: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "testrd",
+		ResourceGroupName: "rg-a",
+	}); err != nil {
+		t.Fatalf("seed rd: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPut(t, base+"/v1/resource-definitions/testrd",
+		[]byte(`{"override_props":{"Foo/Bar":"baz"}}`))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 200 (props-only modify). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	rd, err := st.ResourceDefinitions().Get(ctx, "testrd")
+	if err != nil {
+		t.Fatalf("re-fetch rd: %v", err)
+	}
+
+	if got, want := rd.Props["Foo/Bar"], "baz"; got != want {
+		t.Errorf("stored prop Foo/Bar: got %q, want %q", got, want)
+	}
+
+	if got, want := rd.ResourceGroupName, "rg-a"; got != want {
+		t.Errorf("stored resource_group_name: got %q, want %q (props-only must not touch RG)",
+			got, want)
+	}
+}
+
+// TestBug372PUTRDDstRscGrpAliasTriggersGate pins the `dst_rsc_grp`
+// alias (python-linstor 1.27.0's third spelling — see Bug 232). The
+// validation has to fire on every spelling the merge reads.
+func TestBug372PUTRDDstRscGrpAliasTriggersGate(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{Name: "rg-a"}); err != nil {
+		t.Fatalf("seed rg-a: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "testrd",
+		ResourceGroupName: "rg-a",
+	}); err != nil {
+		t.Fatalf("seed rd: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPut(t, base+"/v1/resource-definitions/testrd",
+		[]byte(`{"dst_rsc_grp":"phantom-rg-via-dst-alias"}`))
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		got, _ := readAllBody(resp)
+		t.Fatalf("status: got %d, want 404 (dst_rsc_grp alias must also gate). Body: %s",
+			resp.StatusCode, got)
+	}
+
+	rd, err := st.ResourceDefinitions().Get(ctx, "testrd")
+	if err != nil {
+		t.Fatalf("re-fetch rd: %v", err)
+	}
+
+	if got, want := rd.ResourceGroupName, "rg-a"; got != want {
+		t.Errorf("stored resource_group_name: got %q, want %q (must not persist after rejection)",
+			got, want)
+	}
+}

--- a/pkg/rest/resource_definitions.go
+++ b/pkg/rest/resource_definitions.go
@@ -486,6 +486,50 @@ func (s *Server) refuseRDCreateOnUnknownRG(w http.ResponseWriter, r *http.Reques
 	return false
 }
 
+// refuseRDUpdateOnUnknownRG is Bug 372's gate, the symmetric pair to
+// refuseRDCreateOnUnknownRG. Pre-fix `PUT /v1/resource-definitions/
+// {rd}` with a `resource_group` / `resource_group_name` /
+// `dst_rsc_grp` value naming a non-existent RG returned 200 +
+// "resource definition modified" and silently stamped the bogus name
+// onto `RD.Spec.ResourceGroupName`. The RD then lived on with a
+// dangling reference: `linstor rd l` rendered fine, but the placer's
+// Controller→RG→RD prop-inheritance walk silently dropped the RG
+// tier, breaking auto-place, auto-diskful, place_count observability,
+// and rebalance scheduling.
+//
+// Reuses refuseRDCreateOnUnknownRG since the gate semantics are
+// identical — the wire envelope wording stays uniform across create
+// and modify.
+//
+// Skip the gate when `rgChange` equals the RD's current
+// ResourceGroupName: Bug 163's GET→jq→PUT round-trip echoes the
+// stored RG name back unchanged, and the well-known `DfltRscGrp` is
+// lazily-created (ensureDefaultRGAssignment on RD create) — an
+// existing RD may legitimately reference an RG name that `Get`
+// surfaces as ErrNotFound during the round-trip window. A no-op
+// stamp must never refuse; only a real move to a fresh name does.
+//
+// Empty `rgChange` (the canonical `rd set-property` shape that
+// doesn't touch the RG link) bypasses the gate entirely — the
+// downstream merge leaves ResourceGroupName alone.
+//
+// Returns true when the caller may proceed; false when the HTTP
+// error has already been written.
+func (s *Server) refuseRDUpdateOnUnknownRG(w http.ResponseWriter, r *http.Request, rdName, rgChange string) bool {
+	if rgChange == "" {
+		return true
+	}
+
+	current, getErr := s.Store.ResourceDefinitions().Get(r.Context(), rdName)
+	if getErr == nil && current.ResourceGroupName == rgChange {
+		return true
+	}
+
+	probe := apiv1.ResourceDefinition{ResourceGroupName: rgChange}
+
+	return s.refuseRDCreateOnUnknownRG(w, r, &probe)
+}
+
 // DefaultResourceGroupName is the well-known RG every RD falls into
 // when the caller didn't pin one. Matches upstream LINSTOR's
 // `DfltRscGrp` literal so golinstor / linstor-csi callers that walk
@@ -946,6 +990,12 @@ func (s *Server) handleRDUpdate(w http.ResponseWriter, r *http.Request) {
 	// through the `--dst-rsc-grp` CLI flag.
 	if rgChange == "" {
 		rgChange = patch.DstRscGrp
+	}
+
+	// Bug 372 (P1): refuse rgChange that names a non-existent RG. See
+	// refuseRDUpdateOnUnknownRG below for the full rationale.
+	if !s.refuseRDUpdateOnUnknownRG(w, r, name, rgChange) {
+		return
 	}
 
 	err := s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(r.Context(), name, func(rd *apiv1.ResourceDefinition) error {

--- a/tests/e2e/rd-update-rg-validation.sh
+++ b/tests/e2e/rd-update-rg-validation.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# usage: rd-update-rg-validation.sh WORK_DIR
+#
+# Bug 372 (P1, hunt-caught 2026-06-02) — PUT /v1/resource-definitions/
+# {rd} with a body `{"resource_group":"nonexistent-rg-xyz"}` returned
+# HTTP 200 + "resource definition modified", silently stamping the
+# bogus name onto `RD.Spec.ResourceGroupName`. The RD then lived on
+# with a dangling reference: `linstor rd l` rendered fine, but the
+# placer's Controller→RG→RD prop-inheritance walk silently dropped
+# the RG tier, breaking auto-place, auto-diskful, place_count
+# observability, and rebalance scheduling.
+#
+# Sibling Bug 134 closed the same hole on RD create; this is the
+# symmetric gap on `rd modify --resource-group`. This e2e pins the
+# rejection on a live cluster and verifies the RG reference stays
+# untouched after the refusal — i.e. a failing PUT never persists.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug372-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+    curl -s -X DELETE "http://localhost:$PF_PORT/v1/resource-definitions/bug372-rd" >/dev/null 2>&1 || true
+    curl -s -X DELETE "http://localhost:$PF_PORT/v1/resource-groups/bug372-okrg" >/dev/null 2>&1 || true
+    curl -s -X DELETE "http://localhost:$PF_PORT/v1/resource-groups/bug372-other" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# --- Setup: two real RGs + one RD pointing at the first ---
+echo ">> seed bug372-okrg + bug372-other RGs"
+curl -sf -X POST "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"bug372-okrg","select_filter":{"place_count":1}}' >/dev/null
+curl -sf -X POST "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"bug372-other","select_filter":{"place_count":1}}' >/dev/null
+
+echo ">> seed bug372-rd in bug372-okrg"
+curl -sf -X POST "$B/v1/resource-definitions" -H "Content-Type: application/json" \
+    -d '{"resource_definition":{"name":"bug372-rd","resource_group_name":"bug372-okrg"}}' >/dev/null
+
+# --- Bug 372: PUT RD with nonexistent RG name ---
+echo ">> PUT /v1/resource-definitions/bug372-rd resource_group=ghost (Bug 372: must 404 + persist nothing)"
+CODE=$(curl -s -o /tmp/bug372-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug372-rd" \
+    -H "Content-Type: application/json" \
+    -d '{"resource_group":"ghost-rg-bug372"}')
+if [[ "$CODE" != "404" ]]; then
+    echo "FAIL: ghost RG PUT returned $CODE, expected 404"
+    cat /tmp/bug372-resp.txt
+    exit 1
+fi
+if ! grep -q "ghost-rg-bug372" /tmp/bug372-resp.txt; then
+    echo "FAIL: rejection envelope missing offending name:"
+    cat /tmp/bug372-resp.txt
+    exit 1
+fi
+echo "   404 + envelope OK"
+
+# --- Persistence: RG reference unchanged ---
+RG_NAME=$(curl -sf "$B/v1/resource-definitions/bug372-rd" | python3 -c 'import sys,json; print(json.load(sys.stdin)["resource_group_name"])')
+if [[ "$RG_NAME" != "bug372-okrg" ]]; then
+    echo "FAIL: RD.resource_group_name changed to $RG_NAME after rejected PUT (expected bug372-okrg)"
+    exit 1
+fi
+echo ">> persistence check: RD.resource_group_name unchanged after rejected PUT OK"
+
+# --- Bug 232 alias: dst_rsc_grp must trigger the same gate ---
+echo ">> PUT dst_rsc_grp=ghost (Bug 232 alias must also gate)"
+CODE=$(curl -s -o /tmp/bug372-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug372-rd" \
+    -H "Content-Type: application/json" \
+    -d '{"dst_rsc_grp":"ghost-via-dst-alias"}')
+if [[ "$CODE" != "404" ]]; then
+    echo "FAIL: dst_rsc_grp alias PUT returned $CODE, expected 404"
+    cat /tmp/bug372-resp.txt
+    exit 1
+fi
+echo "   404 + envelope OK"
+
+# --- Positive: valid RG move must work ---
+echo ">> PUT /v1/resource-definitions/bug372-rd resource_group=bug372-other (must 200)"
+CODE=$(curl -s -o /tmp/bug372-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug372-rd" \
+    -H "Content-Type: application/json" \
+    -d '{"resource_group":"bug372-other"}')
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: valid RG move PUT returned $CODE, expected 200"
+    cat /tmp/bug372-resp.txt
+    exit 1
+fi
+RG_NAME=$(curl -sf "$B/v1/resource-definitions/bug372-rd" | python3 -c 'import sys,json; print(json.load(sys.stdin)["resource_group_name"])')
+if [[ "$RG_NAME" != "bug372-other" ]]; then
+    echo "FAIL: RD.resource_group_name did not move to bug372-other (got $RG_NAME)"
+    exit 1
+fi
+echo "   200 + RG moved OK"
+
+# --- Negative: props-only PUT must not be gated by the RG check ---
+echo ">> PUT override_props (props-only, no RG key): must 200, RG untouched"
+CODE=$(curl -s -o /tmp/bug372-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug372-rd" \
+    -H "Content-Type: application/json" \
+    -d '{"override_props":{"Aux/bug372":"smoke"}}')
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: props-only PUT returned $CODE, expected 200"
+    cat /tmp/bug372-resp.txt
+    exit 1
+fi
+RG_NAME=$(curl -sf "$B/v1/resource-definitions/bug372-rd" | python3 -c 'import sys,json; print(json.load(sys.stdin)["resource_group_name"])')
+if [[ "$RG_NAME" != "bug372-other" ]]; then
+    echo "FAIL: props-only PUT side-effected RG (got $RG_NAME, expected bug372-other)"
+    exit 1
+fi
+echo "   200 + RG unchanged OK"
+
+echo ">> PASS: Bug 372 — PUT /v1/resource-definitions/{rd} rejects unknown RG at REST wire"


### PR DESCRIPTION
## Summary

PUT /v1/resource-definitions/{rd} with `{"resource_group":"nonexistent-rg-xyz"}` returned HTTP 200 and silently stamped the bogus name onto `RD.Spec.ResourceGroupName`. The RD then lived on with a dangling reference: `linstor rd l` rendered fine, but the placer's Controller→RG→RD prop-inheritance walk silently dropped the RG tier, breaking auto-place, auto-diskful, place_count observability, and the RGRebalanceReconciler.

Sibling Bug 134 closed the same hole on RD create; this is the symmetric gap on `rd modify --resource-group`. `refuseRDUpdateOnUnknownRG` reuses the existing create-path helper so the wire envelope wording stays uniform; all three RG-naming spellings the handler merges (`resource_group`, `resource_group_name`, `dst_rsc_grp`) funnel through the same gate.

A no-op stamp (rgChange equals the RD's current `ResourceGroupName`) short-circuits before the existence check so Bug 163's GET → jq → PUT round-trip stays green even when the well-known `DfltRscGrp` is in its lazy-create window.

## Reproducer

Live dev stand, Round 7 bug-hunt 2026-06-02:

```
$ curl -sS -X PUT http://.../v1/resource-definitions/testrd \
    -d '{"resource_group":"nonexistent-rg-xyz"}'
[{"ret_code":4294967296,"message":"resource definition modified: testrd"}]
HTTP=200

$ curl -sS http://.../v1/resource-definitions/testrd | jq .resource_group_name
"nonexistent-rg-xyz"
```

## Test plan

- [x] Unit tests cover the reproducer, positive RG-move, props-only PUT (no RG mutation), and the dst_rsc_grp alias gate
- [x] `go test ./pkg/rest/ -timeout 240s` passes (TestBug232 updated to seed `rg-new`)
- [x] New e2e catcher `tests/e2e/rd-update-rg-validation.sh` pins the rejection on a live cluster
- [ ] CI green