### PR TITLE
fix(rest): recreate tiebreaker after node restore (Bug 386)

### DIFF
--- a/internal/controller/ensure_tiebreaker_test.go
+++ b/internal/controller/ensure_tiebreaker_test.go
@@ -20,6 +20,7 @@ package controller_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -1372,5 +1373,232 @@ func TestEnsureTiebreakerRelocateOntoTiebreakerConverges(t *testing.T) {
 	// node), not back on n3 (the diskful relocate target).
 	if _, err := st.Resources().Get(ctx, rdName, "n2"); err != nil {
 		t.Errorf("witness should land on freed n2; got error %v", err)
+	}
+}
+
+// TestBug386NodeRestoreRecreatesTiebreaker pins the Bug 386 fix: after
+// a node is restored with `linstor n rst`, a 2-diskful resource in a
+// 3-node cluster must re-gain its DISKLESS TIE_BREAKER witness.
+//
+// Repro shape (verbatim operator report): a 3-node cluster runs a
+// 2-diskful RD (n1, n2) whose witness collapsed while n3 was drained
+// (EVICTED). `pickTiebreakerNode` / `isDisabledNode` exclude an
+// EVICTED node, so while n3 carried the flag the only candidate
+// witness host was gone and ensureTiebreaker left the RD at two
+// diskful UpToDate replicas with no witness — a quorum/split-brain
+// hazard on a subsequent failure.
+//
+// `linstor n rst n3` clears the EVICTED flag. The fix wires a Node
+// watch (nodeDrainFlagChanged → enqueueRDsForNode) so the restore
+// re-enqueues the RD and ensureTiebreaker re-runs. This test pins the
+// reconcile-level outcome: with EVICTED cleared, the witness must be
+// (re)placed on n3 so the resource regains the diskful+diskful+TB
+// shape upstream LINSTOR maintains for quorum=majority.
+func TestBug386NodeRestoreRecreatesTiebreaker(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	// 3-node cluster; n3 is currently EVICTED (drained), so it is not
+	// a viable witness candidate.
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n3", Type: apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed evicted node n3: %v", err)
+	}
+
+	// 2 diskful replicas on n1 + n2, NO witness — the collapsed shape
+	// the operator observed while n3 was drained.
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug386", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug386"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	// Pre-restore sanity: with n3 EVICTED, ensureTiebreaker cannot
+	// place a witness (no viable candidate node). The RD stays at 2
+	// diskful, 0 witness — the exact hazard Bug 386 reports.
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("pre-restore EnsureTiebreaker: %v", err)
+	}
+
+	pre, err := st.Resources().ListByDefinition(ctx, "pvc-bug386")
+	if err != nil {
+		t.Fatalf("list pre-restore: %v", err)
+	}
+
+	_, _, preWitness := classifyReplicas(pre)
+	if preWitness != 0 {
+		t.Fatalf("pre-restore: witness=%d, want 0 (n3 EVICTED, no candidate); entries=%v",
+			preWitness, pre)
+	}
+
+	// Operator runs `linstor n rst n3`: the REST handler clears the
+	// EVICTED flag on the Node. Simulate that store mutation.
+	n3, err := st.Nodes().Get(ctx, "n3")
+	if err != nil {
+		t.Fatalf("get n3: %v", err)
+	}
+
+	n3.Flags = nil
+	if err := st.Nodes().Update(ctx, &n3); err != nil {
+		t.Fatalf("restore n3 (clear EVICTED): %v", err)
+	}
+
+	// The Node watch re-enqueues the RD; ensureTiebreaker re-runs.
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("post-restore EnsureTiebreaker: %v", err)
+	}
+
+	post, err := st.Resources().ListByDefinition(ctx, "pvc-bug386")
+	if err != nil {
+		t.Fatalf("list post-restore: %v", err)
+	}
+
+	diskful, diskless, witness := classifyReplicas(post)
+
+	if diskful != 2 {
+		t.Errorf("post-restore: diskful=%d, want 2; entries=%v", diskful, post)
+	}
+
+	if diskless != 0 {
+		t.Errorf("post-restore: plain diskless=%d, want 0; entries=%v", diskless, post)
+	}
+
+	if witness != 1 {
+		t.Fatalf("Bug 386: post-restore witness=%d, want 1 (TB recreated after n rst); entries=%v",
+			witness, post)
+	}
+
+	// The recreated witness must land on the restored n3 — the only
+	// non-diskful candidate now that EVICTED is cleared.
+	tb, err := st.Resources().Get(ctx, "pvc-bug386", "n3")
+	if err != nil {
+		t.Fatalf("Bug 386: witness not on restored n3: %v", err)
+	}
+
+	if !slices.Contains(tb.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("Bug 386: n3 replica must carry TIE_BREAKER; flags=%v", tb.Flags)
+	}
+}
+
+// TestBug386NodeHasDrainFlag pins the EVICTED/LOST flag-set probe that
+// gates the Bug-386 Node watch. The predicate fires only when this
+// membership changes, so it must read both Spec (operator intent) and
+// Status (satellite-observed) flags and ignore unrelated values.
+func TestBug386NodeHasDrainFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		node *blockstoriov1alpha1.Node
+		want bool
+	}{
+		{
+			name: "no flags",
+			node: &blockstoriov1alpha1.Node{},
+			want: false,
+		},
+		{
+			name: "spec EVICTED",
+			node: &blockstoriov1alpha1.Node{
+				Spec: blockstoriov1alpha1.NodeSpec{Flags: []string{apiv1.NodeFlagEvicted}},
+			},
+			want: true,
+		},
+		{
+			name: "spec LOST",
+			node: &blockstoriov1alpha1.Node{
+				Spec: blockstoriov1alpha1.NodeSpec{Flags: []string{apiv1.NodeFlagLost}},
+			},
+			want: true,
+		},
+		{
+			name: "status EVICTED",
+			node: &blockstoriov1alpha1.Node{
+				Status: blockstoriov1alpha1.NodeStatus{Flags: []string{apiv1.NodeFlagEvicted}},
+			},
+			want: true,
+		},
+		{
+			name: "unrelated flag",
+			node: &blockstoriov1alpha1.Node{
+				Spec: blockstoriov1alpha1.NodeSpec{Flags: []string{"STANDBY"}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := controllerpkg.NodeHasDrainFlag(tc.node); got != tc.want {
+				t.Errorf("NodeHasDrainFlag(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBug386EnqueueRDsForNode pins the Node-watch fan-out: a node
+// flag-change event must re-enqueue EVERY ResourceDefinition in the
+// cluster so each RD's tiebreaker invariant re-evaluates against the
+// recovered candidate set. The tiebreaker is a cluster-wide
+// candidate-set decision, so the mapper is intentionally RD-agnostic.
+func TestBug386EnqueueRDsForNode(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	ctx := context.Background()
+
+	rdA := &blockstoriov1alpha1.ResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "rd-a"}}
+	rdB := &blockstoriov1alpha1.ResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "rd-b"}}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rdA, rdB).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{Client: cli, Scheme: scheme, Store: store.NewInMemory()}
+
+	reqs := rec.EnqueueRDsForNode(ctx, &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n3"},
+	})
+
+	if len(reqs) != 2 {
+		t.Fatalf("enqueueRDsForNode: got %d requests, want 2 (one per RD); reqs=%v", len(reqs), reqs)
+	}
+
+	got := map[string]bool{}
+	for _, req := range reqs {
+		got[req.Name] = true
+	}
+
+	for _, want := range []string{"rd-a", "rd-b"} {
+		if !got[want] {
+			t.Errorf("enqueueRDsForNode: missing RD %q in fan-out; reqs=%v", want, reqs)
+		}
 	}
 }

