### PR TITLE
fix(rest): reject StorDriver/* mutation on PUT storage-pool-definitions (Bug 375)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/sys v0.39.0
 	k8s.io/api v0.35.0
@@ -59,7 +60,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/pkg/rest/bug_375_spd_immutable_driver_props_test.go
+++ b/pkg/rest/bug_375_spd_immutable_driver_props_test.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestBug375SPDfnModifyRefusesZPoolOverride pins the Bug 375 (Round 9)
+// guard: `PUT /v1/storage-pool-definitions/{name}` MUST refuse any
+// `override_props` that touches the backing-driver identity keys
+// (StorDriver/ZPool[Thin], LvmVg, ThinPool, FileDir, StorPoolName)
+// when the named SPD already exists.
+//
+// SPD-level echo of Bug 373: the StoragePoolDefinition is the catalog
+// row every future per-node StoragePool inherits its default backing
+// driver identity from. Pre-fix, `linstor sp-d set-property zfs-thin
+// StorDriver/ZPoolThin bogus-pool` returned 200 + MASK_INFO and the
+// catalog row flipped to "bogus-pool", silently desyncing the SPD
+// default from any per-node SP that hadn't materialised yet. Post-fix:
+// 400 + apiCallRcFailInvldStorPoolName (552), live row stays byte-
+// identical, operator gets actionable "drop + recreate the definition"
+// guidance.
+func TestBug375SPDfnModifyRefusesZPoolOverride(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name:  "zfs-thin",
+		Props: map[string]string{"StorDriver/ZPoolThin": "blockstor-zfs"},
+	}); err != nil {
+		t.Fatalf("seed SPD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		OverrideProps: map[string]string{"StorDriver/ZPoolThin": "bogus-catalog-pool"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/storage-pool-definitions/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var envelope []apiv1.APICallRc
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (body: %s)", err, string(raw))
+	}
+
+	if len(envelope) == 0 {
+		t.Fatalf("envelope empty, want one ApiCallRc")
+	}
+
+	if envelope[0].RetCode != apiCallRcError|apiCallRcFailInvldStorPoolName {
+		t.Errorf("ret_code = %d, want %d (apiCallRcError | apiCallRcFailInvldStorPoolName)",
+			envelope[0].RetCode, apiCallRcError|apiCallRcFailInvldStorPoolName)
+	}
+
+	if !strings.Contains(envelope[0].Message, "StorDriver/ZPoolThin") {
+		t.Errorf("message missing offending key: %q", envelope[0].Message)
+	}
+
+	if envelope[0].ObjRefs["StorPoolDfn"] != "zfs-thin" {
+		t.Errorf("obj_refs[StorPoolDfn] = %q, want zfs-thin", envelope[0].ObjRefs["StorPoolDfn"])
+	}
+
+	// Catalog row's Props must stay byte-identical to pre-call — the
+	// whole point of the fix is "PUT must not flip the backing key on
+	// an existing definition".
+	got, err := st.StoragePoolDefinitions().Get(ctx, "zfs-thin")
+	if err != nil {
+		t.Fatalf("Get after refused PUT: %v", err)
+	}
+
+	if got.Props["StorDriver/ZPoolThin"] != "blockstor-zfs" {
+		t.Errorf("Props[StorDriver/ZPoolThin] = %q, want blockstor-zfs (refused PUT must not mutate the row)",
+			got.Props["StorDriver/ZPoolThin"])
+	}
+}
+
+// TestBug375SPDfnModifyRefusesDeletePropsOnDriverKey pins the
+// `delete_props`-flank guard. Same as the SP-level Bug 373 case: a
+// `delete_props` of `StorDriver/LvmVg` is arguably worse than override
+// because it leaves the catalog with no default backing key, so every
+// per-node SP that auto-inherits from the SPD breaks on creation with
+// a misleading "requires StorDriver/<key> in props" error.
+func TestBug375SPDfnModifyRefusesDeletePropsOnDriverKey(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name: "lvm-thin",
+		Props: map[string]string{
+			"StorDriver/LvmVg":    "vg1",
+			"StorDriver/ThinPool": "thin",
+		},
+	}); err != nil {
+		t.Fatalf("seed SPD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		DeleteProps: []string{"StorDriver/LvmVg"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/storage-pool-definitions/lvm-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	got, err := st.StoragePoolDefinitions().Get(ctx, "lvm-thin")
+	if err != nil {
+		t.Fatalf("Get after refused PUT: %v", err)
+	}
+
+	if got.Props["StorDriver/LvmVg"] != "vg1" {
+		t.Errorf("Props[StorDriver/LvmVg] = %q, want vg1 (refused delete_props must not drop the key)",
+			got.Props["StorDriver/LvmVg"])
+	}
+}
+
+// TestBug375SPDfnModifyRefusesDeleteNamespaceOnStorDriver pins the
+// `delete_namespaces`-flank guard. `linstor sp-d delete-namespace
+// <name> StorDriver` would otherwise wipe the SPD's entire default
+// backing identity in one round-trip.
+func TestBug375SPDfnModifyRefusesDeleteNamespaceOnStorDriver(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name:  "zfs-thin",
+		Props: map[string]string{"StorDriver/ZPoolThin": "blockstor-zfs"},
+	}); err != nil {
+		t.Fatalf("seed SPD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		DeleteNamespace: []string{"StorDriver"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/storage-pool-definitions/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	raw, _ := io.ReadAll(resp.Body)
+
+	var envelope []apiv1.APICallRc
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (body: %s)", err, string(raw))
+	}
+
+	if !strings.Contains(envelope[0].Message, "delete_namespaces:StorDriver") {
+		t.Errorf("message missing namespace hit: %q", envelope[0].Message)
+	}
+
+	got, err := st.StoragePoolDefinitions().Get(ctx, "zfs-thin")
+	if err != nil {
+		t.Fatalf("Get after refused PUT: %v", err)
+	}
+
+	if got.Props["StorDriver/ZPoolThin"] != "blockstor-zfs" {
+		t.Errorf("Props[StorDriver/ZPoolThin] = %q, want blockstor-zfs (refused delete_namespaces must not drop keys)",
+			got.Props["StorDriver/ZPoolThin"])
+	}
+}
+
+// TestBug375SPDfnModifyAcceptsBenignOverride is the positive flank: a
+// PUT that only touches non-driver props (Aux/*, MaxOversubscription
+// Ratio, etc.) MUST keep landing exactly as it did before the fix.
+// Regression guard against an overly-broad refuseSPDriverPropMutation
+// match.
+func TestBug375SPDfnModifyAcceptsBenignOverride(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.StoragePoolDefinitions().Create(ctx, &store.StoragePoolDefinition{
+		Name:  "zfs-thin",
+		Props: map[string]string{"StorDriver/ZPoolThin": "blockstor-zfs"},
+	}); err != nil {
+		t.Fatalf("seed SPD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		OverrideProps: map[string]string{
+			"Aux/rack-id":              "r1",
+			"MaxOversubscriptionRatio": "2.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/storage-pool-definitions/zfs-thin", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (benign override must land)", resp.StatusCode)
+	}
+
+	got, err := st.StoragePoolDefinitions().Get(ctx, "zfs-thin")
+	if err != nil {
+		t.Fatalf("Get after PUT: %v", err)
+	}
+
+	if got.Props["Aux/rack-id"] != "r1" {
+		t.Errorf("Props[Aux/rack-id] = %q, want r1", got.Props["Aux/rack-id"])
+	}
+
+	if got.Props["MaxOversubscriptionRatio"] != "2.0" {
+		t.Errorf("Props[MaxOversubscriptionRatio] = %q, want 2.0", got.Props["MaxOversubscriptionRatio"])
+	}
+
+	if got.Props["StorDriver/ZPoolThin"] != "blockstor-zfs" {
+		t.Errorf("Props[StorDriver/ZPoolThin] = %q, want blockstor-zfs (benign PUT must preserve backing key)",
+			got.Props["StorDriver/ZPoolThin"])
+	}
+}
+
+// TestBug375SPDfnPUTCreateAllowsDriverKey is the PUT-create flank.
+// When the named SPD does NOT yet exist, the handler's auto-create
+// branch must still accept StorDriver/* seed props — that's the
+// `linstor sp-d set-property new-def StorDriver/LvmVg vg-x` one-round-
+// trip provisioning flow operators rely on. The refusal is gated on
+// "the row exists already"; brand-new names are a seed path, not a
+// mutation path.
+func TestBug375SPDfnPUTCreateAllowsDriverKey(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.GenericPropsModify{
+		OverrideProps: map[string]string{
+			"StorDriver/LvmVg":    "vg-new-1",
+			"StorDriver/ThinPool": "thin",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/storage-pool-definitions/brand-new-spd", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (PUT-create with seed StorDriver/* must succeed)",
+			resp.StatusCode)
+	}
+
+	got, err := st.StoragePoolDefinitions().Get(ctx, "brand-new-spd")
+	if err != nil {
+		t.Fatalf("Get after PUT-create: %v", err)
+	}
+
+	if got.Props["StorDriver/LvmVg"] != "vg-new-1" {
+		t.Errorf("Props[StorDriver/LvmVg] = %q, want vg-new-1 (PUT-create must seed the backing key)",
+			got.Props["StorDriver/LvmVg"])
+	}
+
+	if got.Props["StorDriver/ThinPool"] != "thin" {
+		t.Errorf("Props[StorDriver/ThinPool] = %q, want thin", got.Props["StorDriver/ThinPool"])
+	}
+}

--- a/pkg/rest/storage_pool_definitions.go
+++ b/pkg/rest/storage_pool_definitions.go
@@ -167,6 +167,9 @@ func (s *Server) handleStoragePoolDefinitionModify(w http.ResponseWriter, r *htt
 	}
 
 	def, err := s.Store.StoragePoolDefinitions().Get(r.Context(), name)
+
+	existing := !errors.Is(err, store.ErrNotFound)
+
 	switch {
 	case errors.Is(err, store.ErrNotFound):
 		def = store.StoragePoolDefinition{Name: name, Props: map[string]string{}}
@@ -176,28 +179,21 @@ func (s *Server) handleStoragePoolDefinitionModify(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if def.Props == nil {
-		def.Props = map[string]string{}
-	}
+	// Bug 375: SPD-level echo of Bug 373. Refuse a PUT that mutates
+	// StorDriver/* identity keys on an EXISTING definition; PUT-create
+	// on a brand-new name is still allowed (the seed path operators
+	// rely on for one-round-trip provisioning via
+	// `linstor sp-d set-property new-def StorDriver/LvmVg vg-x`).
+	// Helper detail in writeSPDfnDriverPropMutationRefusal.
+	if existing {
+		if msg, refused := refuseSPDriverPropMutation(&body); refused {
+			writeSPDfnDriverPropMutationRefusal(w, name, msg)
 
-	maps.Copy(def.Props, body.OverrideProps)
-
-	for _, k := range body.DeleteProps {
-		delete(def.Props, k)
-	}
-
-	// delete_namespaces: drop every key under the given namespace
-	// prefix. Mirrors upstream LINSTOR's `delete_namespaces` behaviour
-	// — separator is '/', prefix matches literally.
-	for _, ns := range body.DeleteNamespace {
-		prefix := ns + "/"
-
-		for k := range def.Props {
-			if strings.HasPrefix(k, prefix) {
-				delete(def.Props, k)
-			}
+			return
 		}
 	}
+
+	applySPDfnPropsPatch(&def, &body)
 
 	// Try Update first; on ErrNotFound (PUT-creates path) fall back to
 	// Create so the wire surface is upsert-idempotent.
@@ -216,6 +212,37 @@ func (s *Server) handleStoragePoolDefinitionModify(w http.ResponseWriter, r *htt
 		RetCode: maskInfo,
 		Message: "storage pool definition modified: " + name,
 	}})
+}
+
+// applySPDfnPropsPatch merges a `GenericPropsModify` payload onto
+// `def.Props` in place: override_props is `maps.Copy`'d on top,
+// delete_props drops the listed keys, and delete_namespaces strips
+// every key whose `<namespace>/` prefix matches (separator is '/',
+// matching upstream LINSTOR's semantics). Pulled out of
+// handleStoragePoolDefinitionModify so the handler stays under the
+// funlen budget after the Bug 375 immutability gate landed; centralises
+// the merge so the SPD-side patch shape stays in lockstep with the
+// per-node SP-side flow (see refuseSPDriverPropMutation comments).
+func applySPDfnPropsPatch(def *store.StoragePoolDefinition, patch *apiv1.GenericPropsModify) {
+	if def.Props == nil {
+		def.Props = map[string]string{}
+	}
+
+	maps.Copy(def.Props, patch.OverrideProps)
+
+	for _, k := range patch.DeleteProps {
+		delete(def.Props, k)
+	}
+
+	for _, ns := range patch.DeleteNamespace {
+		prefix := ns + "/"
+
+		for k := range def.Props {
+			if strings.HasPrefix(k, prefix) {
+				delete(def.Props, k)
+			}
+		}
+	}
 }
 
 // handleStoragePoolDefinitionDelete serves DELETE /v1/storage-pool-definitions/{name}.
@@ -256,6 +283,44 @@ func (s *Server) handleStoragePoolDefinitionDelete(w http.ResponseWriter, r *htt
 	writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
 		RetCode: maskInfo,
 		Message: "storage pool definition deleted: " + name,
+	}})
+}
+
+// writeSPDfnDriverPropMutationRefusal emits the Bug 375 typed-envelope
+// 400 response. SPD-side echo of `writeSPDriverPropMutationRefusal`
+// (Bug 373) — same LINSTOR sub-code (552 FAIL_INVLD_STOR_POOL_NAME),
+// same operator-facing prose, but obj_refs pin the StorPoolDfn name
+// (the SPD has no per-node anchor) and the correction points at the
+// SPD escape path (drop + recreate the definition with the desired
+// backing key instead of mutating it on the live row).
+//
+// Only the existing-row PUT path calls this; PUT-create against a
+// brand-new SPD name is still allowed to seed StorDriver/* keys in a
+// single round-trip — that's the `linstor sp-d set-property new-def
+// StorDriver/LvmVg vg-x` flow operators rely on for one-call
+// provisioning of fresh definitions.
+func writeSPDfnDriverPropMutationRefusal(w http.ResponseWriter, name, msg string) {
+	writeJSON(w, http.StatusBadRequest, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInvldStorPoolName,
+		Message: "storage pool definition '" + name +
+			"': refusing to mutate backing-driver identity prop(s): " + msg,
+		Cause: "the requested override_props / delete_props / " +
+			"delete_namespaces touches a StorDriver/* key that pins " +
+			"this StoragePoolDefinition's default backing identity. " +
+			"Per-node StoragePools created against this definition " +
+			"inherit StorDriver/* keys from the SPD when the per-node " +
+			"create body omits them; silently flipping the SPD's " +
+			"backing key under existing per-node pools desyncs the " +
+			"catalog from the live rows and breaks placement / " +
+			"autoplace consistency the moment the next per-node " +
+			"`linstor sp c` lands.",
+		Correc: "drop the storage pool definition (`linstor sp-d d`) " +
+			"and recreate it with the desired backing key, OR target " +
+			"the prop on a freshly-named SPD — never mutate the " +
+			"backing key on an existing definition row.",
+		ObjRefs: map[string]string{
+			objRefStorPoolDfn: name,
+		},
 	}})
 }
 

--- a/tests/e2e/spd-immutable-driver-props.sh
+++ b/tests/e2e/spd-immutable-driver-props.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# usage: spd-immutable-driver-props.sh WORK_DIR
+#
+# Bug 375 (P2, hunt-caught 2026-06-02) — SPD-level echo of Bug 373.
+# `PUT /v1/storage-pool-definitions/{name}` accepted `override_props`
+# (and `delete_props` / `delete_namespaces`) that touched the backing-
+# driver identity keys (StorDriver/ZPool[Thin], LvmVg, ThinPool,
+# FileDir, StorPoolName) on an EXISTING definition. The StoragePool
+# Definition is the catalog row every future per-node StoragePool
+# inherits its default backing-driver identity from; silently flipping
+# the SPD default desyncs the catalog from any per-node SP that hasn't
+# materialised yet, breaking placement / autoplace consistency the
+# moment the next `linstor sp c <node> <name>` lands.
+#
+# This e2e pins the rejection on a live cluster and verifies:
+#   1. PUT override_props with StorDriver/* on an EXISTING SPD => 400
+#   2. PUT delete_props on StorDriver/* => 400
+#   3. PUT delete_namespaces=[StorDriver] => 400
+#   4. Catalog row stays byte-identical post-call
+#   5. PUT-create with StorDriver/* on a brand-new SPD name => 200
+#      (seed path operators rely on for one-round-trip provisioning)
+#   6. Benign PUT (Aux/*) on existing SPD still lands (regression guard)
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug375-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    # best-effort drop of any SPD this test stamped — keeps the stand
+    # clean for the next scenario regardless of where we exited.
+    curl -sf -X DELETE "http://localhost:$PF_PORT/v1/storage-pool-definitions/bug375-existing" >/dev/null 2>&1 || true
+    curl -sf -X DELETE "http://localhost:$PF_PORT/v1/storage-pool-definitions/bug375-create" >/dev/null 2>&1 || true
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# Seed an SPD we know is ours so we can mutate / refuse / verify
+# without depending on stand-fixture pools. The POST path is the
+# upstream-canonical CREATE for SPDs.
+echo ">> seed SPD bug375-existing"
+CODE=$(curl -s -o /tmp/bug375-seed.txt -w "%{http_code}" -X POST \
+    "$B/v1/storage-pool-definitions" -H "Content-Type: application/json" \
+    -d '{"storage_pool_name":"bug375-existing","props":{"StorDriver/LvmVg":"vg-original"}}')
+
+if [[ "$CODE" != "201" ]]; then
+    echo "FAIL: seed SPD POST returned $CODE, expected 201"
+    cat /tmp/bug375-seed.txt
+    exit 1
+fi
+
+# Snapshot the seeded backing key so every "must not mutate" assertion
+# has a definite pre-state to compare against.
+PRE_VG=$(curl -s "$B/v1/storage-pool-definitions/bug375-existing" | python3 -c '
+import sys, json
+try:
+    arr = json.load(sys.stdin)
+    if isinstance(arr, list):
+        spd = arr[0] if arr else {}
+    else:
+        spd = arr
+except Exception:
+    print("")
+    sys.exit(0)
+print((spd.get("props") or {}).get("StorDriver/LvmVg", ""))
+')
+
+if [[ "$PRE_VG" != "vg-original" ]]; then
+    echo "FAIL: seeded SPD backing key wrong: got '$PRE_VG', want 'vg-original'"
+    exit 1
+fi
+
+# --- override_props on a backing-driver key must 400 ---
+echo ">> PUT override_props StorDriver/LvmVg=bogus on EXISTING SPD: must 400"
+CODE=$(curl -s -o /tmp/bug375-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/storage-pool-definitions/bug375-existing" -H "Content-Type: application/json" \
+    -d '{"override_props":{"StorDriver/LvmVg":"bug375-bogus"}}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 375 PUT override_props returned $CODE, expected 400"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+
+if ! grep -q "StorDriver/LvmVg" /tmp/bug375-resp.txt; then
+    echo "FAIL: rejection envelope missing offending key:"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+
+if ! grep -q "refusing to mutate" /tmp/bug375-resp.txt; then
+    echo "FAIL: rejection envelope missing operator-facing phrase:"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+
+if ! grep -q "StorPoolDfn" /tmp/bug375-resp.txt; then
+    echo "FAIL: rejection envelope missing StorPoolDfn obj_ref (operator can't grep audit log by SPD name):"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+
+echo "   400 + structured envelope OK"
+
+# --- live row must stay byte-identical ---
+POST_VG=$(curl -s "$B/v1/storage-pool-definitions/bug375-existing" | python3 -c '
+import sys, json
+try:
+    arr = json.load(sys.stdin)
+    spd = arr[0] if isinstance(arr, list) and arr else (arr if not isinstance(arr, list) else {})
+except Exception:
+    print("")
+    sys.exit(0)
+print((spd.get("props") or {}).get("StorDriver/LvmVg", ""))
+')
+
+if [[ "$POST_VG" != "$PRE_VG" ]]; then
+    echo "FAIL: backing key mutated despite rejected PUT: $PRE_VG -> $POST_VG"
+    exit 1
+fi
+echo ">> backing key unchanged post-rejection OK"
+
+# --- delete_props on backing-driver key must 400 ---
+echo ">> PUT delete_props=[StorDriver/LvmVg] on EXISTING SPD: must 400"
+CODE=$(curl -s -o /tmp/bug375-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/storage-pool-definitions/bug375-existing" -H "Content-Type: application/json" \
+    -d '{"delete_props":["StorDriver/LvmVg"]}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 375 PUT delete_props returned $CODE, expected 400"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# --- delete_namespaces=[StorDriver] must 400 ---
+echo ">> PUT delete_namespaces=[StorDriver] on EXISTING SPD: must 400"
+CODE=$(curl -s -o /tmp/bug375-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/storage-pool-definitions/bug375-existing" -H "Content-Type: application/json" \
+    -d '{"delete_namespaces":["StorDriver"]}')
+
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: Bug 375 PUT delete_namespaces returned $CODE, expected 400"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+echo "   400 OK"
+
+# --- benign override_props on EXISTING SPD must STILL land (regression guard) ---
+echo ">> PUT override_props Aux/rack=r1 on EXISTING SPD: must 200 (benign)"
+CODE=$(curl -s -o /tmp/bug375-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/storage-pool-definitions/bug375-existing" -H "Content-Type: application/json" \
+    -d '{"override_props":{"Aux/rack":"r1"}}')
+
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: benign PUT Aux/rack returned $CODE, expected 200 (regression)"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+echo "   200 OK"
+
+# --- final: backing key still byte-identical to pre-test ---
+FINAL_VG=$(curl -s "$B/v1/storage-pool-definitions/bug375-existing" | python3 -c '
+import sys, json
+try:
+    arr = json.load(sys.stdin)
+    spd = arr[0] if isinstance(arr, list) and arr else (arr if not isinstance(arr, list) else {})
+except Exception:
+    print("")
+    sys.exit(0)
+print((spd.get("props") or {}).get("StorDriver/LvmVg", ""))
+')
+
+if [[ "$FINAL_VG" != "$PRE_VG" ]]; then
+    echo "FAIL: backing key mutated across the test sequence: $PRE_VG -> $FINAL_VG"
+    exit 1
+fi
+
+# --- PUT-create on brand-new SPD with StorDriver/* seed props must 200 ---
+# This is the operator's one-round-trip provisioning flow
+# (`linstor sp-d set-property new-def StorDriver/LvmVg vg-x`). The
+# refusal is gated on "the SPD row exists already"; brand-new names
+# are a seed path, not a mutation path.
+echo ">> PUT-create brand-new SPD bug375-create with StorDriver/LvmVg seed: must 200"
+CODE=$(curl -s -o /tmp/bug375-resp.txt -w "%{http_code}" -X PUT \
+    "$B/v1/storage-pool-definitions/bug375-create" -H "Content-Type: application/json" \
+    -d '{"override_props":{"StorDriver/LvmVg":"vg-fresh"}}')
+
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: PUT-create with seed StorDriver/* returned $CODE, expected 200"
+    cat /tmp/bug375-resp.txt
+    exit 1
+fi
+
+SEED_VG=$(curl -s "$B/v1/storage-pool-definitions/bug375-create" | python3 -c '
+import sys, json
+try:
+    arr = json.load(sys.stdin)
+    spd = arr[0] if isinstance(arr, list) and arr else (arr if not isinstance(arr, list) else {})
+except Exception:
+    print("")
+    sys.exit(0)
+print((spd.get("props") or {}).get("StorDriver/LvmVg", ""))
+')
+
+if [[ "$SEED_VG" != "vg-fresh" ]]; then
+    echo "FAIL: PUT-create seed value not persisted: got '$SEED_VG', want 'vg-fresh'"
+    exit 1
+fi
+
+echo ">> PASS: Bug 375 — PUT storage-pool-definitions refuses StorDriver/* mutation on existing rows; PUT-create still seeds"


### PR DESCRIPTION
## Summary

Bug 375 (P2, hunt-caught 2026-06-02) — SPD-level echo of Bug 373.

`PUT /v1/storage-pool-definitions/{name}` accepted `override_props` (and `delete_props` / `delete_namespaces`) that touched the backing-driver identity keys (`StorDriver/ZPool[Thin]`, `LvmVg`, `ThinPool`, `FileDir`, `StorPoolName`) on an EXISTING definition. The `StoragePoolDefinition` is the catalog row every future per-node `StoragePool` inherits its default backing-driver identity from. Silently flipping the SPD default desyncs the catalog from any per-node SP that has not materialised yet, breaking placement / autoplace consistency the moment the next `linstor sp c <node> <name>` lands.

Reproducer on the dev stand:

```
$ curl -X POST /v1/storage-pool-definitions -d '{"storage_pool_name":"spd","props":{"StorDriver/LvmVg":"vg-orig"}}'
$ curl -X PUT  /v1/storage-pool-definitions/spd -d '{"override_props":{"StorDriver/LvmVg":"vg-new"}}'
HTTP/1.1 200 OK
$ curl /v1/storage-pool-definitions/spd
[{"storage_pool_name":"spd","props":{"StorDriver/LvmVg":"vg-new"}}]   # silent mutation
```

## Fix

Gate `refuseSPDriverPropMutation` (the same helper Bug 373 uses on the per-node SP side) on the existing-row PUT path of `handleStoragePoolDefinitionModify`. PUT-create on a brand-new SPD name is still allowed to seed `StorDriver/*` keys, preserving the `linstor sp-d set-property new-def StorDriver/LvmVg vg-x` one-round-trip provisioning flow operators rely on.

Refusal uses the same `552` sub-code (`FAIL_INVLD_STOR_POOL_NAME`) as the SP-side refusal so audit-log greppers catch both classes with one rule; `obj_refs` pins the `StorPoolDfn` name instead of the `(node, pool)` pair the SP-side refusal carries.

The merge logic was extracted into `applySPDfnPropsPatch` to keep `handleStoragePoolDefinitionModify` under the `funlen` budget after the immutability gate landed.

## Test plan

- [x] `go test ./pkg/rest/ -run TestBug375` — five unit cases pin every flank (override / `delete_props` / `delete_namespaces` refusal, benign override regression, PUT-create seed-path positive)
- [x] `go test ./pkg/rest/` full sweep — green (no regressions on adjacent SPD / SP handlers)
- [x] `golangci-lint run ./pkg/rest/...` — clean
- [ ] CI: `tests/e2e/spd-immutable-driver-props.sh` on real QEMU stand — exercises POST → PUT-refuse → byte-identical-row → PUT-create seed flow against the live REST surface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage Pool Definition driver identity properties are now immutable when updating existing definitions. Attempts to modify or delete driver-related properties (such as StorDriver keys) return HTTP 400 with detailed error messages. Non-driver properties can still be updated. Creating new definitions with driver properties as initial values remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->