### PR TITLE
fix(rest): reject non-positive size_kib on VD PUT regardless of force (Bug 383)

### DIFF
--- a/pkg/rest/bug_383_vd_put_non_positive_size_test.go
+++ b/pkg/rest/bug_383_vd_put_non_positive_size_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 383 (P3, bughunt round 12 — 2026-06-02): the VD PUT update path
+// `PUT /v1/resource-definitions/{rd}/volume-definitions/{vn}` silently
+// accepted non-positive `size_kib` when `force=true` was set. The
+// force escape hatch was scoped only at the scenario 4.W13 "no auto-
+// shrink" refusal — callers that already ran `resize2fs -s` on the
+// consumer know the new size is below the live one and need to land
+// the smaller spec. force was never intended to let a caller persist
+// `size_kib=0` or a negative value into the spec.
+//
+// The satellite reconciler then looped on `drbdadm create-md`
+// indefinitely (DRBD's per-device minimum is ~4 MiB once metadata is
+// reserved), identical to the Bug 381 spawn-fast-path footgun but
+// reached through the PUT update path. The POST VD create path
+// already rejected the same input via Bug 155 validateVDSize. Bug 383
+// mirrors that gate on the PUT branch before the shrink+force check —
+// the operator-facing message is the right one ("must be > 0",
+// not "filesystem shrink-then-resize required").
+
+// seedRDWithVD seeds a single-volume RD into the in-memory store so
+// the PUT tests can run against a real VD without a spawn round-trip.
+func seedRDWithVD(t *testing.T, st store.Store, rdName string, sizeKib int64) {
+	t.Helper()
+
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{
+		Name:              rdName,
+		ResourceGroupName: "DfltRscGrp",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.VolumeDefinitions().Create(t.Context(), rdName, &apiv1.VolumeDefinition{
+		VolumeNumber: 0,
+		SizeKib:      sizeKib,
+	}); err != nil {
+		t.Fatalf("seed VD: %v", err)
+	}
+}
+
+// assertVDSize fetches the VD from the store and fails the test when
+// its persisted size_kib doesn't match the expected value. Used by the
+// Bug 383 tests to pin that a rejected PUT did NOT mutate the row.
+func assertVDSize(t *testing.T, st store.Store, rdName string, want int64) {
+	t.Helper()
+
+	vd, err := st.VolumeDefinitions().Get(t.Context(), rdName, 0)
+	if err != nil {
+		t.Fatalf("get VD after rejection: %v", err)
+	}
+
+	if vd.SizeKib != want {
+		t.Errorf("size_kib leaked through rejection: got %d, want %d", vd.SizeKib, want)
+	}
+}
+
+// TestBug383_VDPutNegativeSizeWithForceRejected: PUT VD with
+// `size_kib=-100, force=true` returns 400 + Bug-155-shaped envelope
+// and does NOT mutate the stored row. Pre-fix this 200'd and persisted
+// `size_kib=-100` into the spec.
+func TestBug383_VDPutNegativeSizeWithForceRejected(t *testing.T) {
+	st := store.NewInMemory()
+	seedRDWithVD(t, st, "bug383-neg-rd", 8192)
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	negSize := int64(-100)
+	body, err := json.Marshal(volumeDefinitionModifyBody{
+		SizeKib: &negSize,
+		Force:   true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/resource-definitions/bug383-neg-rd/volume-definitions/0", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 400; body=%s", resp.StatusCode, respBody)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.Unmarshal(respBody, &rcs); err != nil {
+		t.Fatalf("unmarshal envelope: %v; body=%s", err, respBody)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope length: got %d, want 1; body=%s", len(rcs), respBody)
+	}
+
+	// Bug 383 message must point at the absolute floor, not the
+	// shrink-then-resize cause text — operators reading the LINSTOR
+	// error need to see "this size is invalid" not "you forgot to
+	// resize2fs first".
+	if !strings.Contains(rcs[0].Message, "must be > 0") {
+		t.Errorf("message must mention the > 0 floor; got %q", rcs[0].Message)
+	}
+	if strings.Contains(rcs[0].Message, "filesystem shrink-then-resize") {
+		t.Errorf("message must NOT confuse Bug 383 with the shrink-force path; got %q", rcs[0].Message)
+	}
+
+	// Crucially: the stored row stays at the pre-PUT size.
+	assertVDSize(t, st, "bug383-neg-rd", 8192)
+}
+
+// TestBug383_VDPutZeroSizeWithForceRejected: PUT VD with
+// `size_kib=0, force=true` returns 400 + Bug-155-shaped envelope and
+// does NOT mutate the stored row. Pre-fix this 200'd and persisted
+// `size_kib=0` into the spec, then the satellite reconciler hot-
+// looped on `drbdadm create-md`.
+func TestBug383_VDPutZeroSizeWithForceRejected(t *testing.T) {
+	st := store.NewInMemory()
+	seedRDWithVD(t, st, "bug383-zero-rd", 8192)
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	zeroSize := int64(0)
+	body, err := json.Marshal(volumeDefinitionModifyBody{
+		SizeKib: &zeroSize,
+		Force:   true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/resource-definitions/bug383-zero-rd/volume-definitions/0", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 400; body=%s", resp.StatusCode, respBody)
+	}
+
+	assertVDSize(t, st, "bug383-zero-rd", 8192)
+}
+
+// TestBug383_VDPutNegativeSizeWithoutForceRejected: PUT VD with
+// `size_kib=-100` and no force still rejects. This was already
+// blocked pre-Bug 383 via the shrink-without-force path, but the
+// message routing changes (the Bug 383 floor check runs first), so
+// pin the regression that the gate stays closed and the row stays
+// untouched.
+func TestBug383_VDPutNegativeSizeWithoutForceRejected(t *testing.T) {
+	st := store.NewInMemory()
+	seedRDWithVD(t, st, "bug383-noforce-rd", 8192)
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	negSize := int64(-100)
+	body, err := json.Marshal(volumeDefinitionModifyBody{
+		SizeKib: &negSize,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/resource-definitions/bug383-noforce-rd/volume-definitions/0", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 400; body=%s", resp.StatusCode, respBody)
+	}
+
+	assertVDSize(t, st, "bug383-noforce-rd", 8192)
+}
+
+// TestBug383_VDPutValidShrinkWithForceStillWorks: scenario 4.W13
+// regression guard — the legitimate force-shrink path (positive new
+// size below the previous size) must still land. This is the path
+// linstor-csi uses after a `resize2fs -s` on the consumer, so the
+// guard at Bug 383 must NOT regress it.
+func TestBug383_VDPutValidShrinkWithForceStillWorks(t *testing.T) {
+	st := store.NewInMemory()
+	seedRDWithVD(t, st, "bug383-shrink-rd", 1024*1024)
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	newSize := int64(512 * 1024)
+	body, err := json.Marshal(volumeDefinitionModifyBody{
+		SizeKib: &newSize,
+		Force:   true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/resource-definitions/bug383-shrink-rd/volume-definitions/0", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, respBody)
+	}
+
+	assertVDSize(t, st, "bug383-shrink-rd", newSize)
+}
+
+// TestBug383_VDPutValidGrowStillWorks: positive growth path must
+// still land. Confirms the Bug 383 gate is not over-broad.
+func TestBug383_VDPutValidGrowStillWorks(t *testing.T) {
+	st := store.NewInMemory()
+	seedRDWithVD(t, st, "bug383-grow-rd", 8192)
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	newSize := int64(16384)
+	body, err := json.Marshal(volumeDefinitionModifyBody{
+		SizeKib: &newSize,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPut(t, base+"/v1/resource-definitions/bug383-grow-rd/volume-definitions/0", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200; body=%s", resp.StatusCode, respBody)
+	}
+
+	assertVDSize(t, st, "bug383-grow-rd", newSize)
+}

--- a/pkg/rest/volume_definitions.go
+++ b/pkg/rest/volume_definitions.go
@@ -677,21 +677,8 @@ func writeVDExistsConflict(w http.ResponseWriter, rd string, vn int32) {
 func (s *Server) handleVDUpdate(w http.ResponseWriter, r *http.Request) {
 	rd := r.PathValue("rd")
 
-	vn, err := parseVolNum(r.PathValue("vn"))
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-
-		return
-	}
-
-	// Bug 365: reject out-of-range volume_number at the PUT/PATCH
-	// wire boundary too. Symmetric to Bug 363 (create) and the
-	// vd-get / vd-delete gates — keeps the entire VD CRUD surface
-	// consistent on the addressable [0, 65535] DRBD-9 range.
-	vnErr := validateVolumeNumber(vn)
-	if vnErr != nil {
-		writeVDNumberRejection(w, rd, vn, vnErr)
-
+	vn, ok := parseAndValidateVDPathVolNum(w, rd, r.PathValue("vn"))
+	if !ok {
 		return
 	}
 
@@ -717,12 +704,7 @@ func (s *Server) handleVDUpdate(w http.ResponseWriter, r *http.Request) {
 
 	previousSizeKib := existing.SizeKib
 
-	// Scenario 4.W13: reject any shrink (`new < previous`) unless the
-	// operator opted in via `force=true`. Runs BEFORE the merge + store
-	// write so a rejected shrink leaves the stored spec untouched — a
-	// partial update would desync the controller spec from the
-	// satellite reality.
-	if rejectShrinkWithoutForce(w, r, &patch, rd, vn, previousSizeKib) {
+	if rejectVDPatchSize(w, r, &patch, rd, vn, previousSizeKib) {
 		return
 	}
 
@@ -785,6 +767,86 @@ func appendForceShrinkAdvisory(envelope []apiv1.APICallRc, patch *volumeDefiniti
 			objRefVlmNr:  strconv.FormatInt(int64(vn), 10),
 		},
 	})
+}
+
+// parseAndValidateVDPathVolNum decodes `{vn}` from the URL path and
+// runs the Bug 365 range check, writing the typed envelope and
+// returning ok=false on either failure. Extracted out of
+// handleVDUpdate to keep the HTTP handler under the funlen budget.
+func parseAndValidateVDPathVolNum(w http.ResponseWriter, rd, rawVN string) (int32, bool) {
+	vn, err := parseVolNum(rawVN)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+
+		return 0, false
+	}
+
+	// Bug 365: reject out-of-range volume_number at the PUT/PATCH
+	// wire boundary too. Symmetric to Bug 363 (create) and the
+	// vd-get / vd-delete gates — keeps the entire VD CRUD surface
+	// consistent on the addressable [0, 65535] DRBD-9 range.
+	vnErr := validateVolumeNumber(vn)
+	if vnErr != nil {
+		writeVDNumberRejection(w, rd, vn, vnErr)
+
+		return 0, false
+	}
+
+	return vn, true
+}
+
+// rejectVDPatchSize runs the two size-related preflight checks on a
+// VD PUT patch: the Bug 383 non-positive floor and the scenario 4.W13
+// shrink-refusal. Returns true when either rejection fired (the HTTP
+// envelope is already written) so the caller short-circuits. Split
+// out of handleVDUpdate to keep the handler under the funlen budget;
+// preserves the documented evaluation order (floor first, then shrink-
+// vs-force) so the operator-facing error message stays accurate.
+func rejectVDPatchSize(
+	w http.ResponseWriter, r *http.Request, patch *volumeDefinitionModifyBody,
+	rd string, vn int32, previousSizeKib int64,
+) bool {
+	// Bug 383 (P3, hunt-caught 2026-06-02): reject `size_kib <= 0` on
+	// PUT regardless of `force=true`. See rejectVDNonPositiveSize.
+	if rejectVDNonPositiveSize(w, patch, rd, vn) {
+		return true
+	}
+
+	// Scenario 4.W13: reject any shrink (`new < previous`) unless the
+	// operator opted in via `force=true`. Runs BEFORE the merge + store
+	// write so a rejected shrink leaves the stored spec untouched — a
+	// partial update would desync the controller spec from the
+	// satellite reality.
+	return rejectShrinkWithoutForce(w, r, patch, rd, vn, previousSizeKib)
+}
+
+// rejectVDNonPositiveSize writes a 400 + FAIL_INVLD_VLM_SIZE envelope
+// when the patch carries a non-positive `size_kib` and returns true
+// to signal the caller to short-circuit.
+//
+// Bug 383 (P3, hunt-caught 2026-06-02): force=true MUST NOT relax the
+// absolute non-positive floor on PUT. The shrink path's force escape
+// hatch was scoped only at "no auto-shrink" (callers that already ran
+// `resize2fs -s` know the new size is below the live one); it was
+// never intended to let a caller persist `size_kib=0` or a negative
+// value into the spec. The satellite reconciler then looped on
+// `drbdadm create-md` indefinitely (DRBD's per-device minimum is
+// ~4 MiB once metadata is reserved), identical to the Bug 381 spawn-
+// fast-path footgun but reached through the PUT update path. Rejected
+// before the shrink-check so the operator-facing message is the right
+// one (invalid size, not "filesystem shrink-then-resize").
+func rejectVDNonPositiveSize(
+	w http.ResponseWriter, patch *volumeDefinitionModifyBody, rd string, vn int32,
+) bool {
+	if patch.SizeKib == nil || *patch.SizeKib > 0 {
+		return false
+	}
+
+	writeVDSizeRejection(w, rd, vn, *patch.SizeKib,
+		fmt.Errorf("%w: size_kib=%d must be > 0 (force=true does NOT relax this floor)",
+			ErrVolumeSizeBelowMinimum, *patch.SizeKib))
+
+	return true
 }
 
 // rejectShrinkWithoutForce writes a 400 + FAIL_INVLD_VLM_SIZE

--- a/tests/e2e/vd-put-non-positive-size.sh
+++ b/tests/e2e/vd-put-non-positive-size.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# usage: vd-put-non-positive-size.sh WORK_DIR
+#
+# Bug 383 (P3, hunt-caught 2026-06-02) — VD PUT update path
+# `PUT /v1/resource-definitions/{rd}/volume-definitions/{vn}` silently
+# accepted non-positive `size_kib` when `force=true` was set. The
+# force escape hatch was scoped only at the scenario 4.W13 "no auto-
+# shrink" refusal (callers that already ran `resize2fs -s` on the
+# consumer know the new size is below the live one); it was never
+# intended to let a caller persist `size_kib=0` or a negative value
+# into the spec.
+#
+# Pre-fix the satellite reconciler then looped on `drbdadm create-md`
+# indefinitely (DRBD's per-device minimum is ~4 MiB once metadata is
+# reserved), identical to the Bug 381 spawn-fast-path footgun but
+# reached through the PUT update path.
+#
+# This e2e pins the rejection on a live cluster and verifies:
+#   1. PUT VD with `size_kib=-100, force=true` returns 400.
+#   2. PUT VD with `size_kib=0, force=true` returns 400.
+#   3. The stored VD row stays at the pre-PUT size after rejection.
+#   4. Legitimate force-shrink (positive new size below previous)
+#      still lands — the gate is not over-broad.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PF_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+kubectl -n "$NS" port-forward deploy/blockstor-apiserver "$PF_PORT":3370 \
+    >/tmp/bug383-pf.log 2>&1 &
+PF_PID=$!
+
+cleanup() {
+    curl -sf -X DELETE "http://localhost:$PF_PORT/v1/resource-definitions/bug383-rd" >/dev/null 2>&1 || true
+    kill "$PF_PID" 2>/dev/null || true
+    wait "$PF_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+    if curl -sf -m1 "http://localhost:$PF_PORT/v1/nodes" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+B="http://localhost:$PF_PORT"
+
+# Seed RD + VD at a sane size so each PUT has a real row to mutate.
+echo ">> seed RD bug383-rd with VD 0 at 1 GiB"
+CODE=$(curl -s -o /tmp/bug383-seed.txt -w "%{http_code}" -X POST \
+    "$B/v1/resource-definitions" -H "Content-Type: application/json" \
+    -d '{"resource_definition":{"name":"bug383-rd"}}')
+if [[ "$CODE" != "201" ]]; then
+    echo "FAIL: seed RD returned $CODE"
+    cat /tmp/bug383-seed.txt
+    exit 1
+fi
+
+CODE=$(curl -s -o /tmp/bug383-vd.txt -w "%{http_code}" -X POST \
+    "$B/v1/resource-definitions/bug383-rd/volume-definitions" \
+    -H "Content-Type: application/json" \
+    -d '{"volume_definition":{"size_kib":1048576}}')
+if [[ "$CODE" != "200" && "$CODE" != "201" ]]; then
+    echo "FAIL: seed VD returned $CODE"
+    cat /tmp/bug383-vd.txt
+    exit 1
+fi
+
+# helper: read VD's persisted size_kib via GET.
+get_vd_size() {
+    curl -s "$B/v1/resource-definitions/bug383-rd/volume-definitions/0" \
+        | python3 -c "import sys, json; d=json.load(sys.stdin); print(d['size_kib'] if isinstance(d, dict) else d[0]['size_kib'])"
+}
+
+INITIAL=$(get_vd_size)
+if [[ "$INITIAL" != "1048576" ]]; then
+    echo "FAIL: initial seed size_kib=$INITIAL, want 1048576"
+    exit 1
+fi
+
+# Case 1: negative + force=true must be rejected, row untouched.
+echo ">> case 1: PUT size_kib=-100 force=true returns 400"
+BODY1=/tmp/bug383-neg.txt
+CODE=$(curl -s -o "$BODY1" -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug383-rd/volume-definitions/0" \
+    -H "Content-Type: application/json" \
+    -d '{"size_kib":-100,"force":true}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: negative + force returned $CODE, expected 400"
+    cat "$BODY1"
+    exit 1
+fi
+
+python3 -c "
+import sys, json
+with open('$BODY1') as f:
+    arr = json.load(f)
+if not isinstance(arr, list) or len(arr) != 1:
+    print('FAIL: envelope shape:', arr)
+    sys.exit(1)
+msg = arr[0].get('message', '')
+if 'must be > 0' not in msg:
+    print('FAIL: message does not mention the > 0 floor:', msg)
+    sys.exit(1)
+if 'filesystem shrink-then-resize' in msg:
+    print('FAIL: message confuses Bug 383 with the shrink-force path:', msg)
+    sys.exit(1)
+print('OK')
+"
+
+AFTER1=$(get_vd_size)
+if [[ "$AFTER1" != "1048576" ]]; then
+    echo "FAIL: row mutated after negative-force rejection: size_kib=$AFTER1"
+    exit 1
+fi
+
+# Case 2: zero + force=true must be rejected, row untouched.
+echo ">> case 2: PUT size_kib=0 force=true returns 400"
+BODY2=/tmp/bug383-zero.txt
+CODE=$(curl -s -o "$BODY2" -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug383-rd/volume-definitions/0" \
+    -H "Content-Type: application/json" \
+    -d '{"size_kib":0,"force":true}')
+if [[ "$CODE" != "400" ]]; then
+    echo "FAIL: zero + force returned $CODE, expected 400"
+    cat "$BODY2"
+    exit 1
+fi
+
+AFTER2=$(get_vd_size)
+if [[ "$AFTER2" != "1048576" ]]; then
+    echo "FAIL: row mutated after zero-force rejection: size_kib=$AFTER2"
+    exit 1
+fi
+
+# Case 3: legitimate force-shrink (positive, below previous) still works.
+echo ">> case 3: legitimate force-shrink to 524288 KiB still lands"
+BODY3=/tmp/bug383-shrink.txt
+CODE=$(curl -s -o "$BODY3" -w "%{http_code}" -X PUT \
+    "$B/v1/resource-definitions/bug383-rd/volume-definitions/0" \
+    -H "Content-Type: application/json" \
+    -d '{"size_kib":524288,"force":true}')
+if [[ "$CODE" != "200" ]]; then
+    echo "FAIL: legitimate force-shrink returned $CODE, expected 200"
+    cat "$BODY3"
+    exit 1
+fi
+
+AFTER3=$(get_vd_size)
+if [[ "$AFTER3" != "524288" ]]; then
+    echo "FAIL: force-shrink did not land: size_kib=$AFTER3"
+    exit 1
+fi
+
+echo "PASS: bug 383 — VD PUT rejects non-positive size_kib regardless of force, legitimate shrink still works"


### PR DESCRIPTION
## Summary

Bug 383 (P3, hunt-caught round 12 — 2026-06-02): `PUT /v1/resource-definitions/{rd}/volume-definitions/{vn}` silently accepted non-positive `size_kib` when `force=true` was set. Mirror the Bug 155 `validateVDSize` gate on PUT before the shrink+force check so `size_kib<=0` is refused regardless of force.

## Background

The force escape hatch was scoped only at the scenario 4.W13 "no auto-shrink" refusal — callers that already ran `resize2fs -s` on the consumer know the new size is below the live one and need to land the smaller spec. force was never intended to let a caller persist `size_kib=0` or a negative value into the spec.

Pre-fix the satellite reconciler then looped on `drbdadm create-md` indefinitely (DRBD's per-device minimum is ~4 MiB once metadata is reserved), identical to the Bug 381 spawn-fast-path footgun but reached through the PUT update path.

## Changes

- `pkg/rest/volume_definitions.go`: new `rejectVDNonPositiveSize` helper runs before the existing `rejectShrinkWithoutForce`; emits a Bug 155-shaped envelope (`FAIL_INVLD_VLM_SIZE`, 400) with a "must be > 0" message instead of the misleading "filesystem shrink-then-resize required" cause text.
- `pkg/rest/bug_383_vd_put_non_positive_size_test.go`: 5 unit tests pinning negative+force, zero+force, negative without force, legitimate force-shrink (positive new size below previous), and positive growth.
- `tests/e2e/vd-put-non-positive-size.sh`: live-cluster e2e covering the same 3 acceptance cases.

## Test plan

- [x] `go test ./pkg/rest/ -run TestBug383` — 5/5 PASS
- [x] `go test ./pkg/rest/...` — full package green
- [x] `golangci-lint run ./pkg/rest/...` — 0 issues
- [ ] CI green
- [ ] e2e `vd-put-non-positive-size` passes on stand