--- a/internal/controller/export_test.go
+++ b/internal/controller/export_test.go
@@ -46,6 +46,21 @@ func (r *ResourceDefinitionReconciler) EnqueueRDForResource(ctx context.Context,
 	return r.enqueueRDForResource(ctx, obj)
 }
 
+// EnqueueRDsForNode exposes the Bug-386 Node-watch fan-out for tests.
+// Production wiring stays unexported via SetupWithManager. Pins the
+// "node flag toggle re-enqueues every RD" contract that recreates a
+// collapsed tiebreaker after `linstor n rst`.
+func (r *ResourceDefinitionReconciler) EnqueueRDsForNode(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.enqueueRDsForNode(ctx, obj)
+}
+
+// NodeHasDrainFlag exposes the EVICTED/LOST flag-set probe the Bug-386
+// Node-watch predicate uses to decide whether a Node event is a drain
+// transition worth re-enqueueing RDs for.
+func NodeHasDrainFlag(n *blockstoriov1alpha1.Node) bool {
+	return nodeHasDrainFlag(n)
+}
+
 // AlreadyExists exposes the wrapped-error keyword check the RD
 // reconciler uses to tolerate kube-apiserver "already exists"
 // races. Tests pin both the positive and the false-positive paths.

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -1312,8 +1312,110 @@ func (r *ResourceDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&blockstoriov1alpha1.Resource{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueRDForResource),
 			builder.WithPredicates(resourceEventFilter)).
