### PR TITLE
fix(controller): r d of diskful must not convert to useless tiebreaker on inactive-replica resource (Bug 387)

### DIFF
--- a/internal/controller/ensure_tiebreaker_inactive_bug_387_test.go
+++ b/internal/controller/ensure_tiebreaker_inactive_bug_387_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestBug387InactiveReplicaNotCountedAsVotingDiskful pins the Bug 387
+// fix: an INACTIVE replica (`drbdadm down`) is NOT a voting peer in the
+// DRBD quorum, so the auto-tiebreaker policy must not count it as a
+// diskful replica.
+//
+// Repro (operator-level): an RD with 2 active diskful + 1 INACTIVE
+// diskful. The operator runs `linstor r d <one-of-the-active-diskful>`,
+// leaving 1 active diskful + 1 INACTIVE diskful. Before the fix the
+// reconciler saw "2 diskful, 0 non-witness diskless, even parity" and
+// spuriously grew a TIE_BREAKER witness (1 active diskful + 1 witness =
+// 2 votes, no majority protection) — diverging from upstream LINSTOR,
+// which simply deletes the replica with no witness conversion.
+//
+// Post-fit invariant: the INACTIVE replica is dropped from the voting
+// set, leaving exactly 1 voting diskful → no witness, quorum "off".
+func TestBug387InactiveReplicaNotCountedAsVotingDiskful(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	// Three satellites; worker-1 holds the INACTIVE replica, worker-3
+	// the surviving active diskful, worker-2 is the now-free node the
+	// buggy reconciler would have picked as the spurious witness.
+	for _, n := range []string{"worker-1", "worker-2", "worker-3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// worker-1: INACTIVE diskful (operator-deactivated, not voting).
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "test1", NodeName: "worker-1",
+		Flags: []string{apiv1.ResourceFlagInactive},
+	}); err != nil {
+		t.Fatalf("seed inactive replica: %v", err)
+	}
+
+	// worker-3: surviving active diskful (the only voting peer).
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "test1", NodeName: "worker-3",
+	}); err != nil {
+		t.Fatalf("seed active replica: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// No witness must have been auto-added on any node — the topology
+	// has only 1 voting diskful, so a TIE_BREAKER would be a useless
+	// 2-voter quorum with no majority.
+	replicas, err := st.Resources().ListByDefinition(ctx, "test1")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if len(replicas) != 2 {
+		t.Fatalf("replica count: got %d, want 2 (inactive + active, no witness); replicas=%v",
+			len(replicas), replicas)
+	}
+
+	for i := range replicas {
+		for _, f := range replicas[i].Flags {
+			if f == apiv1.ResourceFlagTieBreaker {
+				t.Errorf("spurious TIE_BREAKER witness created on %s; an INACTIVE replica must not be counted as a voting diskful",
+					replicas[i].NodeName)
+			}
+		}
+	}
+
+	// worker-2 (the free node) must stay empty — the buggy reconciler
+	// converted the deleted diskful's freed node into a witness.
+	if _, err := st.Resources().Get(ctx, "test1", "worker-2"); err == nil {
+		t.Errorf("unexpected witness on worker-2 — the deleted diskful must not be converted into a tiebreaker")
+	}
+
+	// quorum prop must be "off": 1 voting diskful can never reach
+	// majority, so the controller writes "off" to match DRBD reality.
+	final := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "test1"}, final); err != nil {
+		t.Fatalf("Get RD: %v", err)
+	}
+
+	if final.Spec.Props["DrbdOptions/Resource/quorum"] != "off" {
+		t.Errorf("quorum prop: got %q, want off (1 voting diskful + 1 inactive)",
+			final.Spec.Props["DrbdOptions/Resource/quorum"])
+	}
+}
+
+// TestBug387TwoActiveDiskfulStillGetWitness is the positive control for
+// the Bug 387 fix: dropping INACTIVE replicas from the voting set must
+// NOT regress the canonical auto-witness invariant. An RD with 2 active
+// diskful (no INACTIVE flag) plus a third INACTIVE replica must still
+// grow a witness — the two active peers are a genuine even-parity
+// quorum that needs the third voter.
+func TestBug387TwoActiveDiskfulStillGetWitness(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"worker-1", "worker-2", "worker-3", "worker-4"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// Two active diskful peers — a real even-parity quorum.
+	for _, n := range []string{"worker-2", "worker-3"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "test2", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed active replica %s: %v", n, err)
+		}
+	}
+
+	// An INACTIVE replica that must be ignored by the policy.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "test2", NodeName: "worker-1",
+		Flags: []string{apiv1.ResourceFlagInactive},
+	}); err != nil {
+		t.Fatalf("seed inactive replica: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test2"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// Witness landed on worker-4 (the only free, non-diskful,
+	// non-inactive node — worker-1 is excluded because it hosts a
+	// replica row).
+	got, err := st.Resources().Get(ctx, "test2", "worker-4")
+	if err != nil {
+		t.Fatalf("witness not created on worker-4: %v", err)
+	}
+
+	hasTB := false
+
+	for _, f := range got.Flags {
+		if f == apiv1.ResourceFlagTieBreaker {
+			hasTB = true
+
+			break
+		}
+	}
+
+	if !hasTB {
+		t.Errorf("witness must carry TIE_BREAKER flag; got %v", got.Flags)
+	}
+
+	final := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "test2"}, final); err != nil {
+		t.Fatalf("Get RD: %v", err)
+	}
+
+	if final.Spec.Props["DrbdOptions/Resource/quorum"] != "majority" {
+		t.Errorf("quorum prop: got %q, want majority (2 active diskful + witness)",
+			final.Spec.Props["DrbdOptions/Resource/quorum"])
+	}
+}

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -223,6 +223,18 @@ func (r *ResourceDefinitionReconciler) ensureTiebreaker(ctx context.Context, rd 
 		return err
 	}
 
