### PR TITLE
fix(rest): emit ApiCallRc envelope on five bare-200 write endpoints (Bug 374)

### DIFF
--- a/pkg/rest/bug_374_envelope_shape_test.go
+++ b/pkg/rest/bug_374_envelope_shape_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 374 (P2, bughunt round 9 — 2026-06-02): several write-side REST
+// endpoints returned a bare `WriteHeader(200|201)` with no JSON body.
+// Sibling endpoints learned the lesson the hard way (Bug 45 against
+// golinstor, Bug 129 against python-linstor 1.27.1) — both response
+// parsers unconditionally json-decode every non-204 2xx response and
+// crash with `"Expecting value: line 1 column 1 (char 0)"` on an
+// empty body. Drift discovered in round-9 bughunt:
+//
+//   - POST /v1/resource-definitions/{rd}/adjust
+//   - POST /v1/resource-definitions/{rd}/resources/{node}/adjust
+//   - POST /v1/resource-definitions/{rd}/encryption-passphrase
+//     (per-RD DRBD shared-secret writer)
+//   - POST /v1/encryption/passphrase  (idempotent-replay branch only)
+//   - POST /v1/resource-definitions/{rd}/resource-connections/
+//     {a}/{b}/paths
+//   - PUT  /v1/resource-groups/{rg}/volume-groups/{vlmNr}
+//
+// This file pins the wire shape so a future refactor can't silently
+// reintroduce the bare 200. Each test reads the body, json.Unmarshals
+// into `[]apiv1.APICallRc`, and asserts the slice is non-empty.
+
+// Common assertion: status code is `wantCode`, body decodes as
+// `[]apiv1.APICallRc`, slice non-empty, first entry has a non-empty
+// Message. This is the shape every CLI parser dereferences. Callers
+// must drain + close resp.Body themselves so the linter's bodyclose
+// rule stays happy at the call-site.
+func assertEnvelopeShape(t *testing.T, body []byte, gotCode, wantCode int) {
+	t.Helper()
+
+	if gotCode != wantCode {
+		t.Fatalf("status: got %d, want %d", gotCode, wantCode)
+	}
+
+	if len(body) == 0 {
+		t.Fatalf("empty body — bare WriteHeader regression (Bug 374)")
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(body, &rcs); err != nil {
+		t.Fatalf("body not []ApiCallRc: %v; body=%q", err, body)
+	}
+
+	if len(rcs) == 0 {
+		t.Fatalf("empty []ApiCallRc slice; body=%q", body)
+	}
+
+	if rcs[0].Message == "" {
+		t.Fatalf("first ApiCallRc has empty Message; body=%q", body)
+	}
+}
+
+// readBodyBytes drains a response body that the caller has already
+// scheduled to close via `defer resp.Body.Close()`. Separated from
+// the body-close itself so golangci-lint's bodyclose pass sees the
+// `Close()` at the use-site of the response and stops complaining.
+func readBodyBytes(t *testing.T, resp *http.Response) []byte {
+	t.Helper()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return body
+}
+
+// TestBug374_AdjustAllEnvelope: POST /v1/resource-definitions/{rd}/
+// adjust returns 200 + ApiCallRc envelope, not a bare 200.
+func TestBug374_AdjustAllEnvelope(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPost(t, base+"/v1/resource-definitions/rd-1/adjust", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertEnvelopeShape(t, readBodyBytes(t, resp), resp.StatusCode, http.StatusOK)
+}
+
+// TestBug374_AdjustOneEnvelope: POST /v1/resource-definitions/{rd}/
+// resources/{node}/adjust returns 200 + ApiCallRc envelope.
+func TestBug374_AdjustOneEnvelope(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "rd-1", NodeName: "n1"}); err != nil {
+		t.Fatalf("seed Res: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpPost(t, base+"/v1/resource-definitions/rd-1/resources/n1/adjust", nil)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertEnvelopeShape(t, readBodyBytes(t, resp), resp.StatusCode, http.StatusOK)
+}
+
+// TestBug374_DRBDPassphraseEnvelope: POST /v1/resource-definitions/
+// {rd}/encryption-passphrase returns 200 + ApiCallRc envelope.
+func TestBug374_DRBDPassphraseEnvelope(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	reqBody, _ := json.Marshal(map[string]string{"passphrase": "supersecret"})
+	resp := httpPost(t, base+"/v1/resource-definitions/rd-1/encryption-passphrase", reqBody)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertEnvelopeShape(t, readBodyBytes(t, resp), resp.StatusCode, http.StatusOK)
+}
+
+// TestBug374_VGUpdateEnvelope: PUT /v1/resource-groups/{rg}/volume-
+// groups/{vlmNr} returns 200 + ApiCallRc envelope.
+func TestBug374_VGUpdateEnvelope(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg-1",
+		VolumeGroups: []apiv1.VolumeGroup{
+			{VolumeNumber: 0},
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	reqBody, _ := json.Marshal(map[string]any{
+		"override_props": map[string]string{"foo": "bar"},
+	})
+	resp := httpPut(t, base+"/v1/resource-groups/rg-1/volume-groups/0", reqBody)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertEnvelopeShape(t, readBodyBytes(t, resp), resp.StatusCode, http.StatusOK)
+}
+
+// TestBug374_ResourceConnectionPathCreateEnvelope: POST
+// /v1/resource-definitions/{rd}/resource-connections/{a}/{b}/paths
+// returns 201 + ApiCallRc envelope.
+func TestBug374_ResourceConnectionPathCreateEnvelope(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "rd-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	reqBody, _ := json.Marshal(map[string]any{
+		"name": "ipath",
+	})
+	resp := httpPost(t,
+		base+"/v1/resource-definitions/rd-1/resource-connections/a/b/paths", reqBody)
+	defer func() { _ = resp.Body.Close() }()
+
+	assertEnvelopeShape(t, readBodyBytes(t, resp), resp.StatusCode, http.StatusCreated)
+}

--- a/pkg/rest/drbd_passphrase.go
+++ b/pkg/rest/drbd_passphrase.go
@@ -20,6 +20,8 @@ package rest
 
 import (
 	"net/http"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
 )
 
 // drbdPassphraseRequest carries the per-RD DRBD shared secret.
@@ -73,7 +75,20 @@ func (s *Server) handleDRBDPassphraseSet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	// Bug 374: emit `[]ApiCallRc` envelope on 200 instead of a bare
+	// WriteHeader. python-linstor 1.27.1 (Bug 129) and golinstor
+	// (Bug 45) unconditionally json-decode every non-204 2xx response
+	// and crash with "Expecting value: line 1 column 1 (char 0)" on
+	// an empty body. Sibling props-write paths
+	// (handleControllerPropsModify, mutateResourceFlag) all emit a
+	// MASK_INFO envelope so the CLI surfaces a clean success line.
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "DRBD shared secret set on resource definition: " + rdName,
+		ObjRefs: map[string]string{
+			objRefRscDfn: rdName,
+		},
+	}})
 }
 
 // drbdSharedSecretKey is the upstream LINSTOR property name we mirror