+		// Bug 386: re-run the tiebreaker invariant when a node's
+		// EVICTED / LOST flag set changes. `linstor n rst` clears
+		// EVICTED on a recovered node; `linstor n evacuate` sets it.
+		// `ensureTiebreaker` (and pickTiebreakerNode) treat an
+		// EVICTED/LOST node as an unusable witness candidate, so a
+		// 2-diskful RD whose witness collapsed while a node was drained
+		// must re-place the TIE_BREAKER once the node returns. Without
+		// this watch nothing enqueues the RD on a node-flag toggle and
+		// the witness is only (re)placed on the next periodic re-sync —
+		// leaving two diskful UpToDate replicas with no quorum witness
+		// in between (split-brain risk on a subsequent failure). The
+		// nodeDrainFlagChanged predicate filters to the flag transition
+		// so unrelated Node Spec edits (props, net-interfaces) don't
+		// fan out to every RD.
+		Watches(&blockstoriov1alpha1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueRDsForNode),
+			builder.WithPredicates(nodeDrainFlagChanged())).
 		Named("resourcedefinition").
 		Complete(r)
+}
+
+// nodeDrainFlagChanged fires only when a Node's drain-signal flag set
+// (EVICTED / LOST) transitions. The REST `n rst` / `n evacuate` /
+// `n lost` handlers stamp these onto `Spec.Flags`; the satellite also
+// re-applies Node Spec on every reconcile with the flag set unchanged,
+// so a bare generation/Spec-equality watch would fan out to every RD
+// on every heartbeat. Restricting to the EVICTED/LOST membership delta
+// keeps the Bug 386 re-enqueue precise.
+//
+// Create fires when the node already carries a drain flag (controller
+// restart re-reads existing state) so the witness invariant runs at
+// least once against the recovered topology.
+func nodeDrainFlagChanged() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			n, ok := e.Object.(*blockstoriov1alpha1.Node)
+			if !ok {
+				return false
+			}
+
+			return nodeHasDrainFlag(n)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, ok := e.ObjectOld.(*blockstoriov1alpha1.Node)
+			if !ok {
+				return false
+			}
+
+			newNode, ok := e.ObjectNew.(*blockstoriov1alpha1.Node)
+			if !ok {
+				return false
+			}
+
+			return nodeHasDrainFlag(oldNode) != nodeHasDrainFlag(newNode)
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+// nodeHasDrainFlag reports whether a Node CRD carries an EVICTED or
+// LOST flag on either Spec (operator intent, set by the REST handlers)
+// or Status (satellite-observed). Mirrors isDisabledNode's flag set so
+// the watch predicate and the witness-candidate filter agree on what
+// "drained" means.
+func nodeHasDrainFlag(n *blockstoriov1alpha1.Node) bool {
+	for _, f := range n.Spec.Flags {
+		if f == apiv1.NodeFlagEvicted || f == apiv1.NodeFlagLost {
+			return true
+		}
+	}
+
+	for _, f := range n.Status.Flags {
+		if f == apiv1.NodeFlagEvicted || f == apiv1.NodeFlagLost {
+			return true
+		}
+	}
+
+	return false
+}
+
+// enqueueRDsForNode maps a Node flag-change event to every
+// ResourceDefinition in the cluster. The tiebreaker invariant is a
+// cluster-wide candidate-set decision (any RD's witness might have
+// collapsed onto, or now want to re-land on, the toggled node), so a
+// per-node restore re-evaluates all RDs. The set of RDs is small
+// relative to Resources, and the nodeDrainFlagChanged predicate gates
+// the fan-out to genuine EVICTED/LOST transitions, so this stays cheap.
+func (r *ResourceDefinitionReconciler) enqueueRDsForNode(ctx context.Context, _ client.Object) []reconcile.Request {
+	var rdList blockstoriov1alpha1.ResourceDefinitionList
+
+	err := r.List(ctx, &rdList)
+	if err != nil {
+		return nil
+	}
+
+	out := make([]reconcile.Request, 0, len(rdList.Items))
+	for i := range rdList.Items {
+		out = append(out, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rdList.Items[i].Name},
+		})
+	}
+
+	return out
 }
 
 // enqueueRDForResource maps a Resource event to its parent RD.

