### PR TITLE
fix(rest): emit operator-grade envelope on non-numeric VD path-vn (Bug 380)

### DIFF
--- a/pkg/rest/bug_380_vd_path_non_numeric_envelope_test.go
+++ b/pkg/rest/bug_380_vd_path_non_numeric_envelope_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 380 (P3, bughunt round 11 — 2026-06-02): the {vn} URL pathvar
+// on every per-volume-definition REST entry point
+// (`GET /v1/resource-definitions/{rd}/volume-definitions/{vn}`,
+// PUT, DELETE, plus the per-resource `volumes/{vlmNr}` mirror)
+// leaked a raw `strconv.ParseInt: parsing "abc": invalid syntax`
+// when the caller passed a non-numeric segment. The stdlib func name
+// in the wire body is internal Go plumbing — operators have no idea
+// what the allowed range is, and the python CLI's XML decoder
+// fallback can crash on the unexpected punctuation.
+//
+// Bug 365 already shipped a `volume_number must be in [0, 65535]`
+// correction on the POST/DELETE *body* branch. Bug 380 brings the
+// URL-path branch to the same shape via parseVolNum, so every wire
+// edge in the VD CRUD surface returns the same operator-grade
+// correction hint regardless of where the bad value arrived.
+
+// TestBug380_VDGetNonNumericPathReturnsRangeHint pins the GET path.
+// Pre-fix: body=`strconv.ParseInt: parsing "abc": invalid syntax`,
+// status=400. Post-fix: body names the field, gives the [0, 65535]
+// range, references the LINSTOR REST API documentation.
+func TestBug380_VDGetNonNumericPathReturnsRangeHint(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpGet(t,
+		base+"/v1/resource-definitions/some-rd/volume-definitions/abc")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	assertVolNumEnvelope(t, body, "abc")
+}
+
+// TestBug380_VDDeleteNonNumericPathReturnsRangeHint pins the DELETE
+// path. Symmetric with the GET assertion above.
+func TestBug380_VDDeleteNonNumericPathReturnsRangeHint(t *testing.T) {
+	base, stop := startServerWithStore(t, store.NewInMemory())
+	defer stop()
+
+	resp := httpDelete(t,
+		base+"/v1/resource-definitions/some-rd/volume-definitions/abc")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	assertVolNumEnvelope(t, body, "abc")
+}
+
+// TestBug380_VolumeGetNonNumericPathReturnsRangeHint pins the
+// per-resource volumes mirror that ships parseVolNum from
+// volumes_per_resource.go. Pre-fix that handler also surfaced
+// `strconv.ParseInt: ...` because it shared parseVolNum.
+func TestBug380_VolumeGetNonNumericPathReturnsRangeHint(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceDefinitions().Create(t.Context(),
+		&apiv1.ResourceDefinition{Name: "rd-1"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpGet(t,
+		base+"/v1/resource-definitions/rd-1/resources/some-node/volumes/xyz")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	assertVolNumEnvelope(t, body, "xyz")
+}
+
+// assertVolNumEnvelope is the shared shape-assertion the Bug 380
+// tests reuse: ApiCallRc array of one entry whose message names the
+// offending segment, mentions `volume_number`, AND surfaces the
+// canonical [0, 65535] range. Crucially the message must NOT leak
+// the stdlib `strconv.ParseInt:` prefix.
+func assertVolNumEnvelope(t *testing.T, body []byte, badSegment string) {
+	t.Helper()
+
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(body, &rcs); err != nil {
+		t.Fatalf("unmarshal envelope: %v; body=%s", err, body)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope length: got %d, want 1; body=%s", len(rcs), body)
+	}
+
+	msg := rcs[0].Message
+
+	if strings.Contains(msg, "strconv.ParseInt") {
+		t.Errorf("Bug 380: message still leaks raw strconv.ParseInt prefix: %q", msg)
+	}
+
+	if !strings.Contains(msg, badSegment) {
+		t.Errorf("message must name the offending segment %q; got %q", badSegment, msg)
+	}
+
+	if !strings.Contains(msg, "volume_number") {
+		t.Errorf("message must mention `volume_number` field; got %q", msg)
+	}
+
+	if !strings.Contains(msg, "[0, 65535]") {
+		t.Errorf("message must surface the canonical [0, 65535] range; got %q", msg)
+	}
+}

--- a/pkg/rest/volume_definitions.go
+++ b/pkg/rest/volume_definitions.go
@@ -1266,13 +1266,32 @@ func (s *Server) pruneVolumesFromResources(ctx context.Context, rd string, vn in
 	}
 }
 
+// parseVolNum decodes the {vn} / {vlmNr} URL pathvar into the int32
+// volume-number DRBD expects. Bug 380 (P3, bughunt round 11): pre-fix
+// the wire surfaced a raw `strconv.ParseInt: parsing "abc": invalid
+// syntax` to the caller — an internal Go error string that leaks the
+// stdlib func name and gives the operator zero hint about what the
+// allowed range actually is. Symmetric with the Bug 365 / Bug 363
+// envelope on the POST/DELETE body branches: an out-of-range or
+// non-numeric `volume_number` returns the same `[0, 65535]` correction
+// regardless of whether it arrived via path or body. parseVolNum
+// itself returns the wire-ready error string so every caller
+// (handleVDGet / handleVDDelete / handleVDPut / handleVolumeGet ...)
+// stays a one-line `writeError(w, 400, err.Error())` — no new
+// per-handler envelope drift.
 func parseVolNum(raw string) (int32, error) {
-	v, err := strconv.ParseInt(raw, 10, 32)
+	parsed, err := strconv.ParseInt(raw, 10, 32)
 	if err != nil {
-		return 0, err //nolint:wrapcheck // returned to handler that wraps it
+		// Same correction hint Bug 365 surfaces on the body branch —
+		// volume_number is a DRBD wire field, [0, 65535].
+		return 0, errors.Newf( //nolint:wrapcheck // wire-ready string, returned straight to writeError
+			"invalid volume number %q in URL path: "+
+				"volume_number must be a decimal integer in [0, 65535]; "+
+				"check the LINSTOR REST API documentation",
+			raw)
 	}
 
-	return int32(v), nil
+	return int32(parsed), nil
 }
 
 // resizePendingAnnotationPrefix is the per-volume annotation key

--- a/tests/e2e/vd-path-non-numeric-envelope.sh
+++ b/tests/e2e/vd-path-non-numeric-envelope.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# usage: vd-path-non-numeric-envelope.sh WORK_DIR
+#
+# Bug 380 (P3, hunt-caught 2026-06-02) — per-volume-definition URL
+# {vn} pathvar leaked a raw `strconv.ParseInt: parsing "abc": invalid
+# syntax` envelope when the caller passed a non-numeric segment. The
+# stdlib func name in the wire body is internal Go plumbing — gives
+# the operator zero hint about the allowed [0, 65535] range, and the
+# python-linstor CLI's XML decoder fallback can crash on the
+# unexpected punctuation.
+#
+# This e2e pins the rejection on a live cluster and verifies:
+#   1. GET on {vn}=abc returns 400 + envelope that names
+#      `volume_number`, the `[0, 65535]` range, AND the offending
+#      segment.
+#   2. DELETE on {vn}=abc returns the same shape.
+#   3. The envelope does NOT leak the raw `strconv.ParseInt:` prefix.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug380-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+assert_volnum_envelope() {
+    local body_file="$1"
+    local label="$2"
+    python3 -c "
+import sys, json
+with open('$body_file') as f:
+    body = f.read()
+try:
+    arr = json.loads(body)
+except Exception as e:
+    print('FAIL[$label]: body not JSON:', e, '— body=', body)
+    sys.exit(1)
+if not isinstance(arr, list) or len(arr) != 1:
+    print('FAIL[$label]: envelope shape:', arr)
+    sys.exit(1)
+msg = arr[0].get('message', '')
+if 'strconv.ParseInt' in msg:
+    print('FAIL[$label]: leaks raw stdlib prefix:', msg)
+    sys.exit(1)
+if 'volume_number' not in msg:
+    print('FAIL[$label]: does not name volume_number field:', msg)
+    sys.exit(1)
+if '[0, 65535]' not in msg:
+    print('FAIL[$label]: does not surface canonical range:', msg)
+    sys.exit(1)
+print('OK[$label]')
+"
+}
+
+echo ">> case 1: GET vd with non-numeric vn"
+BODY1=/tmp/bug380-get.txt
+CODE=$(curl -s -o "$BODY1" -w "%{http_code}" \
+    "$B/v1/resource-definitions/some-rd/volume-definitions/abc")
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: GET returned $CODE, expected 400"
+    cat "$BODY1"
+    exit 1
+fi
+assert_volnum_envelope "$BODY1" "get"
+
+echo ">> case 2: DELETE vd with non-numeric vn"
+BODY2=/tmp/bug380-del.txt
+CODE=$(curl -s -o "$BODY2" -w "%{http_code}" -X DELETE \
+    "$B/v1/resource-definitions/some-rd/volume-definitions/abc")
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: DELETE returned $CODE, expected 400"
+    cat "$BODY2"
+    exit 1
+fi
+assert_volnum_envelope "$BODY2" "delete"
+
+echo "PASS: bug 380 — VD {vn} pathvar emits operator-grade envelope on non-numeric input"