+	// Bug 387: an INACTIVE replica is `drbdadm down` (operator
+	// deactivation) — its DRBD device is not up, so it is NOT a voting
+	// peer in the quorum the auto-tiebreaker invariant defends. Counting
+	// it as a diskful replica corrupts every downstream witness decision:
+	// e.g. an RD with 2 active diskful + 1 INACTIVE diskful, after an
+	// `r d` of one active diskful, would otherwise look like "2 diskful,
+	// nonWitnessDiskless==0, even" and spuriously grow a TIE_BREAKER —
+	// upstream LINSTOR just deletes the replica with no witness. Drop
+	// INACTIVE replicas from the voting set before the split so they
+	// influence neither the diskful count nor the diskless/witness count.
+	replicas = filterActiveReplicas(replicas)
+
 	diskful, diskless := splitByDiskless(replicas)
 	witness := filterTieBreaker(diskless)
 
@@ -1035,6 +1047,27 @@ func (r *ResourceDefinitionReconciler) removeWitnesses(ctx context.Context, rdNa
 	}
 
 	return nil
+}
+
+// filterActiveReplicas drops INACTIVE replicas from the slice. An
+// INACTIVE replica is one the operator deactivated with `drbdadm down`
+// (Bug 387): its DRBD device is not running, so it casts no vote in the
+// `quorum: majority` decision the auto-tiebreaker invariant defends.
+// The tiebreaker policy must reason only over the live voting peers, so
+// INACTIVE replicas are excluded before the diskful/diskless split —
+// they count as neither a voting diskful nor a diskless witness/peer.
+func filterActiveReplicas(replicas []apiv1.Resource) []apiv1.Resource {
+	active := make([]apiv1.Resource, 0, len(replicas))
+
+	for i := range replicas {
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagInactive) {
+			continue
+		}
+
+		active = append(active, replicas[i])
+	}
+
+	return active
 }
 
 // splitByDiskless partitions replicas into (diskful, diskless) lists.

