### PR TITLE
fix(rest): drop-property is idempotent on parent-missing (Bug 378)

### DIFF
--- a/pkg/rest/bug_378_prop_delete_parent_missing_test.go
+++ b/pkg/rest/bug_378_prop_delete_parent_missing_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 378 (P3, bughunt round 10 — 2026-06-02): the per-key DELETE on
+// node + RG properties returned 404 when the parent (node / RG) was
+// already gone, in contrast to the sibling
+// `DELETE /v1/controller/properties/{key...}` which has been
+// idempotent on every input since Bug 142. The drift broke
+// cozystack's node-evacuation playbook: `linstor n d <node>`
+// followed by `linstor n dp <node> Foo` raced into a 404 on the
+// second call once the node finally cleared.
+//
+// Both per-key drop-property endpoints now fold parent-NotFound into
+// the same warn-band 200 envelope that the "key already absent on
+// extant parent" branch uses. Mirrors the controller-prop sibling +
+// the parent-delete handlers (`handleNodeDelete` / `handleRGDelete`)
+// which both surface warnNodeNotFound / warnRGNotFound on the same
+// input shape.
+
+// TestBug378_NodePropDeleteMissingNodeIsIdempotent: drop-property on
+// a node that does not exist returns 200, not 404.
+func TestBug378_NodePropDeleteMissingNodeIsIdempotent(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpDelete(t,
+		base+"/v1/nodes/ghost-node/properties/Aux/anything")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (parent-missing should be idempotent)",
+			resp.StatusCode)
+	}
+}
+
+// TestBug378_RGPropDeleteMissingRGIsIdempotent: drop-property on an
+// RG that does not exist returns 200, not 404.
+func TestBug378_RGPropDeleteMissingRGIsIdempotent(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpDelete(t,
+		base+"/v1/resource-groups/ghost-rg/properties/DrbdOptions/auto-quorum")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (parent-missing should be idempotent)",
+			resp.StatusCode)
+	}
+}

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -942,6 +942,30 @@ func (s *Server) handleNodePropDelete(w http.ResponseWriter, r *http.Request) {
 	// retry — still converges).
 	probe, err := s.Store.Nodes().Get(r.Context(), nodeName)
 	if err != nil {
+		// Bug 378: parent-NotFound is also idempotent. The
+		// controller-side sibling endpoint
+		// (`DELETE /v1/controller/properties/{key...}`) returns
+		// 200 on every input — see
+		// TestControllerPropertiesDeleteMissingKeyIsIdempotent —
+		// because `controller drop-property` upstream is
+		// intentionally idempotent so a re-run of an operator's
+		// teardown script doesn't error on already-cleaned state.
+		// Pre-fix this branch crashed cozystack's node-evacuation
+		// playbook: `linstor n d <node>` followed by
+		// `linstor n dp <node> Foo` raced into a 404 on the
+		// second call once the node finally cleared. Same
+		// warn-band shape `n d` itself emits (warnNodeNotFound).
+		if errors.Is(err, store.ErrNotFound) {
+			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+				RetCode: maskWarn,
+				Message: "node already absent: " + nodeName +
+					" (drop-property no-op on " + key + ")",
+				ObjRefs: map[string]string{objRefNode: nodeName},
+			}})
+
+			return
+		}
+
 		writeStoreError(w, err)
 
 		return

--- a/pkg/rest/resource_groups.go
+++ b/pkg/rest/resource_groups.go
@@ -776,6 +776,25 @@ func (s *Server) handleRGPropDelete(w http.ResponseWriter, r *http.Request) {
 	// deletion via wholesale-Spec-replace.
 	probe, err := s.Store.ResourceGroups().Get(r.Context(), rgName)
 	if err != nil {
+		// Bug 378: parent-NotFound is idempotent, same as the
+		// controller-prop-delete sibling
+		// (handleControllerPropDelete) and `rg d <rg>` itself
+		// (warnRGNotFound). Pre-fix, a teardown script that ran
+		// `rg d <rg>` then `rg dp <rg> Foo` raced into a 404
+		// once the RG cleared; now the second call folds to the
+		// same warn-band 200 the rest of the rg-delete surface
+		// emits.
+		if errors.Is(err, store.ErrNotFound) {
+			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+				RetCode: maskWarn,
+				Message: "resource group already absent: " + rgName +
+					" (drop-property no-op on " + key + ")",
+				ObjRefs: map[string]string{objRefRscGrp: rgName},
+			}})
+
+			return
+		}
+
 		writeStoreError(w, err)
 
 		return


### PR DESCRIPTION
## Summary

Round-10 bughunt static-scan caught a parity drift: `DELETE /v1/nodes/{node}/properties/{key...}` and `DELETE /v1/resource-groups/{rg}/properties/{key...}` returned 404 on parent-missing input, while the sibling `DELETE /v1/controller/properties/{key...}` has been fully idempotent since Bug 142 (see `TestControllerPropertiesDeleteMissingKeyIsIdempotent`). The fix folds parent-NotFound into the same warn-band 200 envelope the "key already absent on extant parent" branch uses.

## Endpoints touched

- `DELETE /v1/nodes/{node}/properties/{key...}` (handleNodePropDelete)
- `DELETE /v1/resource-groups/{rg}/properties/{key...}` (handleRGPropDelete)

## Why this matters

cozystack's node-evacuation playbook calls `linstor n d <node>` followed by `linstor n dp <node> Foo` to clean up trailing Aux keys; the second call raced into a 404 once the node finally cleared. The sibling parent-delete handlers (`handleNodeDelete` / `handleRGDelete`) both emit warnNodeNotFound / warnRGNotFound on the same input, so this brings the prop-delete surface in lockstep with the rest of the delete surface.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./pkg/rest/...` clean
- [x] `go test ./pkg/rest/ -run TestBug378` — 2 new idempotency tests pass
- [x] `go test ./pkg/rest/` — full pkg/rest unit suite green
- [ ] CI lanes (unit + contract + integration + 6 E2E lanes + piraeus interop)