### PR TITLE
fix(rest): reject StorDriver/* mutation on PUT storage-pools (Bug 373)

### DIFF
--- a/pkg/rest/bug_373_sp_immutable_driver_props_test.go
+++ b/pkg/rest/bug_373_sp_immutable_driver_props_test.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestBug373SPModifyRefusesZPoolOverride pins the Bug 373 (Round 8 P1)
+// guard: `PUT /v1/nodes/{node}/storage-pools/{pool}` MUST refuse any
+// `override_props` that touches the backing-driver identity keys
+// (StorDriver/ZPool[Thin], LvmVg, ThinPool, FileDir, StorPoolName).
+//
+// Pre-fix, `linstor sp set-property dev-worker-1 zfs-thin
+// StorDriver/ZPoolThin bogus-pool` returned 200 + MASK_INFO, the
+// store row's StorDriver/ZPoolThin flipped to "bogus-pool", and the
+// satellite's NewProviderFromKind started failing every subsequent
+// placement / autoplace / resize against the pool. All active
+// replicas still reported UpToDate (the kernel-DRBD device was
+// already open against the original backend), so the cluster gave
+// no operator-visible signal until the next provisioning call.
+//
+// Post-fix: 400 + apiCallRcFailInvldStorPoolName (552), live row's
+// Props stay byte-identical to pre-call, operator gets actionable
+// "drop + recreate the pool with the new backing key" guidance.
+func TestBug373SPModifyRefusesZPoolOverride(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "n1", Type: apiv1.NodeTypeSatellite}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		NodeName:        "n1",
+		StoragePoolName: "zfs-thin",
+		ProviderKind:    apiv1.StoragePoolKindZFSThin,
+		Props:           map[string]string{"StorDriver/ZPoolThin": "blockstor-zfs"},
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		OverrideProps: map[string]string{"StorDriver/ZPoolThin": "bogus-live-pool"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/nodes/n1/storage-pools/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var envelope []apiv1.APICallRc
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (body: %s)", err, string(raw))
+	}
+
+	if len(envelope) == 0 {
+		t.Fatalf("envelope empty, want one ApiCallRc")
+	}
+
+	if envelope[0].RetCode != apiCallRcError|apiCallRcFailInvldStorPoolName {
+		t.Errorf("ret_code = %d, want %d (apiCallRcError | apiCallRcFailInvldStorPoolName)",
+			envelope[0].RetCode, apiCallRcError|apiCallRcFailInvldStorPoolName)
+	}
+
+	if !strings.Contains(envelope[0].Message, "StorDriver/ZPoolThin") {
+		t.Errorf("message missing offending key: %q", envelope[0].Message)
+	}
+
+	// Live row's Props must stay byte-identical to pre-call — the
+	// whole point of the fix is "PUT must not flip the backing key".
+	got, err := st.StoragePools().Get(ctx, "n1", "zfs-thin")
+	if err != nil {
+		t.Fatalf("Get after refused PUT: %v", err)
+	}
+
+	if got.Props["StorDriver/ZPoolThin"] != "blockstor-zfs" {
+		t.Errorf("Props[StorDriver/ZPoolThin] = %q, want blockstor-zfs (refused PUT must not mutate the row)",
+			got.Props["StorDriver/ZPoolThin"])
+	}
+}
+
+// TestBug373SPModifyRefusesDeletePropsOnDriverKey pins the
+// `delete_props`-flank guard. The same backing-identity keys must be
+// refused via `delete_props` too — dropping the key wholesale is
+// arguably worse than overriding it (the satellite-side provider
+// loader will surface "requires StorDriver/<key> in props" instead
+// of silently using a wrong backend).
+func TestBug373SPModifyRefusesDeletePropsOnDriverKey(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "n1", Type: apiv1.NodeTypeSatellite}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		NodeName:        "n1",
+		StoragePoolName: "lvm-thin",
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		Props: map[string]string{
+			"StorDriver/LvmVg":    "vg1",
+			"StorDriver/ThinPool": "thin",
+		},
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		DeleteProps: []string{"StorDriver/LvmVg"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/nodes/n1/storage-pools/lvm-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	got, err := st.StoragePools().Get(ctx, "n1", "lvm-thin")
+	if err != nil {
+		t.Fatalf("Get after refused PUT: %v", err)
+	}
+
+	if got.Props["StorDriver/LvmVg"] != "vg1" {
+		t.Errorf("Props[StorDriver/LvmVg] = %q, want vg1 (refused delete_props must not drop the key)",
+			got.Props["StorDriver/LvmVg"])
+	}
+}
+
+// TestBug373SPModifyRefusesDeleteNamespaceOnStorDriver pins the
+// `delete_namespaces`-flank guard. `linstor sp delete-namespace
+// <n> <p> StorDriver` would otherwise wipe the pool's entire backing
+// identity in one round-trip.
+func TestBug373SPModifyRefusesDeleteNamespaceOnStorDriver(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "n1", Type: apiv1.NodeTypeSatellite}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		NodeName:        "n1",
+		StoragePoolName: "zfs-thin",
+		ProviderKind:    apiv1.StoragePoolKindZFSThin,
+		Props:           map[string]string{"StorDriver/ZPoolThin": "blockstor-zfs"},
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		DeleteNamespace: []string{"StorDriver"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/nodes/n1/storage-pools/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var envelope []apiv1.APICallRc
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (body: %s)", err, string(raw))
+	}
+
+	if !strings.Contains(envelope[0].Message, "delete_namespaces:StorDriver") {
+		t.Errorf("message missing namespace hit: %q", envelope[0].Message)
+	}
+
+	got, err := st.StoragePools().Get(ctx, "n1", "zfs-thin")
+	if err != nil {
+		t.Fatalf("Get after refused PUT: %v", err)
+	}
+
+	if got.Props["StorDriver/ZPoolThin"] != "blockstor-zfs" {
+		t.Errorf("Props[StorDriver/ZPoolThin] = %q, want blockstor-zfs (refused delete_namespaces must not drop keys)",
+			got.Props["StorDriver/ZPoolThin"])
+	}
+}
+
+// TestBug373SPModifyAcceptsBenignOverride is the positive flank: a
+// PUT that only touches non-driver props (PrefNic, Aux/*, etc.) MUST
+// keep landing exactly as it did before the fix. Regression guard
+// against an overly-broad refuseSPDriverPropMutation match.
+func TestBug373SPModifyAcceptsBenignOverride(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "n1", Type: apiv1.NodeTypeSatellite}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		NodeName:        "n1",
+		StoragePoolName: "zfs-thin",
+		ProviderKind:    apiv1.StoragePoolKindZFSThin,
+		Props:           map[string]string{"StorDriver/ZPoolThin": "blockstor-zfs"},
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		OverrideProps: map[string]string{
+			"PrefNic":     "default",
+			"Aux/rack-id": "r1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/nodes/n1/storage-pools/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (benign override must land)", resp.StatusCode)
+	}
+
+	got, err := st.StoragePools().Get(ctx, "n1", "zfs-thin")
+	if err != nil {
+		t.Fatalf("Get after PUT: %v", err)
+	}
+
+	if got.Props["PrefNic"] != "default" {
+		t.Errorf("Props[PrefNic] = %q, want default", got.Props["PrefNic"])
+	}
+
+	if got.Props["Aux/rack-id"] != "r1" {
+		t.Errorf("Props[Aux/rack-id] = %q, want r1", got.Props["Aux/rack-id"])
+	}
+
+	if got.Props["StorDriver/ZPoolThin"] != "blockstor-zfs" {
+		t.Errorf("Props[StorDriver/ZPoolThin] = %q, want blockstor-zfs (benign PUT must preserve backing key)",
+			got.Props["StorDriver/ZPoolThin"])
+	}
+}

--- a/pkg/rest/storage_pools.go
+++ b/pkg/rest/storage_pools.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"maps"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -77,6 +78,26 @@ func (s *Server) handleNodeStoragePoolModify(w http.ResponseWriter, r *http.Requ
 	}
 
 	patch := body.GenericPropsModify
+
+	// Bug 373 (P1 data-availability): refuse any patch that touches
+	// the backing-driver identity props (StorDriver/ZPool[Thin],
+	// LvmVg, ThinPool, FileDir, StorPoolName). These keys are
+	// effectively immutable — they pin a StoragePool to a specific
+	// VG / zpool / directory on the host, and the satellite's
+	// NewProviderFromKind reads them once at registration. Letting
+	// a PUT override them silently flips the pool to a different /
+	// non-existent backend, leaves every active replica still
+	// UpToDate (the kernel-side DRBD device is already open) but
+	// breaks every subsequent placement / autoplace / resize.
+	// Refused HERE rather than at the store boundary so the wire
+	// envelope carries the LINSTOR-standard 552 sub-code and points
+	// at the right escape path (drop + recreate the pool, never
+	// mutate the backing key on the live row).
+	if msg, refused := refuseSPDriverPropMutation(&patch); refused {
+		writeSPDriverPropMutationRefusal(w, node, pool, msg)
+
+		return
+	}
 
 	// Bug 204b: route through PatchStoragePoolSpec so the override /
 	// delete delta is re-applied to the freshly-fetched StoragePool on
@@ -738,6 +759,122 @@ const (
 	propZPoolThin    = "StorDriver/ZPoolThin"
 	propFileDir      = "StorDriver/FileDir"
 )
+
+// immutableSPDriverProps returns the StoragePool prop keys that pin
+// the pool to a specific backing VG / zpool / directory on the host.
+// Mutating any of these on a live StoragePool row silently flips the
+// pool to a different (or non-existent) backend without re-running the
+// satellite's NewProviderFromKind, which leaves every active replica
+// still UpToDate at the kernel-DRBD layer but breaks every subsequent
+// placement / autoplace / resize call against the pool — a P1 data-
+// availability footgun. Bug 373: refuse the mutation at the REST
+// boundary; the only safe path is "drop + recreate the pool with the
+// new backing key".
+//
+// `StorDriver/StorPoolName` is in the list too because Bug 63's
+// expandStorPoolNameAlias derives the kind-specific keys from it on
+// the create path — letting a PUT clobber it would re-trigger the
+// same alias-rewrite path against the live row and silently mutate
+// the kind-specific key downstream.
+//
+// Returned as a function (not a package-level var) so the lint
+// `gochecknoglobals` budget stays clean; the slice is tiny and the
+// validator is hit once per PUT.
+func immutableSPDriverProps() []string {
+	return []string{
+		propStorPoolName,
+		propLvmVG,
+		propThinPool,
+		propZPool,
+		propZPoolThin,
+		propFileDir,
+	}
+}
+
+// refuseSPDriverPropMutation walks the GenericPropsModify patch and
+// returns a (joined-prop-list, true) tuple when any of the immutable
+// backing-driver keys would be touched. Three flanks are checked:
+//
+//   - override_props: an explicit value for any immutable key.
+//   - delete_props: an explicit key in the immutable set.
+//   - delete_namespaces: a prefix that, with the '/' separator
+//     appended, would catch any immutable key. The shared "StorDriver"
+//     prefix means deleting the namespace would wipe the pool's
+//     backing identity wholesale, so refuse that too.
+//
+// Returns ("", false) when the patch is clean (no immutable keys
+// touched). The caller writes the typed-envelope error on refuse.
+func refuseSPDriverPropMutation(patch *apiv1.GenericPropsModify) (string, bool) {
+	if patch == nil {
+		return "", false
+	}
+
+	keys := immutableSPDriverProps()
+	hit := make([]string, 0, len(keys))
+
+	for _, key := range keys {
+		if _, ok := patch.OverrideProps[key]; ok {
+			hit = append(hit, key)
+
+			continue
+		}
+
+		if slices.Contains(patch.DeleteProps, key) {
+			hit = append(hit, key)
+		}
+	}
+
+	// delete_namespaces: a single "StorDriver" entry (or any prefix
+	// that catches the immutable keys' shared "StorDriver/" namespace)
+	// would otherwise nuke the backing identity wholesale. Flag the
+	// whole namespace so the operator sees the actionable name.
+	for _, ns := range patch.DeleteNamespace {
+		prefix := ns + "/"
+
+		for _, key := range keys {
+			if strings.HasPrefix(key, prefix) {
+				hit = append(hit, "delete_namespaces:"+ns)
+
+				break
+			}
+		}
+	}
+
+	if len(hit) == 0 {
+		return "", false
+	}
+
+	return strings.Join(hit, ", "), true
+}
+
+// writeSPDriverPropMutationRefusal emits the Bug 373 typed-envelope
+// 400 response: LINSTOR sub-code 552 (FAIL_INVLD_STOR_POOL_NAME),
+// operator-facing cause + correction text, and obj_refs pinning the
+// (node, pool) pair so audit-log greppers can correlate against the
+// originating PUT. Extracted out of handleNodeStoragePoolModify to
+// keep the handler under the funlen budget.
+func writeSPDriverPropMutationRefusal(w http.ResponseWriter, node, pool, msg string) {
+	writeJSON(w, http.StatusBadRequest, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInvldStorPoolName,
+		Message: "storage pool '" + pool + "' on node '" + node +
+			"': refusing to mutate backing-driver identity prop(s): " + msg,
+		Cause: "the requested override_props / delete_props / " +
+			"delete_namespaces touches a StorDriver/* key that pins " +
+			"this StoragePool to its backing VG / zpool / directory. " +
+			"These keys are read once at satellite registration; " +
+			"changing them on a live pool silently desyncs the row " +
+			"from the actual backend and breaks every subsequent " +
+			"placement, autoplace, and resize call against the pool.",
+		Correc: "drop the storage pool (`linstor sp d`) and recreate " +
+			"it with the desired backing key, OR target the prop " +
+			"on a freshly-created StoragePool — never mutate the " +
+			"backing key on the live row.",
+		ObjRefs: map[string]string{
+			objRefNode:     node,
+			objRefStorPool: pool,
+		},
+	}})
+}
 
 // expandStorPoolNameAlias normalises a pool's Spec.Props for Bug 63.
 //

--- a/tests/e2e/sp-immutable-driver-props.sh
+++ b/tests/e2e/sp-immutable-driver-props.sh
@@ -44,26 +44,98 @@ for _ in $(seq 1 30); do
 done
 
 B="http://localhost:$PF_PORT"
-NODE="${E2E_NODE_DISKFUL_1:-dev-worker-1}"
-POOL="zfs-thin"
 
-# Capture the live pool's StorDriver/ZPoolThin so we can verify
-# byte-identical state post-call.
-PRE_BACKING=$(curl -sf "$B/v1/nodes/$NODE/storage-pools/$POOL" \
-    | python3 -c 'import sys, json; sp=json.load(sys.stdin); print(sp.get("props",{}).get("StorDriver/ZPoolThin",""))')
+# Use the discovered worker name from lib.sh ($WORKER_1 maps to
+# "<stand-prefix>-worker-1" so dev/ci-laneN/anyN-NAMEd stand work
+# unchanged). Pick the first pool that carries any StorDriver/* backing
+# key — `make pools TYPE=both` provisions both zfs-thin and lvm-thin on
+# the CI stand, but a TYPE=zfs / TYPE=lvm caller has only one. The
+# probe is `curl -s` (not `-sf`) so an HTTP error still surfaces a
+# body to grep + a non-empty payload to log instead of an opaque
+# JSONDecodeError on an empty pipe stdin.
+NODE="${WORKER_1:-dev-worker-1}"
 
-if [[ -z "$PRE_BACKING" ]]; then
-    echo "FAIL: pool $POOL on $NODE has no StorDriver/ZPoolThin to protect; check stand fixture"
+# Find a pool on this node that has a StorDriver/* backing prop we can
+# round-trip. zfs-thin's `ZPoolThin` and lvm-thin's `LvmVg` both qualify;
+# the immutable-list covers either. Bail with a useful diagnostic if
+# the stand only registered FILE_THIN (`stand` pool — has no backing
+# prop to mutate, so the scenario is moot).
+SP_JSON=$(curl -s "$B/v1/nodes/$NODE/storage-pools" || true)
+
+if [[ -z "$SP_JSON" || "$SP_JSON" == "null" ]]; then
+    echo "FAIL: GET storage-pools returned empty body; port-forward up but apiserver not ready"
     exit 1
 fi
 
-echo ">> pre-call StorDriver/ZPoolThin = $PRE_BACKING"
+POOL=$(echo "$SP_JSON" | python3 -c '
+import sys, json
+try:
+    pools = json.load(sys.stdin)
+except Exception as exc:
+    print("", end="")
+    sys.exit(0)
+for sp in pools:
+    props = sp.get("props") or {}
+    for k in ("StorDriver/ZPoolThin", "StorDriver/ZPool", "StorDriver/LvmVg"):
+        if props.get(k):
+            print(sp["storage_pool_name"])
+            sys.exit(0)
+')
+
+if [[ -z "$POOL" ]]; then
+    echo "FAIL: no StorDriver-backed pool found on $NODE; got:"
+    echo "$SP_JSON" | head -c 500
+    exit 1
+fi
+
+echo ">> targeting pool $POOL on $NODE"
+
+# Capture which backing key the pool uses so we can craft a body that
+# touches THE pool's actual key (a ZFS pool has no LvmVg; the immutable
+# list covers both, but the response body needs the right key name to
+# diagnose).
+PRE_KEY=$(curl -s "$B/v1/nodes/$NODE/storage-pools/$POOL" | python3 -c '
+import sys, json
+try:
+    sp = json.load(sys.stdin)
+except Exception:
+    print("")
+    sys.exit(0)
+props = sp.get("props") or {}
+for k in ("StorDriver/ZPoolThin", "StorDriver/ZPool", "StorDriver/LvmVg"):
+    if props.get(k):
+        print(k)
+        sys.exit(0)
+print("")
+')
+
+if [[ -z "$PRE_KEY" ]]; then
+    echo "FAIL: pool $POOL on $NODE has no StorDriver/* prop; check stand fixture"
+    exit 1
+fi
+
+PRE_BACKING=$(curl -s "$B/v1/nodes/$NODE/storage-pools/$POOL" | python3 -c '
+import sys, json
+try:
+    sp = json.load(sys.stdin)
+except Exception:
+    print("")
+    sys.exit(0)
+print((sp.get("props") or {}).get("'"$PRE_KEY"'", ""))
+')
+
+if [[ -z "$PRE_BACKING" ]]; then
+    echo "FAIL: pool $POOL backing $PRE_KEY is empty"
+    exit 1
+fi
+
+echo ">> backing key $PRE_KEY = $PRE_BACKING"
 
 # --- override_props on a backing-driver key must 400 ---
-echo ">> PUT override_props StorDriver/ZPoolThin=bogus: must 400 + structured envelope"
+echo ">> PUT override_props $PRE_KEY=bogus: must 400 + structured envelope"
 CODE=$(curl -s -o /tmp/bug373-resp.txt -w "%{http_code}" -X PUT \
     "$B/v1/nodes/$NODE/storage-pools/$POOL" -H "Content-Type: application/json" \
-    -d '{"override_props":{"StorDriver/ZPoolThin":"bug373-bogus"}}')
+    -d '{"override_props":{"'"$PRE_KEY"'":"bug373-bogus"}}')
 
 if [[ "$CODE" != "400" ]]; then
     echo "FAIL: Bug 373 PUT override_props returned $CODE, expected 400"
@@ -71,7 +143,7 @@ if [[ "$CODE" != "400" ]]; then
     exit 1
 fi
 
-if ! grep -q "StorDriver/ZPoolThin" /tmp/bug373-resp.txt; then
+if ! grep -q "$PRE_KEY" /tmp/bug373-resp.txt; then
     echo "FAIL: rejection envelope missing offending key:"
     cat /tmp/bug373-resp.txt
     exit 1
@@ -86,8 +158,15 @@ fi
 echo "   400 + structured envelope OK"
 
 # --- live row must stay byte-identical ---
-POST_BACKING=$(curl -sf "$B/v1/nodes/$NODE/storage-pools/$POOL" \
-    | python3 -c 'import sys, json; sp=json.load(sys.stdin); print(sp.get("props",{}).get("StorDriver/ZPoolThin",""))')
+POST_BACKING=$(curl -s "$B/v1/nodes/$NODE/storage-pools/$POOL" | python3 -c '
+import sys, json
+try:
+    sp = json.load(sys.stdin)
+except Exception:
+    print("")
+    sys.exit(0)
+print((sp.get("props") or {}).get("'"$PRE_KEY"'", ""))
+')
 
 if [[ "$POST_BACKING" != "$PRE_BACKING" ]]; then
     echo "FAIL: backing key mutated despite rejected PUT: $PRE_BACKING -> $POST_BACKING"
@@ -96,10 +175,10 @@ fi
 echo ">> backing key unchanged post-rejection OK"
 
 # --- delete_props on backing-driver key must 400 ---
-echo ">> PUT delete_props=[StorDriver/ZPoolThin]: must 400"
+echo ">> PUT delete_props=[$PRE_KEY]: must 400"
 CODE=$(curl -s -o /tmp/bug373-resp.txt -w "%{http_code}" -X PUT \
     "$B/v1/nodes/$NODE/storage-pools/$POOL" -H "Content-Type: application/json" \
-    -d '{"delete_props":["StorDriver/ZPoolThin"]}')
+    -d '{"delete_props":["'"$PRE_KEY"'"]}')
 
 if [[ "$CODE" != "400" ]]; then
     echo "FAIL: Bug 373 PUT delete_props returned $CODE, expected 400"
@@ -142,8 +221,15 @@ curl -sf -X PUT "$B/v1/nodes/$NODE/storage-pools/$POOL" \
     -d '{"delete_props":["PrefNic"]}' >/dev/null || true
 
 # --- final: backing key still byte-identical to pre-test ---
-FINAL_BACKING=$(curl -sf "$B/v1/nodes/$NODE/storage-pools/$POOL" \
-    | python3 -c 'import sys, json; sp=json.load(sys.stdin); print(sp.get("props",{}).get("StorDriver/ZPoolThin",""))')
+FINAL_BACKING=$(curl -s "$B/v1/nodes/$NODE/storage-pools/$POOL" | python3 -c '
+import sys, json
+try:
+    sp = json.load(sys.stdin)
+except Exception:
+    print("")
+    sys.exit(0)
+print((sp.get("props") or {}).get("'"$PRE_KEY"'", ""))
+')
 
 if [[ "$FINAL_BACKING" != "$PRE_BACKING" ]]; then
     echo "FAIL: backing key mutated across the test sequence: $PRE_BACKING -> $FINAL_BACKING"

--- a/tests/e2e/sp-immutable-driver-props.sh
+++ b/tests/e2e/sp-immutable-driver-props.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# usage: sp-immutable-driver-props.sh WORK_DIR
+#
+# Bug 373 (P1, hunt-caught 2026-06-02) — `PUT /v1/nodes/{node}/
+# storage-pools/{pool}` accepted `override_props` (and `delete_props`
+# / `delete_namespaces`) that touched the backing-driver identity
+# keys (StorDriver/ZPool[Thin], LvmVg, ThinPool, FileDir,
+# StorPoolName). Mutating any of them silently flipped the live
+# StoragePool to a different / non-existent backend; every active
+# replica still reported UpToDate (the kernel-DRBD device was open
+# against the original backend), so the cluster gave NO operator-
+# visible signal until the next placement / autoplace / resize call
+# blew up with "pool backing storage missing on node …".
+#
+# This e2e pins the rejection on a live cluster (not just the unit
+# test) and verifies the pool row stays byte-identical post-call.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug373-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+NODE="${E2E_NODE_DISKFUL_1:-dev-worker-1}"
+POOL="zfs-thin"
+
+# Capture the live pool's StorDriver/ZPoolThin so we can verify
+# byte-identical state post-call.
+PRE_BACKING=$(curl -sf "$B/v1/nodes/$NODE/storage-pools/$POOL" \
+    | python3 -c 'import sys, json; sp=json.load(sys.stdin); print(sp.get("props",{}).get("StorDriver/ZPoolThin",""))')
+
+if [[ -z "$PRE_BACKING" ]]; then
+    echo "FAIL: pool $POOL on $NODE has no StorDriver/ZPoolThin to protect; check stand fixture"
+    exit 1
+fi
+
+echo ">> pre-call StorDriver/ZPoolThin = $PRE_BACKING"
+
+# --- override_props on a backing-driver key must 400 ---
+echo ">> PUT override_props StorDriver/ZPoolThin=bogus: must 400 + structured envelope"
+CODE=$(curl -s -o /tmp/bug373-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/nodes/$NODE/storage-pools/$POOL" -H "Content-Type: application/json" \
+    -d '{"override_props":{"StorDriver/ZPoolThin":"bug373-bogus"}}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 373 PUT override_props returned $CODE, expected 400"
+    cat /tmp/bug373-resp.txt
+    exit 1
+fi
+
+if ! grep -q "StorDriver/ZPoolThin" /tmp/bug373-resp.txt; then
+    echo "FAIL: rejection envelope missing offending key:"
+    cat /tmp/bug373-resp.txt
+    exit 1
+fi
+
+if ! grep -q "refusing to mutate" /tmp/bug373-resp.txt; then
+    echo "FAIL: rejection envelope missing operator-facing phrase:"
+    cat /tmp/bug373-resp.txt
+    exit 1
+fi
+
+echo "   400 + structured envelope OK"
+
+# --- live row must stay byte-identical ---
+POST_BACKING=$(curl -sf "$B/v1/nodes/$NODE/storage-pools/$POOL" \
+    | python3 -c 'import sys, json; sp=json.load(sys.stdin); print(sp.get("props",{}).get("StorDriver/ZPoolThin",""))')
+
+if [[ "$POST_BACKING" != "$PRE_BACKING" ]]; then
+    echo "FAIL: backing key mutated despite rejected PUT: $PRE_BACKING -> $POST_BACKING"
+    exit 1
+fi
+echo ">> backing key unchanged post-rejection OK"
+
+# --- delete_props on backing-driver key must 400 ---
+echo ">> PUT delete_props=[StorDriver/ZPoolThin]: must 400"
+CODE=$(curl -s -o /tmp/bug373-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/nodes/$NODE/storage-pools/$POOL" -H "Content-Type: application/json" \
+    -d '{"delete_props":["StorDriver/ZPoolThin"]}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 373 PUT delete_props returned $CODE, expected 400"
+    cat /tmp/bug373-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# --- delete_namespaces=[StorDriver] must 400 ---
+echo ">> PUT delete_namespaces=[StorDriver]: must 400"
+CODE=$(curl -s -o /tmp/bug373-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/nodes/$NODE/storage-pools/$POOL" -H "Content-Type: application/json" \
+    -d '{"delete_namespaces":["StorDriver"]}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 373 PUT delete_namespaces returned $CODE, expected 400"
+    cat /tmp/bug373-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# --- benign override_props (PrefNic) must STILL land (regression guard) ---
+echo ">> PUT override_props PrefNic=default: must 200 (benign)"
+CODE=$(curl -s -o /tmp/bug373-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/nodes/$NODE/storage-pools/$POOL" -H "Content-Type: application/json" \
+    -d '{"override_props":{"PrefNic":"default"}}')
+
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: benign PUT PrefNic returned $CODE, expected 200 (regression)"
+    cat /tmp/bug373-resp.txt
+    exit 1
+fi
+echo "   200 OK"
+
+# Drop the benign PrefNic we just stamped so the next e2e run sees a
+# clean fixture; the backing-key delete is allowed because PrefNic
+# isn't in the immutable list.
+curl -sf -X PUT "$B/v1/nodes/$NODE/storage-pools/$POOL" \
+    -H "Content-Type: application/json" \
+    -d '{"delete_props":["PrefNic"]}' >/dev/null || true
+
+# --- final: backing key still byte-identical to pre-test ---
+FINAL_BACKING=$(curl -sf "$B/v1/nodes/$NODE/storage-pools/$POOL" \
+    | python3 -c 'import sys, json; sp=json.load(sys.stdin); print(sp.get("props",{}).get("StorDriver/ZPoolThin",""))')
+
+if [[ "$FINAL_BACKING" != "$PRE_BACKING" ]]; then
+    echo "FAIL: backing key mutated across the test sequence: $PRE_BACKING -> $FINAL_BACKING"
+    exit 1
+fi
+
+echo ">> PASS: Bug 373 — PUT storage-pools refuses StorDriver/* mutation"


### PR DESCRIPTION
## Summary

`PUT /v1/nodes/{node}/storage-pools/{pool}` accepted `override_props` (and `delete_props` / `delete_namespaces`) that touched the backing-driver identity keys: `StorDriver/ZPool`, `StorDriver/ZPoolThin`, `StorDriver/LvmVg`, `StorDriver/ThinPool`, `StorDriver/FileDir`, and `StorDriver/StorPoolName`. These keys pin the `StoragePool` to a specific VG / zpool / directory on the host. Mutating any of them silently flipped the live row to a different (or non-existent) backend; all active replicas still reported `UpToDate` (the kernel-DRBD device was already open against the original backend), so the cluster gave NO operator-visible signal until the next placement / autoplace / resize call blew up with `pool backing storage missing on node ...`.

A single `linstor sp set-property <node> <pool> StorDriver/ZPoolThin bogus` call from any client with PUT rights was enough to silently DoS the pool.

This PR refuses the mutation at the REST boundary with `400` + `apiCallRcFailInvldStorPoolName` (552, mirroring upstream LINSTOR's `FAIL_INVLD_STOR_POOL_NAME` wire shape) and operator-facing guidance pointing at the only safe path: drop the pool and recreate it with the desired backing key.

Bug-hunt round 8 P1 finding (2026-06-02). Caught empirically on the dev stand.

## Test plan

- [x] Unit tests (`pkg/rest/bug_373_sp_immutable_driver_props_test.go`):
  - `TestBug373SPModifyRefusesZPoolOverride` — override_props on `StorDriver/ZPoolThin` returns 400, row stays byte-identical.
  - `TestBug373SPModifyRefusesDeletePropsOnDriverKey` — delete_props on `StorDriver/LvmVg` returns 400, row stays byte-identical.
  - `TestBug373SPModifyRefusesDeleteNamespaceOnStorDriver` — delete_namespaces=["StorDriver"] returns 400.
  - `TestBug373SPModifyAcceptsBenignOverride` — `PrefNic` / `Aux/rack-id` overrides still land (regression guard).
- [x] E2E test (`tests/e2e/sp-immutable-driver-props.sh`) that runs the same matrix on a live QEMU cluster — verified pre-fix on the dev stand to fail (200 instead of 400), post-fix expected to pass.
- [x] `go test ./pkg/rest/` — full suite clean.
- [x] `golangci-lint run ./pkg/rest/...` — 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage pool driver identity properties are now protected against unintended modifications. The API rejects attempts to override, delete, or remove driver-related configuration properties with HTTP 400 error responses, preventing potential corruption of storage pool backing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->