--- a/tests/e2e/cli-matrix/r-d-inactive-no-tiebreaker.sh
+++ b/tests/e2e/cli-matrix/r-d-inactive-no-tiebreaker.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# usage: r-d-inactive-no-tiebreaker.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 387 (P1, user-reported, stand-observable).
+#
+# Reproduction from the operator stand (resource `test1`):
+#
+#   $ linstor r l
+#   test1  worker-1  DRBD,STORAGE  INACTIVE
+#   test1  worker-2  DRBD,STORAGE  UpToDate
+#   test1  worker-3  DRBD,STORAGE  UpToDate
+#
+#   $ linstor r d worker-2 test1
+#   SUCCESS: resource deleted: test1 on worker-2
+#
+#   $ linstor r l
+#   test1  worker-1  DRBD,STORAGE  INACTIVE
+#   test1  worker-2  DRBD,STORAGE  Connecting(worker-3)  Created   <-- WRONG: became a TieBreaker witness
+#   test1  worker-3  DRBD,STORAGE  Unknown
+#
+# Root cause: an INACTIVE replica is `drbdadm down` (operator
+# deactivation) — its DRBD device is not up, so it does NOT vote in the
+# `quorum: majority` decision the auto-tiebreaker invariant defends. The
+# RD reconciler's witness-decision counted the INACTIVE replica as a
+# full diskful, so after the `r d` of one active diskful the topology
+# looked like "2 diskful, 0 user-diskless, even parity" → it spuriously
+# grew a TIE_BREAKER witness (1 active diskful + 1 witness = a 2-voter
+# quorum with no majority protection). Upstream LINSTOR simply deletes
+# the replica with no witness conversion.
+#
+# Fix: drop INACTIVE replicas from the voting set before the
+# diskful/diskless split in ensureTiebreaker — they influence neither
+# the diskful count nor the diskless/witness count.
+#
+# Unit pin: internal/controller/ensure_tiebreaker_inactive_bug_387_test.go
+# (TestBug387InactiveReplicaNotCountedAsVotingDiskful).
+# This L6 cell is the stand-side companion: drives the real
+# python-linstor CLI sequence on the 3-diskful → deactivate-one →
+# r-d-one shape and asserts that NO tiebreaker is spawned, leaving
+# exactly two Resource rows (1 INACTIVE + 1 active diskful) with no
+# TIE_BREAKER residue.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-387
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    # If a replica is still INACTIVE, re-activate it first so delete_rd
+    # can drive a clean cascade.
+    "${LCTL[@]}" resource activate "$N1" "$RD" 2>/dev/null || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 387] shape-3r: 3-replica diskful RD (no auto-tiebreaker — odd parity)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=3 --storage-pool=stand "$RD" >/dev/null
+
+echo ">> wait for steady state: 3 diskful UpToDate"
+deadline=$(( $(date +%s) + 180 ))
+ready=false
+while (( $(date +%s) < deadline )); do
+    n_diskful=$(linstor_diskful_count "$RD")
+    n_total=$(linstor_replica_count "$RD")
+    if [[ "$n_diskful" == "3" ]] && [[ "$n_total" == "3" ]]; then
+        ok_count=0
+        for n in "$N1" "$N2" "$N3"; do
+            d=$(status_disk_state "$RD" "$n" 0 2>/dev/null || echo "")
+            [[ "$d" == "UpToDate" ]] && ok_count=$(( ok_count + 1 ))
+        done
+        if (( ok_count == 3 )); then
+            ready=true
+            break
+        fi
+    fi
+    sleep 3
+done
+if [[ "$ready" != "true" ]]; then
+    echo "FAIL: never reached 3 diskful UpToDate within 180s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   3 diskful UpToDate on $N1 $N2 $N3"
+
+# Deactivate worker-1 → INACTIVE flag. This is the deactivated, non-
+# voting replica the witness policy must learn to ignore.
+echo ">> linstor r deactivate $N1 $RD  (→ INACTIVE)"
+"${LCTL[@]}" resource deactivate "$N1" "$RD" >/dev/null 2>&1 || {
+    echo "FAIL: r deactivate $N1 $RD exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 30s for INACTIVE flag visible on $N1"
+deadline=$(( $(date +%s) + 30 ))
+inactive=false
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N1}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$flags" == *"INACTIVE"* ]]; then
+        inactive=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$inactive" != "true" ]]; then
+    echo "FAIL: INACTIVE flag never landed on $N1 within 30s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   $N1 is INACTIVE; voting set is now {$N2, $N3} (2 active diskful)"
+
+# Delete one of the two ACTIVE diskful replicas. The remaining voting
+# set is 1 active diskful + 1 INACTIVE — and an INACTIVE replica is NOT
+# a voting diskful, so there must be NO tiebreaker conversion. Upstream
+# LINSTOR simply deletes the replica.
+echo ">> linstor r d $N2 $RD  (physical delete of one active diskful)"
+"${LCTL[@]}" resource delete "$N2" "$RD" >/dev/null 2>&1 || {
+    echo "FAIL: r d $N2 $RD exited non-zero" >&2
+    exit 1
+}
+
+# Wait for the deleted replica's CRD to physically disappear before
+# asserting "no tiebreaker", so the count check acts on a settled shape.
+wait_replica_absent "$RD" "$N2" 60 \
+    || die "Bug 387: ${RD}.${N2} CRD never disappeared after r d"
+
+# The reconciler runs asynchronously. Give it a fixed window to (wrongly,
+# pre-fix) spawn a witness; if after the window no TIE_BREAKER exists and
+# exactly the 2 expected rows remain, the fix holds.
+echo ">> watch 30s: NO tiebreaker must be spawned; exactly 2 rows must remain"
+deadline=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < deadline )); do
+    tb=$(linstor_tiebreaker_node "$RD")
+    if [[ -n "$tb" ]]; then
+        echo "FAIL (Bug 387 regression): spurious TIE_BREAKER witness spawned on $tb" >&2
+        echo "  an INACTIVE replica must not be counted as a voting diskful" >&2
+        "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+        exit 1
+    fi
+    sleep 2
+done
+
+# Final shape assertion: exactly 2 Resource rows — 1 INACTIVE ($N1) and
+# 1 active diskful ($N3) — and neither carries TIE_BREAKER / DISKLESS.
+n_total=$(linstor_replica_count "$RD")
+if [[ "$n_total" != "2" ]]; then
+    echo "FAIL (Bug 387): expected 2 rows after r d, got $n_total" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# $N1 must still be INACTIVE (and definitely not a witness).
+n1_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N1}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+if [[ "$n1_flags" != *"INACTIVE"* ]] || [[ "$n1_flags" == *"TIE_BREAKER"* ]]; then
+    echo "FAIL (Bug 387): $N1 flags=$n1_flags, want INACTIVE with no TIE_BREAKER" >&2
+    exit 1
+fi
+
+# $N3 must be the lone surviving active diskful: no DISKLESS / TIE_BREAKER.
+n3_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+if [[ "$n3_flags" == *"TIE_BREAKER"* ]] || [[ "$n3_flags" == *"DISKLESS"* ]]; then
+    echo "FAIL (Bug 387): $N3 carries unexpected flags=$n3_flags" >&2
+    exit 1
+fi
+
+# $N2 (the deleted node) must NOT have come back as a witness — the exact
+# operator-reported symptom (the deleted diskful re-appearing as a TB).
+if kubectl get "resources.blockstor.cozystack.io/${RD}.${N2}" >/dev/null 2>&1; then
+    echo "FAIL (Bug 387): deleted node $N2 re-appeared — it was converted into a tiebreaker" >&2
+    exit 1
+fi
+
+echo ">> r-d-inactive-no-tiebreaker OK (Bug 387 pinned: r d of an active diskful on a 1-active+1-INACTIVE residual spawns no tiebreaker)"