--- a/pkg/rest/encryption.go
+++ b/pkg/rest/encryption.go
@@ -245,7 +245,16 @@ func (s *Server) handlePassphraseCreate(w http.ResponseWriter, r *http.Request) 
 			// same usable state as the original create.
 			s.passphraseUnlocked.Store(true)
 
-			w.WriteHeader(http.StatusOK)
+			// Bug 374: emit a MASK_INFO envelope on the
+			// idempotent-replay branch. The fresh-create
+			// branch below already does this (Bug 129); the
+			// replay path silently regressed back to a bare
+			// 200, which python-linstor still rejects with
+			// the same "Expecting value" trace.
+			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+				RetCode: maskInfo,
+				Message: "Master passphrase already set",
+			}})
 
 			return
 		}

--- a/pkg/rest/resource_adjust.go
+++ b/pkg/rest/resource_adjust.go
@@ -43,6 +43,15 @@ func (s *Server) registerAdjust(mux *http.ServeMux) {
 // handleAdjustAll verifies the RD exists, then returns 200. A real
 // implementation would bump a generation token the satellite watches,
 // but until WatchResources lands the reconciler polls.
+//
+// Bug 374 (P2, hunt-caught 2026-06-02): emit an `[]ApiCallRc` envelope
+// on 200 instead of a bare WriteHeader. golinstor's response parser
+// (Bug 45) and python-linstor 1.27.1 (Bug 129) unconditionally json-
+// decode every non-204 2xx response, so an empty body crashes the CLI
+// with "Unable to parse REST json data: Expecting value: line 1
+// column 1 (char 0)". Sibling write-side endpoints
+// (`mutateResourceFlag`, autoplace, handleControllerPropsModify) all
+// emit MASK_INFO envelopes for the same reason.
 func (s *Server) handleAdjustAll(w http.ResponseWriter, r *http.Request) {
 	rdName := r.PathValue("rd")
 
@@ -53,10 +62,17 @@ func (s *Server) handleAdjustAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "resource definition adjusted: " + rdName,
+		ObjRefs: map[string]string{
+			objRefRscDfn: rdName,
+		},
+	}})
 }
 
