### PR TITLE
fix(rest): net-interface DELETE is idempotent on parent-missing (Bug 379)

### DIFF
--- a/pkg/rest/bug_379_net_interface_delete_parent_missing_test.go
+++ b/pkg/rest/bug_379_net_interface_delete_parent_missing_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 379 (P3, bughunt round 11 — 2026-06-02): the per-NIC DELETE on
+// `/v1/nodes/{node}/net-interfaces/{name}` returned a raw 404
+// `patch NetInterfaces of Node "X": node "X": object not found` when
+// the parent node was already gone — symmetric to the Bug 378 gap on
+// per-key property delete. The Bug-hunt v0.1.3 Finding 9 fix already
+// made "node present, NIC missing" idempotent
+// (warnNetInterfaceNotFound + 200) but never extended that
+// idempotency to the parent-missing branch, so a teardown script
+// that runs `linstor n d <node>` followed by
+// `linstor node interface delete <node> default` raced into a fatal
+// 404 on the second call once the node finally cleared.
+//
+// Both DELETE no-ops now fold parent-NotFound into the same warn-band
+// 200 envelope that handleNodePropDelete + handleNodeDelete use, so
+// audit-log greppers can distinguish a real drop from an idempotent
+// no-op via the warnNodeNotFound mask.
+
+// TestBug379_NetInterfaceDeleteMissingNodeIsIdempotent: NIC delete on
+// a node that does not exist returns 200 + warn-band envelope, not
+// 404 with a raw `patch NetInterfaces of Node ... object not found`.
+func TestBug379_NetInterfaceDeleteMissingNodeIsIdempotent(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpDelete(t,
+		base+"/v1/nodes/ghost-node/net-interfaces/default")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (parent-missing should be idempotent); body=%s",
+			resp.StatusCode, body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(body, &rcs); err != nil {
+		t.Fatalf("unmarshal envelope: %v; body=%s", err, body)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope length: got %d, want 1; body=%s", len(rcs), body)
+	}
+
+	// Mask must be the warn-band, not the success band — operators
+	// grep audit logs on this to tell "no-op" apart from "I actually
+	// dropped a NIC".
+	if rcs[0].RetCode != maskWarn {
+		t.Errorf("ret_code mask: got 0x%x, want warn-band 0x%x; full=%+v",
+			rcs[0].RetCode, maskWarn, rcs[0])
+	}
+
+	// Message must name BOTH the missing parent node and the NIC the
+	// caller asked us to drop — otherwise the operator can't tell
+	// which retry-loop iteration logged the no-op.
+	if !strings.Contains(rcs[0].Message, "ghost-node") {
+		t.Errorf("message does not name parent node: %q", rcs[0].Message)
+	}
+	if !strings.Contains(rcs[0].Message, "default") {
+		t.Errorf("message does not name NIC: %q", rcs[0].Message)
+	}
+
+	// ObjRefs must pin the Node — same shape every other Bug 378 /
+	// Bug 66 / Bug 142 envelope uses, so audit-log filters built
+	// around objRefNode catch the cascade.
+	if rcs[0].ObjRefs[objRefNode] != "ghost-node" {
+		t.Errorf("obj_refs[Node]: got %q, want %q",
+			rcs[0].ObjRefs[objRefNode], "ghost-node")
+	}
+}
+
+// TestBug379_NetInterfaceDeleteMissingNICOnExistingNode preserves the
+// pre-existing Bug-hunt v0.1.3 Finding 9 envelope shape: when the
+// node is present but the NIC name was never registered, the warn
+// band is `warnNetInterfaceNotFound`, not the Bug 379
+// `warnNodeNotFound`. Pinned here so a regression on either branch
+// of the dual-warn-mask split is caught by CI.
+func TestBug379_NetInterfaceDeleteMissingNICKeepsExistingShape(t *testing.T) {
+	st := store.NewInMemory()
+
+	err := st.Nodes().Create(t.Context(), &apiv1.Node{
+		Name: "extant-node",
+		Type: "SATELLITE",
+		NetInterfaces: []apiv1.NetInterface{{
+			Name:                    "default",
+			Address:                 "10.0.0.1",
+			SatellitePort:           3366,
+			SatelliteEncryptionType: "PLAIN",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t,
+		base+"/v1/nodes/extant-node/net-interfaces/never-registered")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200; body=%s",
+			resp.StatusCode, body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(body, &rcs); err != nil {
+		t.Fatalf("unmarshal envelope: %v; body=%s", err, body)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope length: got %d, want 1; body=%s", len(rcs), body)
+	}
+
+	// Existing branch returns warnNetInterfaceNotFound, not maskWarn,
+	// so the audit log can tell parent-missing apart from
+	// nic-missing-on-extant-parent.
+	if rcs[0].RetCode != warnNetInterfaceNotFound {
+		t.Errorf("ret_code: got 0x%x, want warnNetInterfaceNotFound 0x%x",
+			rcs[0].RetCode, warnNetInterfaceNotFound)
+	}
+}

--- a/pkg/rest/net_interface_test.go
+++ b/pkg/rest/net_interface_test.go
@@ -398,11 +398,18 @@ func TestNetInterfaceUpdateCreatesOnMissing(t *testing.T) {
 	}
 }
 
-// TestNetInterfaceDeleteUnknownNode pins the 404 branch on
-// handleNetInterfaceDelete (was 76.5%): DELETE against an unknown
-// {node} pathvar must surface a clean 404 rather than 500. Operator
-// scripts that idempotently delete interfaces on node teardown
-// expect 404 when the node is already gone.
+// TestNetInterfaceDeleteUnknownNode pins the parent-NotFound branch
+// on handleNetInterfaceDelete (was 76.5%): DELETE against an unknown
+// {node} pathvar must surface a clean response rather than 500.
+//
+// Bug 379 (2026-06-02): the response shape flipped from 404 to a
+// warn-band 200 envelope so the call is idempotent. Operator scripts
+// that delete interfaces on node teardown (e.g. cozystack's
+// node-evacuation playbook calling
+// `linstor node interface delete <node> default` after
+// `linstor n d <node>`) now exit-0 on the second pass, matching the
+// pre-existing Bug 378 contract on per-key property delete and the
+// Bug 66 contract on `linstor n d` itself.
 func TestNetInterfaceDeleteUnknownNode(t *testing.T) {
 	base, stop := startServerWithStore(t, store.NewInMemory())
 	defer stop()
@@ -410,8 +417,9 @@ func TestNetInterfaceDeleteUnknownNode(t *testing.T) {
 	resp := httpDelete(t, base+"/v1/nodes/ghost/net-interfaces/default")
 	_ = resp.Body.Close()
 
-	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (Bug 379: parent-missing is idempotent)",
+			resp.StatusCode)
 	}
 }
 

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -212,6 +212,18 @@ func (s *Server) handleNetInterfaceUpdate(w http.ResponseWriter, r *http.Request
 // shape so audit-log greppers can distinguish a real drop from an
 // idempotent no-op. Mirrors the Bug 56 / 66 pattern every other
 // delete-of-missing handler in this package uses.
+//
+// Bug 379: parent-NotFound (node never existed) folds into the same
+// idempotent envelope. Pre-fix this branch leaked a raw
+// `patch NetInterfaces of Node "X": node "X": object not found`
+// 404 — symmetric with the Bug 378 gap on per-key property delete:
+// cozystack's node-evacuation playbook calls
+// `linstor node interface delete <node> <nic>` in a retry loop, and
+// a second pass after `linstor n d <node>` succeeded should be a
+// no-op rather than a fatal "object not found" envelope. The
+// controller-side sibling
+// (`DELETE /v1/controller/properties/{key...}`) returns 200 on every
+// input for the same reason — see TestControllerPropertiesDelete*.
 func (s *Server) handleNetInterfaceDelete(w http.ResponseWriter, r *http.Request) {
 	nodeName := r.PathValue("node")
 	name := r.PathValue("name")
@@ -238,6 +250,25 @@ func (s *Server) handleNetInterfaceDelete(w http.ResponseWriter, r *http.Request
 		return out, nil
 	})
 	if err != nil {
+		// Bug 379: parent-NotFound is also idempotent. Mirrors the
+		// Bug 378 fix on `handleNodePropDelete`: a teardown script
+		// that first runs `linstor n d <node>` then
+		// `linstor node interface delete <node> default` must not
+		// fail on the second call once the node finally clears.
+		// Surface the same warn-band envelope `handleNodeDelete`
+		// itself emits so an audit-log grep on warnNodeNotFound
+		// catches the cascade.
+		if errors.Is(err, store.ErrNotFound) {
+			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
+				RetCode: maskWarn,
+				Message: "node already absent: " + nodeName +
+					" (net-interface delete no-op on " + name + ")",
+				ObjRefs: map[string]string{objRefNode: nodeName},
+			}})
+
+			return
+		}
+
 		writeStoreError(w, err)
 
 		return

