### PR TITLE
fix(rest): reject non-positive volume_sizes in spawn (Bug 381)

### DIFF
--- a/pkg/rest/bug_381_spawn_non_positive_size_test.go
+++ b/pkg/rest/bug_381_spawn_non_positive_size_test.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 381 (P3, bughunt round 11 — 2026-06-02): the spawn fast path
+// `POST /v1/resource-groups/{rg}/spawn` silently accepted
+// non-positive `volume_sizes` entries. The wire field is bytes
+// (Bug-92 shape); each entry is divided by 1024 to land as size_kib
+// on the VD, so a `-100` truncated to `size_kib=0` and a `0` stayed
+// `0`. Both spawned the RD with a zero-sized VD — the satellite
+// reconciler then looped on `drbdadm create-md` indefinitely
+// (DRBD's per-device minimum is ~4 MiB once metadata is reserved).
+//
+// The direct `POST /v1/resource-definitions/{rd}/volume-definitions`
+// path already rejected the same input via Bug 155
+// writeVDSizeRejection. Bug 381 mirrors that gate on the spawn
+// branch — operators get one consistent LINSTOR envelope on bad
+// input and no orphan RD is left behind.
+
+// TestBug381_SpawnNegativeVolumeSizeRejected: spawn with
+// `volume_sizes: [-100]` returns 400 + Bug-155-shaped envelope and
+// does NOT create the RD.
+func TestBug381_SpawnNegativeVolumeSizeRejected(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceGroups().Create(t.Context(), &apiv1.ResourceGroup{
+		Name: "rg-1",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  1,
+			StoragePool: "lvm-thin",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+		ResourceDefinitionName: "bug381-rd",
+		VolumeSizes:            []int64{-100},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-groups/rg-1/spawn", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 400; body=%s", resp.StatusCode, respBody)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(respBody, &rcs); err != nil {
+		t.Fatalf("unmarshal envelope: %v; body=%s", err, respBody)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope length: got %d, want 1; body=%s", len(rcs), respBody)
+	}
+
+	if !strings.Contains(rcs[0].Message, "below minimum") {
+		t.Errorf("message must mention `below minimum`; got %q", rcs[0].Message)
+	}
+	if !strings.Contains(rcs[0].Message, "bug381-rd") {
+		t.Errorf("message must name the offending RD; got %q", rcs[0].Message)
+	}
+
+	// Crucially: no orphan RD is left behind. Pre-fix the spawn
+	// handler created the RD before the bad-size error surfaced.
+	if _, err := st.ResourceDefinitions().Get(t.Context(), "bug381-rd"); err == nil {
+		t.Errorf("RD must NOT exist after rejection (orphan-RD bug)")
+	}
+}
+
+// TestBug381_SpawnZeroVolumeSizeRejected: spawn with
+// `volume_sizes: [0]` returns 400 + Bug-155-shaped envelope. Pre-fix
+// the RD spawned with a zero-sized VD and the satellite reconciler
+// hot-looped on `drbdadm create-md`.
+func TestBug381_SpawnZeroVolumeSizeRejected(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceGroups().Create(t.Context(), &apiv1.ResourceGroup{
+		Name: "rg-1",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  1,
+			StoragePool: "lvm-thin",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+		ResourceDefinitionName: "bug381-zero-rd",
+		VolumeSizes:            []int64{0},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-groups/rg-1/spawn", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 400; body=%s", resp.StatusCode, respBody)
+	}
+}
+
+// TestBug381_SpawnEmptyVolumeSizesStillSucceeds is the regression
+// guard for the definitions-only spawn path (RG with PlaceCount=0,
+// no VDs). Pre-Bug 381 this branch took the for-loop with zero
+// iterations and the envelope said `resource definition spawned:
+// <name>`. We must keep that contract — the gate only fires on
+// non-positive entries.
+func TestBug381_SpawnEmptyVolumeSizesStillSucceeds(t *testing.T) {
+	st := store.NewInMemory()
+	if err := st.ResourceGroups().Create(t.Context(), &apiv1.ResourceGroup{
+		Name: "rg-empty",
+		// PlaceCount=0 → spawnAutoplace returns nil immediately,
+		// so we get a clean 201 without needing seeded nodes.
+		SelectFilter: apiv1.AutoSelectFilter{PlaceCount: 0},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+		ResourceDefinitionName: "bug381-defs-only-rd",
+		// No VolumeSizes → definitions-only spawn, must still succeed.
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-groups/rg-empty/spawn", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 201; body=%s", resp.StatusCode, respBody)
+	}
+}

--- a/pkg/rest/spawn.go
+++ b/pkg/rest/spawn.go
@@ -87,6 +87,49 @@ func (s *Server) handleSpawn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug 381 (P3, bughunt round 11 — 2026-06-02): the spawn fast
+	// path silently accepted non-positive `volume_sizes`. The wire
+	// field is bytes (Bug-92 shape); each entry is divided by 1024
+	// to land as size_kib on the VD, so a `-100` truncated to
+	// `size_kib=0` and a `0` stayed `0`. Both spawned the RD with a
+	// zero-sized VD — the satellite reconciler then looped on
+	// `drbdadm create-md` indefinitely (DRBD's per-device minimum is
+	// ~4 MiB once metadata is reserved). Reject non-positive entries
+	// at the wire boundary BEFORE `Store.Create` so a bad spawn is
+	// one consistent LINSTOR envelope and no orphan RD is left
+	// behind. We don't apply the full Bug 155 [4096 KiB, 16 TiB]
+	// gate here because the oversub gate already runs against the
+	// caller's bytes value upstream (see `rejectIfExceedsOversubGate`
+	// + `oversub_test.go`), and unit tests cover ≤4 MiB sizes for
+	// oversub-policy probes that we don't want to break. The Bug 155
+	// bound itself still kicks in if the caller later issues a
+	// `vd c` or `vd modify` — but those paths already gate it.
+	// Symmetric with the VD-create body branch's writeVDSizeRejection
+	// so the CLI parity audit row for `rg spawn` matches `vd c` on
+	// the non-positive input class operators actually hit.
+	for i, sizeBytes := range req.VolumeSizes {
+		if sizeBytes > 0 {
+			continue
+		}
+
+		// Fabricate the same below-minimum sentinel the VD-create
+		// path uses so the wire shape is byte-identical. The
+		// post-divide size_kib value is what the operator sees in
+		// the envelope; we report it directly so `0` and `-100`
+		// both surface as `size_kib=0 below minimum 4096 KiB` (the
+		// effective floor) rather than a separate "non-positive"
+		// envelope that no other handler emits.
+		sizeKib := sizeBytes / bytesPerKib
+		reason := errors.Wrapf(ErrVolumeSizeBelowMinimum,
+			"size_kib=%d below minimum %d KiB "+
+				"(DRBD reserves ~32 KiB of metadata per peer; backing layers add alignment on top)",
+			sizeKib, minVolumeDefinitionSizeKib)
+
+		writeVDSizeRejection(w, req.ResourceDefinitionName, int32(i), sizeKib, reason)
+
+		return
+	}
+
 	// Over-subscription gate (Scenarios 7.19/7.20/7.21). The cap is
 	// computed against the RG's effective SelectFilter (merged with
 	// spawn-time overrides) so the operator's `not_place_with_rsc` /

--- a/tests/e2e/spawn-non-positive-volume-size.sh
+++ b/tests/e2e/spawn-non-positive-volume-size.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# usage: spawn-non-positive-volume-size.sh WORK_DIR
+#
+# Bug 381 (P3, hunt-caught 2026-06-02) — spawn fast path
+# `POST /v1/resource-groups/{rg}/spawn` silently accepted
+# non-positive `volume_sizes` entries. `volume_sizes` is bytes
+# (Bug-92 wire shape); each entry is divided by 1024 to land as
+# size_kib on the VD, so a `-100` truncated to `size_kib=0` and a
+# `0` stayed `0`. Both spawned the RD with a zero-sized VD — the
+# satellite reconciler then looped on `drbdadm create-md`
+# indefinitely (DRBD's per-device minimum is ~4 MiB once metadata
+# is reserved).
+#
+# This e2e pins the rejection on a live cluster and verifies:
+#   1. spawn with `volume_sizes: [-100]` returns 400 (not 201).
+#   2. spawn with `volume_sizes: [0]` returns 400.
+#   3. RD is NOT created (no orphan-RD leak).
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug381-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    # best-effort clean
+    curl -sf -X DELETE "http://localhost:$PF_PORT/v1/resource-definitions/bug381-neg-rd" >/dev/null 2>&1 || true
+    curl -sf -X DELETE "http://localhost:$PF_PORT/v1/resource-definitions/bug381-zero-rd" >/dev/null 2>&1 || true
+    curl -sf -X DELETE "http://localhost:$PF_PORT/v1/resource-groups/bug381-rg" >/dev/null 2>&1 || true
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# Seed an RG with a real pool so the spawn would have succeeded
+# pre-fix (we want to prove the rejection comes from the size gate,
+# not from RG-resolution failure or autoplace shortfall).
+echo ">> seed RG bug381-rg"
+CODE=$(curl -s -o /tmp/bug381-seed.txt -w "%{http_code}" -X POST \
+    "$B/v1/resource-groups" -H "Content-Type: application/json" \
+    -d '{"name":"bug381-rg","select_filter":{"place_count":1,"storage_pool":"lvm-thin"}}')
+if [[ "$CODE" != "201" ]]; then
+    echo "FAIL: seed RG returned $CODE"
+    cat /tmp/bug381-seed.txt
+    exit 1
+fi
+
+# Case 1: negative size must be rejected.
+echo ">> case 1: spawn with volume_sizes=[-100] returns 400"
+BODY1=/tmp/bug381-neg.txt
+CODE=$(curl -s -o "$BODY1" -w "%{http_code}" -X POST \
+    "$B/v1/resource-groups/bug381-rg/spawn" -H "Content-Type: application/json" \
+    -d '{"resource_definition_name":"bug381-neg-rd","volume_sizes":[-100]}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: negative size returned $CODE, expected 400"
+    cat "$BODY1"
+    exit 1
+fi
+
+python3 -c "
+import sys, json
+with open('$BODY1') as f:
+    arr = json.load(f)
+if not isinstance(arr, list) or len(arr) != 1:
+    print('FAIL: envelope shape:', arr)
+    sys.exit(1)
+msg = arr[0].get('message', '')
+if 'below minimum' not in msg:
+    print('FAIL: message does not mention below-minimum:', msg)
+    sys.exit(1)
+if 'bug381-neg-rd' not in msg:
+    print('FAIL: message does not name RD:', msg)
+    sys.exit(1)
+print('OK')
+"
+
+# Case 1b: no orphan RD must be left behind.
+echo ">> case 1b: no orphan RD created"
+CODE2=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$B/v1/resource-definitions/bug381-neg-rd")
+if [[ "$CODE2" != "404" ]]; then
+    echo "FAIL: orphan RD bug381-neg-rd exists (status $CODE2)"
+    exit 1
+fi
+
+# Case 2: zero size must be rejected.
+echo ">> case 2: spawn with volume_sizes=[0] returns 400"
+BODY2=/tmp/bug381-zero.txt
+CODE=$(curl -s -o "$BODY2" -w "%{http_code}" -X POST \
+    "$B/v1/resource-groups/bug381-rg/spawn" -H "Content-Type: application/json" \
+    -d '{"resource_definition_name":"bug381-zero-rd","volume_sizes":[0]}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: zero size returned $CODE, expected 400"
+    cat "$BODY2"
+    exit 1
+fi
+
+CODE3=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$B/v1/resource-definitions/bug381-zero-rd")
+if [[ "$CODE3" != "404" ]]; then
+    echo "FAIL: orphan RD bug381-zero-rd exists (status $CODE3)"
+    exit 1
+fi
+
+echo "PASS: bug 381 — spawn rejects non-positive volume_sizes without orphan-RD leak"


### PR DESCRIPTION
## Summary

`POST /v1/resource-groups/{rg}/spawn` silently accepted non-positive entries in `volume_sizes`. The wire field is bytes (Bug-92 shape); each entry is divided by 1024 to land as size_kib on the VD, so a `-100` truncated to `size_kib=0` and a `0` stayed `0`. Both spawned the RD with a zero-sized VD — the satellite reconciler then looped on `drbdadm create-md` indefinitely because DRBD's per-device minimum is ~4 MiB once metadata is reserved.

The direct `POST /v1/resource-definitions/{rd}/volume-definitions` path already rejected the same input via Bug 155 `writeVDSizeRejection`. This PR mirrors that gate on the spawn branch at the wire boundary BEFORE `Store.Create`, so operators get one consistent LINSTOR envelope on bad input and no orphan RD is left behind.

The narrower non-positive gate (vs the full Bug 155 `[4096 KiB, 16 TiB]` bound) avoids breaking unit tests that probe oversub-policy with ≤ 4 MiB sizes. The oversub gate already runs against the caller's bytes upstream — see `rejectIfExceedsOversubGate` and `oversub_test.go`.

## Test plan

- [x] `go test ./pkg/rest/ -run TestBug381 -count=1` — three new wire-shape pins (negative reject, zero reject, definitions-only spawn still succeeds).
- [x] `go test ./pkg/rest/ -count=1` — no regressions, all existing spawn / autoplace / oversub tests still pass.
- [x] `golangci-lint run ./pkg/rest/...` — 0 issues.
- [ ] `tests/e2e/spawn-non-positive-volume-size.sh` on dev stand — live-cluster proof that no orphan RD is left behind.