-// handleAdjustOne is the per-replica counterpart.
+// handleAdjustOne is the per-replica counterpart. Same Bug 374 wire-
+// shape contract as handleAdjustAll.
 func (s *Server) handleAdjustOne(w http.ResponseWriter, r *http.Request) {
 	rdName := r.PathValue("rd")
 	node := r.PathValue("node")
@@ -68,7 +84,14 @@ func (s *Server) handleAdjustOne(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "resource adjusted: " + rdName + " on " + node,
+		ObjRefs: map[string]string{
+			objRefRscDfn: rdName,
+			objRefNode:   node,
+		},
+	}})
 }
 
 // registerResourceLifecycle wires activate/deactivate. Upstream LINSTOR

--- a/pkg/rest/resource_connections.go
+++ b/pkg/rest/resource_connections.go
@@ -266,7 +266,19 @@ func (s *Server) handleResourceConnectionPathCreate(w http.ResponseWriter, r *ht
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
+	// Bug 374: emit `[]ApiCallRc` envelope on 201 instead of a bare
+	// WriteHeader. golinstor's response parser (Bug 45) and python-
+	// linstor 1.27.1 (Bug 129) unconditionally json-decode every
+	// non-204 2xx response, so an empty body crashes the CLI with
+	// "Expecting value: line 1 column 1 (char 0)".
+	writeJSON(w, http.StatusCreated, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "resource connection path created: " + body.Name +
+			" on " + rdName + " (" + nodeA + " <-> " + nodeB + ")",
+		ObjRefs: map[string]string{
+			objRefRscDfn: rdName,
+		},
+	}})
 }
 
 // upsertResourceConnectionPath does the RD read-modify-write so the

--- a/pkg/rest/resource_group_extras.go
+++ b/pkg/rest/resource_group_extras.go
@@ -303,7 +303,19 @@ func (s *Server) handleVGUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	// Bug 374: emit `[]ApiCallRc` envelope on 200 instead of a bare
+	// WriteHeader. Sibling RG/VG write paths (handleVGCreate /
+	// handleVGDelete) already emit MASK_INFO / WARN-mask envelopes
+	// so `linstor rg vg m` doesn't crash python-linstor's
+	// json.loads on the no-op-body 200.
+	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+		RetCode: maskInfo,
+		Message: "volume group modified: " + rgName + " vlmNr " +
+			strconv.Itoa(int(vlmNr)),
+		ObjRefs: map[string]string{
+			objRefRscGrp: rgName,
+		},
+	}})
 }
 
 // handleVGDelete drops a VolumeGroup entry from its parent RG.


### PR DESCRIPTION
## Summary

Round-9 bughunt static-scan caught five write-side REST handlers that regressed back to a bare `WriteHeader(200|201)` with no JSON body. Both `golinstor` (Bug 45) and `python-linstor` 1.27.1 (Bug 129) unconditionally `json.Unmarshal` every non-204 2xx response and crash with `Expecting value: line 1 column 1 (char 0)` on an empty body. The fix mirrors what every sibling write path already does — emit a `[]apiv1.APICallRc` envelope with a MASK_INFO entry plus `ObjRefs`.

## Endpoints touched

- `POST /v1/resource-definitions/{rd}/adjust`
- `POST /v1/resource-definitions/{rd}/resources/{node}/adjust`
- `POST /v1/resource-definitions/{rd}/encryption-passphrase` (per-RD DRBD shared secret)
- `POST /v1/encryption/passphrase` (idempotent-replay branch — fresh-create path was already envelope-shaped via Bug 129)
- `POST /v1/resource-definitions/{rd}/resource-connections/{a}/{b}/paths`
- `PUT  /v1/resource-groups/{rg}/volume-groups/{vlmNr}`

## Why this matters

`linstor r a`, `linstor rd a`, `linstor rd drbd-options --shared-secret`, `linstor rc create-path`, and `linstor rg vg m` all routed through these handlers and would crash the operator CLI with `Unable to parse REST json data: Expecting value: line 1 column 1 (char 0)`. The operations themselves committed correctly; only the response envelope was off — which is exactly the failure mode Bug 45 / Bug 129 nailed for other write paths and which the wire-shape regression test in `bug_374_envelope_shape_test.go` now pins for these five.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./pkg/rest/...` clean
- [x] `go test ./pkg/rest/ -run TestBug374` — 5 new envelope-shape tests pass
- [x] `go test ./pkg/rest/` — full pkg/rest unit suite green
- [x] CI: lint + unit + contract + integration + 6 E2E lanes — all PASS
- [ ] CI: piraeus interop in progress