--- a/tests/e2e/net-interface-delete-parent-missing.sh
+++ b/tests/e2e/net-interface-delete-parent-missing.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# usage: net-interface-delete-parent-missing.sh WORK_DIR
+#
+# Bug 379 (P3, hunt-caught 2026-06-02) — NIC-level echo of Bug 378.
+# `DELETE /v1/nodes/{node}/net-interfaces/{name}` returned a raw 404
+# `patch NetInterfaces of Node "X": node "X": object not found` when
+# the parent node was already gone. Symmetric to the Bug 378 gap on
+# per-key property delete which made cozystack's node-evacuation
+# playbook race into a fatal 404 on the second pass.
+#
+# The Bug-hunt v0.1.3 Finding 9 fix already made "node present, NIC
+# missing" idempotent (200 + warnNetInterfaceNotFound) but never
+# extended that idempotency to the parent-missing branch, so a
+# teardown that runs `linstor n d <node>` then
+# `linstor node interface delete <node> default` crashed once the
+# node finally cleared.
+#
+# This e2e pins the rejection on a live cluster and verifies:
+#   1. DELETE NIC on a ghost node returns 200 (not 404).
+#   2. The envelope carries the warn-band mask + objRefs[Node].
+#   3. Pre-existing branch (node present, NIC missing) keeps its
+#      warnNetInterfaceNotFound 200 envelope.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug379-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# Case 1: parent-missing NIC delete must return 200, not 404 — the
+# Bug 379 promise.
+echo ">> case 1: DELETE NIC on ghost node returns 200"
+BODY=/tmp/bug379-ghost.txt
+CODE=$(curl -s -o "$BODY" -w "%{http_code}" -X DELETE \
+    "$B/v1/nodes/bug379-ghost/net-interfaces/default")
+
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: ghost-node NIC delete returned $CODE, expected 200 (Bug 379)"
+    cat "$BODY"
+    exit 1
+fi
+
+# Case 2: envelope must carry warn-band ret_code + objRefs[Node] so
+# audit-log filters built around objRefNode catch the cascade.
+echo ">> case 2: envelope carries warn-band + objRefs[Node]"
+python3 -c "
+import sys, json
+with open('$BODY') as f:
+    arr = json.load(f)
+if not isinstance(arr, list) or len(arr) != 1:
+    print('FAIL: envelope shape:', arr)
+    sys.exit(1)
+rc = arr[0]
+# warn-band mask is 0x200000000 (Bug 378 / Bug 142 / Bug 66 share it).
+if (rc.get('ret_code', 0) & 0x300000000) != 0x200000000:
+    print('FAIL: ret_code not warn-band:', hex(rc.get('ret_code', 0)))
+    sys.exit(1)
+if 'bug379-ghost' not in rc.get('message', ''):
+    print('FAIL: message does not name node:', rc)
+    sys.exit(1)
+if rc.get('obj_refs', {}).get('Node') != 'bug379-ghost':
+    print('FAIL: obj_refs[Node] missing:', rc)
+    sys.exit(1)
+print('OK')
+"
+
+# Case 3: pre-existing branch (node present, NIC missing) keeps its
+# warn-band envelope but with the older warnNetInterfaceNotFound mask.
+# Use the first real worker as the parent — that one is always there.
+echo ">> case 3: DELETE missing NIC on extant node keeps existing shape"
+BODY2=/tmp/bug379-extant.txt
+CODE2=$(curl -s -o "$BODY2" -w "%{http_code}" -X DELETE \
+    "$B/v1/nodes/$WORKER_1/net-interfaces/bug379-never-registered")
+
+if [[ "$CODE2" != "200" ]]; then
+    echo "FAIL: extant-node missing-NIC delete returned $CODE2, expected 200"
+    cat "$BODY2"
+    exit 1
+fi
+
+python3 -c "
+import sys, json
+with open('$BODY2') as f:
+    arr = json.load(f)
+if not isinstance(arr, list) or len(arr) != 1:
+    print('FAIL: envelope shape:', arr)
+    sys.exit(1)
+rc = arr[0]
+# Whatever mask the pre-existing branch uses, it must NOT be the
+# Bug 379 'node already absent' message — that would mean we
+# regressed and folded a 'NIC missing on extant node' into the new
+# parent-missing branch.
+if 'node already absent' in rc.get('message', ''):
+    print('FAIL: existing-node branch leaked into parent-missing shape:', rc)
+    sys.exit(1)
+print('OK')
+"
+
+echo "PASS: bug 379 — NIC delete is idempotent on parent-missing"