--- a/tests/e2e/cli-matrix/n-rst-recreates-tiebreaker.sh
+++ b/tests/e2e/cli-matrix/n-rst-recreates-tiebreaker.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# usage: n-rst-recreates-tiebreaker.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 386 (user-reported, stand-observable).
+#
+# Reproduction from the operator stand:
+#
+#   $ linstor r l
+#   test  dev-worker-1  …  UpToDate
+#   test  dev-worker-2  …  UpToDate
+#   test  dev-worker-3  …  TieBreaker
+#
+#   $ linstor n evacuate dev-worker-3     # drain the witness node
+#   $ linstor r l
+#   test  dev-worker-1  …  UpToDate
+#   test  dev-worker-2  …  UpToDate       ← witness collapsed (EVICTED)
+#
+#   $ linstor n rst dev-worker-3          # node recovered
+#   $ linstor r l
+#   test  dev-worker-1  …  UpToDate
+#   test  dev-worker-2  …  UpToDate
+#   # TieBreaker was NOT recreated        ← WRONG: quorum/split-brain risk
+#
+# Root cause: the RD reconciler watched only RDs and Resources, never
+# Nodes. `pickTiebreakerNode` / `isDisabledNode` exclude an EVICTED node
+# as a witness candidate, so while dev-worker-3 was drained the witness
+# could not be (re)placed. After `n rst` cleared the EVICTED flag,
+# NOTHING enqueued the RD — so ensureTiebreaker never re-ran and the
+# resource sat at two diskful UpToDate replicas with no witness until
+# the next periodic re-sync (a quorum=majority split-brain hazard in
+# between).
+#
+# Fix: a Node watch on the RD reconciler (nodeDrainFlagChanged →
+# enqueueRDsForNode) re-enqueues every RD when a node's EVICTED/LOST
+# flag set transitions, so `n rst` re-runs the tiebreaker invariant and
+# the witness is re-placed.
+#
+# Unit pin: internal/controller/ensure_tiebreaker_test.go
+# (TestBug386NodeRestoreRecreatesTiebreaker). This L6 cell is the
+# stand-side companion: drives the real python-linstor CLI sequence on
+# the 2r-tb shape, evacuates the witness node to collapse the witness,
+# restores it with `n rst`, and asserts the TIE_BREAKER reappears in
+# `linstor r l` within 60s — leaving the diskful+diskful+TB shape.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-386
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    # Best-effort restore in case the test bailed mid-evacuate, so the
+    # shared stand isn't left with an EVICTED node.
+    "${LCTL[@]}" node restore "$N3" >/dev/null 2>&1 || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 386] shape-2r-tb: 2-replica RD + auto-tiebreaker"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=2 --storage-pool=stand "$RD" >/dev/null
+
+echo ">> wait for steady state: 2 diskful UpToDate + 1 TIE_BREAKER witness"
+deadline=$(( $(date +%s) + 180 ))
+tb_node=""
+while (( $(date +%s) < deadline )); do
+    pair=()
+    tb=""
+    for n in "$N1" "$N2" "$N3"; do
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+        if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+            tb=$n
+            continue
+        fi
+        d=$(status_disk_state "$RD" "$n" 0)
+        if [[ "$d" == "UpToDate" ]]; then
+            pair+=("$n")
+        fi
+    done
+    if (( ${#pair[@]} >= 2 )) && [[ -n "$tb" ]]; then
+        tb_node=$tb
+        break
+    fi
+    sleep 3
+done
+if [[ -z "$tb_node" ]]; then
+    echo "FAIL: never reached steady state (2 diskful UpToDate + TIE_BREAKER) within 180s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   tiebreaker landed on: $tb_node"
+
+# Evacuate the witness node. The TIE_BREAKER witness lives on a node
+# the autoplacer/tiebreaker treats as a candidate; EVICTED removes it
+# from the candidate set, so the witness collapses (no other spare node
+# in a 3-worker cluster with 2 diskful already placed).
+echo ">> linstor n evacuate $tb_node  (drain the witness node → EVICTED)"
+"${LCTL[@]}" node evacuate "$tb_node" >/dev/null 2>&1 || {
+    echo "FAIL: n evacuate exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 60s for the witness on $tb_node to collapse"
+deadline=$(( $(date +%s) + 60 ))
+collapsed=false
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${tb_node}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "ABSENT")
+    if [[ "$flags" == "ABSENT" ]] || { [[ "$flags" != *"TIE_BREAKER"* ]]; }; then
+        collapsed=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$collapsed" != "true" ]]; then
+    echo "FAIL: witness on $tb_node never collapsed after n evacuate within 60s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   witness collapsed (node EVICTED); RD now 2 diskful, no witness"
+
+# Restore the node. This is the load-bearing Bug 386 step: clearing
+# EVICTED must re-run the tiebreaker invariant so the witness reappears.
+echo ">> linstor n rst $tb_node  (node recovered → EVICTED cleared)"
+"${LCTL[@]}" node restore "$tb_node" >/dev/null 2>&1 || {
+    echo "FAIL: n rst exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 60s for the tiebreaker to be RE-created after n rst"
+deadline=$(( $(date +%s) + 60 ))
+recreated=false
+last_rows=""
+while (( $(date +%s) < deadline )); do
+    tb=""
+    for n in "$N1" "$N2" "$N3"; do
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+        if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+            tb=$n
+        fi
+    done
+    last_rows=$(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}' || true)
+    if [[ -n "$tb" ]]; then
+        recreated=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$recreated" != "true" ]]; then
+    echo "FAIL (Bug 386 regression): tiebreaker NOT recreated within 60s of n rst" >&2
+    echo "  CRD rows for ${RD}:" >&2
+    printf '    %s\n' $last_rows >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# Belt-and-suspenders: the operator-visible `linstor r l` surface the
+# bug report cited must show exactly one TIE_BREAKER row plus the two
+# diskful replicas.
+wire=$(linstor_r_l_json "$RD")
+n_tb=$(printf '%s' "$wire" \
+    | jq -r '.[][] | select((.rsc_flags // []) | index("TIE_BREAKER")) | .name' 2>/dev/null \
+    | wc -l | tr -d ' ' || echo 0)
+if [[ "$n_tb" != "1" ]]; then
+    echo "FAIL (Bug 386): linstor r l shows $n_tb TIE_BREAKER rows for $RD, want 1" >&2
+    printf '%s\n' "$wire" | jq '.[][]| {name, node_name, flags: .rsc_flags}' 2>/dev/null >&2 || true
+    exit 1
+fi
+
+echo ">> n-rst-recreates-tiebreaker OK (Bug 386 pinned: tiebreaker recreated after n rst)"

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -231,6 +231,16 @@ print(bad)")
             present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -ci 'TieBreaker' || true)
             [[ "$present" == "0" ]]
             ;;
+        tiebreaker_present)
+            # Bug 386: assert a TieBreaker witness EXISTS for the rd.
+            # The inverse of no_tiebreaker — used by the node-restore
+            # catcher to confirm the witness is RE-created after the
+            # drained node is brought back with `n rst`.
+            local rd present
+            rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
+            present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -ci 'TieBreaker' || true)
+            [[ "$present" -ge 1 ]]
+            ;;
         sync_clean)
             local rd
             rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")