### PR DESCRIPTION
## Summary

Every per-volume-definition REST entry point (`GET /v1/resource-definitions/{rd}/volume-definitions/{vn}`, PUT, DELETE, plus the per-resource `volumes/{vlmNr}` mirror) leaked a raw `strconv.ParseInt: parsing "abc": invalid syntax` envelope when the caller passed a non-numeric segment. The stdlib func name in the wire body is internal Go plumbing — operators have no idea what the allowed range is, and the python-linstor CLI's XML decoder fallback can crash on the unexpected punctuation.

Bug 365 already shipped `volume_number must be in [0, 65535]` on the POST/DELETE body branch. This PR brings the URL-path branch to the same shape via the shared `parseVolNum` helper — one helper change; every caller (handleVDGet / handleVDDelete / handleVDPut, handleVolumeGet, handleVolumeDelete) inherits the new envelope without any per-handler drift.

## Test plan

- [x] `go test ./pkg/rest/ -run TestBug380 -count=1` — three new wire-shape pins (GET, DELETE, per-resource Volume mirror).
- [x] `go test ./pkg/rest/ -count=1` — no regressions; `TestVolumeDefinitionsDeleteBadVolumeNumber` still asserts the 400 status code.
- [x] `golangci-lint run ./pkg/rest/...` — 0 issues.
- [ ] `tests/e2e/vd-path-non-numeric-envelope.sh` on dev stand — live-cluster proof, runs once CI lane lands.