### PR DESCRIPTION
## Summary

`DELETE /v1/nodes/{node}/net-interfaces/{name}` leaked a raw 404 `patch NetInterfaces of Node "X": node "X": object not found` when the parent node was already gone. Symmetric to the Bug 378 gap on per-key property delete: a cozystack node-evacuation playbook that runs `linstor n d <node>` then `linstor node interface delete <node> default` raced into a fatal 404 on the second pass once the node finally cleared.

Bug-hunt v0.1.3 Finding 9 already made "node present, NIC missing" idempotent (200 + `warnNetInterfaceNotFound`) but never extended that idempotency to parent-missing. This PR folds parent-`NotFound` into the same warn-band 200 envelope `handleNodePropDelete` + `handleNodeDelete` use, with `objRefs[Node]` pinned so audit-log filters built around `objRefNode` catch the cascade.

## Test plan

- [x] `go test ./pkg/rest/ -run TestBug379 -count=1` — new wire-shape pins.
- [x] `go test ./pkg/rest/ -count=1` — no regressions; `TestNetInterfaceDeleteUnknownNode` pin flipped 404→200 with a Bug 379 reference comment.
- [x] `golangci-lint run ./pkg/rest/...` — 0 issues.
- [ ] `tests/e2e/net-interface-delete-parent-missing.sh` on dev stand — live-cluster proof, runs once CI lane lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network interface deletion is now idempotent when the parent node is missing, returning HTTP 200 with a warning instead of HTTP 404. The response includes clear messaging about the missing parent node, ensuring consistent and predictable delete behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->