--- a/tests/operator-harness/replay-runner.sh
+++ b/tests/operator-harness/replay-runner.sh
@@ -49,6 +49,8 @@
 #   - all_uptodate         wait until every replica reports UpToDate
 #   - replica_diskless     wait until rd@node has disk_state == Diskless
 #   - no_tiebreaker        assert NO TieBreaker is auto-spawned
+#   - tiebreaker_present   assert a TieBreaker witness EXISTS for rd
+#                           (Bug 386: re-created after `n rst`)
 #   - sync_clean           wait until UpToDate without "(NN%)" suffix
 #   - resource_absent      wait until r d takes effect on a node
 #   - rd_absent            wait until rd is gone everywhere

--- a/tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml
+++ b/tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml
@@ -1,0 +1,75 @@
+name: n-rst-recreates-tiebreaker
+description: |
+  Bug-386 catcher. Cluster shape: 2 diskful replicas + 1 auto TieBreaker
+  on a third node (`r c --auto-place 2`). Operator drains the witness
+  node (`n evacuate`), which collapses the TieBreaker (an EVICTED node
+  is not a witness candidate). Then the node recovers and the operator
+  runs `n rst`. The TieBreaker MUST be re-created so the resource
+  regains the diskful+diskful+TB shape — otherwise two diskful UpToDate
+  replicas sit with no quorum witness (split-brain risk on a subsequent
+  failure).
+
+  Verbatim operator repro:
+    $ linstor n rst dev-worker-3
+    $ linstor r l
+     test  dev-worker-1  DRBD,STORAGE  UpToDate
+     test  dev-worker-3  DRBD,STORAGE  UpToDate
+    # TieBreaker was NOT recreated (the bug)
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: auto-place-2
+    # 2 diskful + auto-tiebreaker → the canonical 2r-tb shape.
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: wait-tiebreaker-spawned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
+  - name: evacuate-node3
+    # Drain the third node. With 2 diskful already placed and no spare
+    # worker in a 3-node cluster, EVICTED collapses the witness.
+    cmd: ["node", "evacuate", "{{node3}}"]
+    expect_exit: 0
+    await:
+      kind: no_tiebreaker
+      rd: "{{rd}}"
+      timeout_s: 60
+  - name: restore-node3
+    # Node recovered. Clearing EVICTED must re-run the tiebreaker
+    # invariant (Bug 386 fix: Node watch on the RD reconciler).
+    cmd: ["node", "restore", "{{node3}}"]
+    expect_exit: 0
+  - name: tiebreaker-recreated
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
+
+teardown:
+  - cmd: ["node", "restore", "{{node3}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

After a node is restored with `linstor n rst`, the auto-managed DRBD TieBreaker witness was not recreated, leaving a 2-diskful resource in a 3+ node cluster with two UpToDate replicas and no witness — a quorum/split-brain hazard on a subsequent failure.

Verbatim operator repro:

```
$ linstor n rst dev-worker-3
$ linstor r l
 test  dev-worker-1  DRBD,STORAGE  UpToDate
 test  dev-worker-3  DRBD,STORAGE  UpToDate
# TieBreaker was NOT recreated
```

## Root cause

The ResourceDefinition reconciler watched only RDs and Resources, never Nodes. `pickTiebreakerNode` / `isDisabledNode` exclude an EVICTED/LOST node as a witness candidate, so while a node was drained the witness could not be (re)placed. After `n rst` cleared the EVICTED flag, nothing enqueued the RD — so `ensureTiebreaker` never re-ran and the witness was only (re)placed on the next periodic re-sync.

## Fix

Add a Node watch to the RD reconciler: a `nodeDrainFlagChanged` predicate fires only on an EVICTED/LOST flag-set transition, and `enqueueRDsForNode` re-enqueues every RD so the tiebreaker invariant re-runs against the recovered candidate set. The witness is then re-placed on the restored node, restoring the diskful+diskful+TB shape upstream LINSTOR maintains for `quorum=majority`.

## Test coverage (CLI-bug-fix protocol)

- **L1**: `TestBug386NodeRestoreRecreatesTiebreaker` (reconcile-level: EVICTED→restore→witness recreated), plus `TestBug386NodeHasDrainFlag` and `TestBug386EnqueueRDsForNode` unit pins.
- **L6**: `tests/e2e/cli-matrix/n-rst-recreates-tiebreaker.sh` — drives the real CLI: autoplace 2r-tb, `n evacuate` to collapse the witness, `n rst`, assert TieBreaker reappears.
- **L7**: `tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml` — codifies the operator sequence; adds a `tiebreaker_present` await kind (inverse of `no_tiebreaker`).

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./internal/controller/...` are all green locally. Live-stand replay validation is performed by the launcher.