--- a/tests/operator-harness/replay/r-d-inactive-no-tiebreaker.yaml
+++ b/tests/operator-harness/replay/r-d-inactive-no-tiebreaker.yaml
@@ -1,0 +1,81 @@
+name: r-d-inactive-no-tiebreaker
+description: |
+  Bug-387 catcher (P1). Deleting one active diskful replica with
+  `linstor r d` on an RD that has 2 active diskful + 1 INACTIVE replica
+  must NOT convert the deleted replica into a TieBreaker witness.
+
+  An INACTIVE replica is `drbdadm down` (operator deactivation) — it is
+  not a voting peer in the DRBD `quorum: majority` decision. The RD
+  auto-tiebreaker reconciler previously counted it as a full diskful, so
+  after the `r d` the topology looked like "2 diskful, even parity, no
+  user-diskless" and it spuriously grew a TieBreaker (1 active diskful +
+  1 witness = a 2-voter quorum with no majority protection). Upstream
+  LINSTOR simply deletes the replica with no witness conversion.
+
+  Sequence: 3 diskful RD → deactivate node1 (INACTIVE) → r d node2 →
+  assert node2 fully gone AND no TieBreaker is auto-spawned, leaving the
+  1 INACTIVE + 1 active diskful residual untouched.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node3
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: r-deactivate-node1
+    cmd: ["resource", "deactivate", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+  - name: r-d-node2-active-diskful
+    cmd: ["resource", "delete", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 60
+  - name: no-tiebreaker-spawned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: no_tiebreaker
+      rd: "{{rd}}"
+      timeout_s: 30
+  - name: node2-stays-absent
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 30
+
+teardown:
+  - cmd: ["resource", "activate", "{{node1}}", "{{rd}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

Deleting one active diskful replica with `linstor r d` on a resource that has 2 active diskful + 1 INACTIVE replica wrongly converted the deleted replica into a TieBreaker witness, producing a useless 2-voter quorum (1 active diskful + 1 TB, no majority protection) and diverging from upstream LINSTOR, which simply deletes the replica with no witness conversion.

Operator repro on resource `test1` (worker-1 INACTIVE, worker-2/worker-3 UpToDate):

```
$ linstor r d worker-2 test1
SUCCESS: resource deleted: test1 on worker-2
$ linstor r l
 test1  worker-1  DRBD,STORAGE  INACTIVE
 test1  worker-2  DRBD,STORAGE  Connecting(worker-3)  Created   <-- WRONG: came back as a TieBreaker
 test1  worker-3  DRBD,STORAGE  Unknown
```

## Root cause

An INACTIVE replica is `drbdadm down` (operator deactivation) — its DRBD device is not up, so it casts no vote in the `quorum: majority` decision the auto-tiebreaker invariant defends. The RD reconciler's `ensureTiebreaker` counted it as a full diskful, so after the `r d` of one active diskful the topology looked like "2 diskful, even parity, no user-diskless" and it spuriously grew a TIE_BREAKER witness.

## Fix

Drop INACTIVE replicas from the voting set before the diskful/diskless split in `ensureTiebreaker`, so they influence neither the diskful count nor the diskless/witness count. Aligns with upstream LINSTOR (delete-only, no witness conversion).

## Test coverage (CLI-bug-fix protocol)

- **L1** `internal/controller/ensure_tiebreaker_inactive_bug_387_test.go` — reproduces the operator repro (no witness, quorum=off) plus a positive control proving 2 genuine active diskful + 1 ignored INACTIVE still grows a witness (quorum=majority), so the canonical auto-witness invariant does not regress.
- **L6** `tests/e2e/cli-matrix/r-d-inactive-no-tiebreaker.sh` — stand cell: 3 diskful → deactivate one → `r d` one active diskful, asserts no TieBreaker and the deleted node never re-appears.
- **L7** `tests/operator-harness/replay/r-d-inactive-no-tiebreaker.yaml` — codifies the operator sequence with `no_tiebreaker` + `resource_absent` convergence assertions.

`go build ./...`, `go test ./internal/controller/... ./pkg/rest/...`, and `golangci-lint run ./internal/controller/...` are green locally. L6/L7 stand validation to be run by the launcher.
