### PR TITLE
fix(satellite): seed-GI late-added volume so it converges UpToDate (Bug 384)

### DIFF
--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -2805,13 +2805,34 @@ func (r *Reconciler) ensurePerVolumeMetadata(ctx context.Context, dr *intent.Des
 // listed in `fresh`. Mirrors the loop in seedInitialGI but limits
 // touch to the volumes whose metadata was just freshly created,
 // so already-stamped sibling volumes (vol-0 in the Bug B.4
-// late-add scenario) are never re-seeded. isWinner is hard-coded
-// to false because this path runs with firstActivation=false on
-// the parent RD — the per-volume gate inside resolveVolumeSeed
-// decides which seed shape (case-A skip-init-sync, case-B
-// winner, or no-op) is appropriate via the per-volume
-// AnyConnectedPeerHasDataForVolume probe.
+// late-add scenario) are never re-seeded.
+//
+// Bug 384 (P0, regression of Bug 79/332): the late-add path runs with
+// firstActivation=false on the parent RD, so the dispatcher's
+// first-activation winner election (auto-primary, gated on
+// !rdInitialized) never fires — the RD is already Initialized by the
+// time `linstor vd c` lands. The previous code therefore passed
+// isWinner=false unconditionally, so EVERY diskful replica took the
+// case-A skip-init-sync seed (current=day0, clean bitmap, NO UpToDate
+// flag). With no replica declaring itself the UpToDate source and no
+// primary --force on this path, the freshly-carved volume came up
+// Inconsistent on ALL replicas and never converged (verbatim operator
+// repro: `vd c test 1G` → vol-1 Inconsistent on every node).
+//
+// Fix: re-run the SAME lowest-node-id winner election the dispatcher
+// runs at first activation, but locally per fresh volume. Exactly one
+// diskful replica (the lowest allocated node-id) takes the case-B
+// winner seed (Consistent+UpToDate) and becomes the SyncSource; the
+// rest take case-A. resolveVolumeSeed's per-volume
+// AnyConnectedPeerHasDataForVolume + PeerHasData vetoes still fire
+// FIRST, so a relocate / migrate-disk target (a peer already holds
+// data on this volume) never wins itself UpToDate-empty — the winner
+// seed is byte-identical to the first-activation winner and shares the
+// day0 lineage anchor, so a staggered dual election agrees rather than
+// split-brains.
 func (r *Reconciler) seedFreshVolumes(ctx context.Context, dr *intent.DesiredResource, devices map[int32]string, fresh map[int32]struct{}) error {
+	isWinner := isLateAddWinner(dr)
+
 	for _, vol := range dr.GetVolumes() {
 		if _, ok := fresh[vol.GetVolumeNumber()]; !ok {
 			continue
@@ -2822,7 +2843,7 @@ func (r *Reconciler) seedFreshVolumes(ctx context.Context, dr *intent.DesiredRes
 			continue
 		}
 
-		seed, ok := r.resolveVolumeSeed(ctx, dr.GetName(), vol, dr.GetPeerHasData(), false, dr.GetSkipInitialSync())
+		seed, ok := r.resolveVolumeSeed(ctx, dr.GetName(), vol, dr.GetPeerHasData(), isWinner, dr.GetSkipInitialSync())
 		if !ok {
 			continue
 		}
@@ -2834,6 +2855,51 @@ func (r *Reconciler) seedFreshVolumes(ctx context.Context, dr *intent.DesiredRes
 	}
 
 	return nil
+}
+
+// isLateAddWinner reports whether THIS node is the elected initial-
+// UpToDate source for a late-added volume — the lowest-node-id diskful
+// replica, the same election the dispatcher runs at first activation
+// (lowestDiskfulID). It returns true iff this node's allocated DRBD
+// node-id is strictly the lowest among the local node-id and every
+// peer's allocated node-id.
+//
+// Why local (not auto-primary): the dispatcher only stamps the
+// auto-primary winner flag on a NOT-yet-Initialized RD (Bug 356 /
+// respawn-StandAlone guard). A `linstor vd c` always lands AFTER the RD
+// is Initialized, so no replica carries auto-primary on this path and
+// isInitialUpToDateWinner can never elect one. Recomputing the election
+// from the node-id set the dispatcher already rendered into the wire
+// payload restores the missing winner without re-arming the unsafe
+// respawn-time auto-primary.
+//
+// Deterministic + split-brain-safe: node-id is stable across reconciles
+// so the SAME replica wins every pass, and the strict-lowest comparison
+// elects EXACTLY ONE node. Peers whose node-id is not yet allocated
+// (NodeID==nil) are skipped — the election waits implicitly for the
+// next reconcile once every peer id is stamped, the same shape
+// diskfulPeersAllocated enforces on the dispatcher side. The result is
+// only ever consumed by resolveVolumeSeed AFTER its PeerHasData /
+// AnyConnectedPeerHasDataForVolume vetoes, so a winner verdict on a
+// volume whose peer already holds data is suppressed before it can
+// seed.
+func isLateAddWinner(dr *intent.DesiredResource) bool {
+	localID, ok := localNodeIDFromOpts(dr)
+	if !ok {
+		return false
+	}
+
+	for _, peer := range dr.GetPeers() {
+		if peer.NodeID == nil {
+			continue
+		}
+
+		if *peer.NodeID <= localID {
+			return false
+		}
+	}
+
+	return true
 }
 
 // createMDWithCollisionRecovery wraps Adm.CreateMD with a one-shot

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -2881,6 +2881,276 @@ func TestApplyDRBDAllocatesBackingForLateAddedVolume(t *testing.T) {
 	}
 }
 
+// TestApplyLateAddedVolumeWinnerSeedsUpToDate pins Bug 384 (P0, data
+// integrity — regression of Bug 79/332): when `linstor vd c <rd> 1G`
+// adds vol-1 to a multi-replica RD whose vol-0 already reached
+// UpToDate, the lowest-node-id diskful replica MUST seed the new
+// volume Consistent+UpToDate (the case-B winner shape) so it converges
+// — NOT take the case-A skip-init-sync seed (clean bitmap, no UpToDate
+// flag), which leaves the new volume Inconsistent on EVERY replica
+// with no SyncSource to recover from.
+//
+// Root cause: the late-add seed path runs with firstActivation=false
+// on the parent RD (the RD is already Initialized by the time the
+// `vd c` lands), so the dispatcher's first-activation auto-primary
+// winner election never fires. seedFreshVolumes previously passed
+// isWinner=false unconditionally → every replica took case-A → no
+// UpToDate authority → vol-1 latched Inconsistent forever (verbatim
+// operator repro on a 2-diskful lvm-thin RD).
+//
+// The fix recomputes the lowest-node-id election locally per fresh
+// volume (isLateAddWinner). This fixture is the lowest-id node
+// (local node-id 0, peer node-id 1) so it is the elected winner: its
+// vol-1 set-gi MUST carry the positional Consistent(idx4=1)+
+// UpToDate(idx5=1) flags at current=day0. vol-0's metadata MUST NOT be
+// re-seeded (HasMD=true short-circuits create-md, so it never enters
+// the fresh-seed set).
+func TestApplyLateAddedVolumeWinnerSeedsUpToDate(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	// vol-0 already provisioned (idempotent lvs short-circuit).
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-win_00000",
+		storage.FakeResponse{Stdout: []byte("pvc-late-win_00000\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-win_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-win_00000|1048576\n")})
+
+	// vol-1 is NEW — lvs reports nothing, CreateVolume lvcreates it,
+	// then the path read returns the freshly-carved LV.
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-win_00001",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-win_00001",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-win_00001|1048576\n")})
+
+	// Per-volume HasMD probe: vol-0 stamped, vol-1 missing.
+	fx.Expect("drbdadm dump-md pvc-late-win/0",
+		storage.FakeResponse{Stdout: []byte("version \"v09\";\nla-size-sect 2048;\n")})
+	fx.Expect("drbdadm dump-md pvc-late-win/1",
+		storage.FakeResponse{Err: errDrbdadmDumpMdNoMeta})
+
+	// Per-volume create-md for vol-1 only.
+	fx.Expect(fmt.Sprintf("drbdadm create-md --force --max-peers=%d pvc-late-win/1", drbd.MaxPeers-1),
+		storage.FakeResponse{})
+
+	// Kernel slot already loaded (vol-0 UpToDate). drbdsetup status
+	// (no --json) drives FSM dispatch; the --json variant
+	// AnyConnectedPeerHasDataForVolume probes returns empty → "no peer
+	// holds data for vol-1" → the seed proceeds.
+	fx.Expect("drbdsetup status pvc-late-win",
+		storage.FakeResponse{Stdout: []byte("pvc-late-win role:Secondary\n  volume:0 disk:UpToDate\n")})
+	fx.Expect("drbdsetup status --verbose pvc-late-win",
+		storage.FakeResponse{Stdout: []byte("pvc-late-win role:Secondary\n  volume:0 disk:UpToDate\n")})
+
+	fx.Expect("drbdadm adjust pvc-late-win", storage.FakeResponse{})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thin1": thin},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	// Steady state: single-volume .res + md-created marker from the
+	// first-activation pass, the on-disk shape when `vd c` lands.
+	resPath := filepath.Join(dir, "pvc-late-win.res")
+	if err := os.WriteFile(resPath, []byte("resource pvc-late-win {\n  on n1 {\n    volume 0 {\n    }\n  }\n}\n"), 0o600); err != nil {
+		t.Fatalf("seed .res: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pvc-late-win.md-created"), nil, 0o600); err != nil {
+		t.Fatalf("seed md-created: %v", err)
+	}
+
+	// 2-diskful RD: local n1 node-id 0 (the lowest → late-add winner),
+	// peer n2 node-id 1. MetadataCreated=true (RD already Initialized),
+	// SkipInitialSync=true (replicas were stamped pre-init), late-add
+	// vol-1. This is the exact wire shape the operator repro produced.
+	peerID := int32(1)
+	dr := []*intent.DesiredResource{
+		{
+			Name:            "pvc-late-win",
+			NodeName:        "n1",
+			MetadataCreated: true,
+			SkipInitialSync: skipInitTrue(),
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+				{VolumeNumber: 1, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			Peers: []intent.DesiredPeer{{Name: "n2", NodeID: &peerID}},
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+				"peer.n2.address": "10.0.0.2", "peer.n2.node-id": "1", "peer.n2.port": "7000",
+			},
+		},
+	}
+
+	results, err := rec.Apply(t.Context(), dr)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].GetOk() {
+		t.Fatalf("Apply: expected Ok=true; got results=%+v", results)
+	}
+
+	calls := fx.CommandLines()
+	day0 := satellite.Day0GiForTest("pvc-late-win", 1)
+
+	// THE FIX: vol-1's local-slot set-gi MUST carry the winner shape —
+	// current=day0, Consistent(idx4=1)+UpToDate(idx5=1). The set-gi
+	// target is `<rd>/1` (vol-1 only); vol-0 is never re-seeded.
+	var vol1LocalSlot string
+
+	for _, line := range calls {
+		if strings.Contains(line, "pvc-late-win/1 ") && strings.Contains(line, "set-gi --node-id 0 ") {
+			vol1LocalSlot = line
+		}
+	}
+
+	if vol1LocalSlot == "" {
+		t.Fatalf("Bug 384: late-added vol-1 got NO winner set-gi on the lowest-id local slot — it would latch Inconsistent forever; cmds=%v", calls)
+	}
+
+	fields := strings.Fields(vol1LocalSlot)
+	gi := fields[len(fields)-1]
+	parts := strings.Split(gi, ":")
+
+	if len(parts) < 6 {
+		t.Fatalf("late-add winner vol-1 slot must carry positional consistent+uptodate flags; got %q", gi)
+	}
+
+	if parts[0] != day0 {
+		t.Errorf("late-add winner vol-1 current-UUID must equal day0 (shared lineage); got current=%s day0=%s", parts[0], day0)
+	}
+
+	if parts[1] != "0" {
+		t.Errorf("late-add winner vol-1 bitmap-base must be empty (0 = bitmap-uuid 0x0); got base=%s", parts[1])
+	}
+
+	if parts[4] != "1" || parts[5] != "1" {
+		t.Errorf("Bug 384: late-add winner vol-1 slot must be Consistent(idx4=1)+UpToDate(idx5=1); got %q — vol-1 would come up Inconsistent on every replica", gi)
+	}
+
+	// vol-0's metadata MUST NOT be touched by the late-add seed — it is
+	// HasMD=true, so it never joins the fresh-seed set. A set-gi against
+	// `<rd>/0` would wipe vol-0's live GI + bitmap state.
+	for _, line := range calls {
+		if strings.Contains(line, "pvc-late-win/0 ") && strings.Contains(line, "set-gi") {
+			t.Errorf("late-add seed re-stamped vol-0 GI (would wipe its live metadata): %s", line)
+		}
+	}
+}
+
+// TestApplyLateAddedVolumeNonWinnerTakesSkipInitSync pins the
+// complementary Bug 384 invariant: a late-add replica that is NOT the
+// lowest node-id (a peer holds a lower id) MUST take the case-A
+// skip-init-sync seed (current=day0, clean bitmap, NO UpToDate flag),
+// never the winner seed. Exactly one replica wins; the rest SyncTarget
+// from it. Here local n1 is node-id 2 with peers at 0 and 1, so n1 is
+// NOT the winner.
+func TestApplyLateAddedVolumeNonWinnerTakesSkipInitSync(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-lose_00000",
+		storage.FakeResponse{Stdout: []byte("pvc-late-lose_00000\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-lose_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-lose_00000|1048576\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-lose_00001",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-lose_00001",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-lose_00001|1048576\n")})
+	fx.Expect("drbdadm dump-md pvc-late-lose/0",
+		storage.FakeResponse{Stdout: []byte("version \"v09\";\nla-size-sect 2048;\n")})
+	fx.Expect("drbdadm dump-md pvc-late-lose/1",
+		storage.FakeResponse{Err: errDrbdadmDumpMdNoMeta})
+	fx.Expect(fmt.Sprintf("drbdadm create-md --force --max-peers=%d pvc-late-lose/1", drbd.MaxPeers-1),
+		storage.FakeResponse{})
+	fx.Expect("drbdsetup status pvc-late-lose",
+		storage.FakeResponse{Stdout: []byte("pvc-late-lose role:Secondary\n  volume:0 disk:UpToDate\n")})
+	fx.Expect("drbdsetup status --verbose pvc-late-lose",
+		storage.FakeResponse{Stdout: []byte("pvc-late-lose role:Secondary\n  volume:0 disk:UpToDate\n")})
+	fx.Expect("drbdadm adjust pvc-late-lose", storage.FakeResponse{})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thin1": thin},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n3",
+	})
+
+	resPath := filepath.Join(dir, "pvc-late-lose.res")
+	if err := os.WriteFile(resPath, []byte("resource pvc-late-lose {\n  on n3 {\n    volume 0 {\n    }\n  }\n}\n"), 0o600); err != nil {
+		t.Fatalf("seed .res: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pvc-late-lose.md-created"), nil, 0o600); err != nil {
+		t.Fatalf("seed md-created: %v", err)
+	}
+
+	peer0, peer1 := int32(0), int32(1)
+	dr := []*intent.DesiredResource{
+		{
+			Name:            "pvc-late-lose",
+			NodeName:        "n3",
+			MetadataCreated: true,
+			SkipInitialSync: skipInitTrue(),
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+				{VolumeNumber: 1, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			Peers: []intent.DesiredPeer{
+				{Name: "n1", NodeID: &peer0},
+				{Name: "n2", NodeID: &peer1},
+			},
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "2", "address": "10.0.0.3", "minor": "1000",
+				"peer.n1.address": "10.0.0.1", "peer.n1.node-id": "0", "peer.n1.port": "7000",
+				"peer.n2.address": "10.0.0.2", "peer.n2.node-id": "1", "peer.n2.port": "7000",
+			},
+		},
+	}
+
+	results, err := rec.Apply(t.Context(), dr)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].GetOk() {
+		t.Fatalf("Apply: expected Ok=true; got results=%+v", results)
+	}
+
+	calls := fx.CommandLines()
+
+	// The non-winner still seeds vol-1 (case-A skip-init-sync) so the
+	// bitmap is clean and it SyncTargets cleanly from the winner — but
+	// the local slot MUST NOT carry the UpToDate flag, otherwise two
+	// replicas would both claim authority.
+	var vol1LocalSlot string
+
+	for _, line := range calls {
+		if strings.Contains(line, "pvc-late-lose/1 ") && strings.Contains(line, "set-gi --node-id 2 ") {
+			vol1LocalSlot = line
+		}
+	}
+
+	if vol1LocalSlot == "" {
+		t.Fatalf("non-winner late-add vol-1 must still get a case-A skip-init-sync seed on its local slot; cmds=%v", calls)
+	}
+
+	gi := strings.Fields(vol1LocalSlot)
+	tuple := gi[len(gi)-1]
+	parts := strings.Split(tuple, ":")
+
+	// Case-A seed is `<day0>:0:0:0` — only current + empty bitmap, no
+	// positional consistent/uptodate flags.
+	if len(parts) >= 6 && parts[5] == "1" {
+		t.Errorf("Bug 384 split-brain guard: non-winner late-add vol-1 MUST NOT carry UpToDate(idx5=1); got %q", tuple)
+	}
+}
+
 // TestApplyAutoPrimaryForceErrorWraps pins the auto-primary force
 // error-wrap branch of applyDRBD: when the mkfs-promote step
 // `drbdadm primary --force` fails on first activation, applyOne

--- a/tests/e2e/cli-matrix/bug-384-late-vd-thin-converges.sh
+++ b/tests/e2e/cli-matrix/bug-384-late-vd-thin-converges.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# usage: bug-384-late-vd-thin-converges.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 384 (P0, DATA INTEGRITY; regression of the
+# Bug 79/332 family).
+#
+# Verbatim operator repro on a 2-diskful lvm-thin RD:
+#
+#   $ linstor rd c test
+#   $ linstor vd c test 1G                 # vol-0
+#   $ linstor r c <n1> test -s lvm-thin
+#   $ linstor r c <n2> test -s lvm-thin
+#   # wait until vol-0 is UpToDate on both replicas
+#   $ linstor vd c test 1G                 # vol-1 — the LATE-added VD
+#
+#   $ linstor r l
+#    test  <n1>  DRBD,STORAGE  Inconsistent
+#    test  <n2>  DRBD,STORAGE  Inconsistent
+#   $ linstor v l
+#    test  <n1>  lvm-thin  vol 0  /dev/drbd20000  UpToDate
+#    test  <n1>  lvm-thin  vol 1  /dev/drbd20001  Inconsistent   ← bug
+#    test  <n2>  lvm-thin  vol 0  /dev/drbd20000  UpToDate
+#    test  <n2>  lvm-thin  vol 1  /dev/drbd20001  Inconsistent   ← bug
+#
+# vol-0 stays UpToDate; the late-added vol-1 is stuck Inconsistent on
+# EVERY replica with no SyncSource to recover from — neither replica
+# was elected the initial-UpToDate winner for the new volume, so DRBD
+# has no authority to drive either out of Inconsistent.
+#
+# Expected (post-fix): the satellite re-runs the lowest-node-id winner
+# election locally per fresh volume (seedFreshVolumes / isLateAddWinner),
+# the lowest-id replica seeds vol-1 Consistent+UpToDate, and BOTH
+# replicas settle vol-1 UpToDate within 60s.
+#
+# Unit pin: pkg/satellite/reconciler_drbd_test.go::
+#   TestApplyLateAddedVolumeWinnerSeedsUpToDate (winner seeds vol-1
+#   Consistent+UpToDate) and ::TestApplyLateAddedVolumeNonWinnerTakes
+#   SkipInitSync (non-winner stays case-A, no split-brain). This L6
+#   cell is the kernel-truth half — only the real stand observes the
+#   actual `linstor v l` / `drbdadm status` Inconsistent surface.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cli-matrix-384
+POOL=${POOL:-lvm-thin}
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+N1=$WORKER_1
+N2=$WORKER_2
+
+# Pre-flight: both target nodes must carry the thin pool — Bug 384's
+# repro is thin-specific (the seed path only skips initial sync on
+# thin/ZFS). Skip cleanly if the fixture pool is not present.
+echo ">> pre-flight: $POOL SP on $N1 + $N2"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+have=$(jq -r --arg n1 "$N1" --arg n2 "$N2" \
+    '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique
+     | map(select(. == $n1 or . == $n2)) | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( have < 2 )); then
+    echo "SKIP: $POOL SP not on both $N1 and $N2 (got $have) — Bug 384 fixture unavailable"
+    exit 0
+fi
+
+echo ">> [Bug 384] rd c + vd c (vol-0)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+
+echo ">> [Bug 384] r c on $N1 + $N2 (-s $POOL)"
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" >/dev/null
+
+echo ">> wait for vol-0 UpToDate on both replicas"
+wait_uptodate "$RD" "$N1" "$N2"
+
+# THE BUG: add vol-1 AFTER vol-0 is UpToDate. The RD is already
+# Initialized, so the first-activation winner election cannot fire.
+echo ">> [Bug 384] late vd c (vol-1)"
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+
+echo ">> wait up to 90s for vol-1 to reach UpToDate on BOTH replicas"
+deadline=$(( $(date +%s) + 90 ))
+late_up=false
+while (( $(date +%s) < deadline )); do
+    s1=$(status_disk_state "$RD" "$N1" 1)
+    s2=$(status_disk_state "$RD" "$N2" 1)
+    if [[ "$s1" == "UpToDate" && "$s2" == "UpToDate" ]]; then
+        late_up=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$late_up" != "true" ]]; then
+    echo "FAIL (Bug 384): late-added vol-1 did not reach UpToDate on both replicas within 90s" >&2
+    echo "  $N1 vol-1: $(status_disk_state "$RD" "$N1" 1)   $N2 vol-1: $(status_disk_state "$RD" "$N2" 1)" >&2
+    "${LCTL[@]}" volume list --resources "$RD" 2>&1 | tail -20 >&2 || true
+    exit 1
+fi
+
+# Kernel-truth guard: drbdadm status on a diskful replica MUST NOT
+# report vol-1 as Inconsistent (the exact operator-observed surface).
+echo ">> [Bug 384] kernel-truth: drbdadm status on $N1"
+if status_out=$(on_node "$N1" drbdadm status "$RD" 2>&1); then
+    echo "$status_out"
+    if grep -E 'volume:1.*disk:Inconsistent' <<<"$status_out" >/dev/null; then
+        echo "FAIL (Bug 384): $N1 reports volume:1 as Inconsistent on kernel state" >&2
+        echo "$status_out" >&2
+        exit 1
+    fi
+else
+    echo "SKIP-PARTIAL: kernel-truth probe on $N1 unavailable; Status-level pin still asserted"
+fi
+
+echo ">> bug-384-late-vd-thin-converges OK (late vd c on $RD brought vol-1 to UpToDate on both replicas, no stuck Inconsistent)"

--- a/tests/operator-harness/replay/vd-late-create-second-volume.yaml
+++ b/tests/operator-harness/replay/vd-late-create-second-volume.yaml
@@ -1,0 +1,68 @@
+name: vd-late-create-second-volume
+description: |
+  Bug-384 catcher (P0, data integrity; regression of the Bug 79/332
+  family). The DISTINGUISHING factor from vd-late-create.yaml is the
+  ordering: here vol-0 is created and driven UpToDate FIRST (so the RD
+  flips Spec.Initialized=true), and ONLY THEN is a SECOND volume added
+  via `vd c`. That late-added vol-1 lands on an ALREADY-initialized RD,
+  so the dispatcher's first-activation winner election (auto-primary,
+  gated on !rdInitialized) can never fire for it.
+
+  Pre-fix the satellite seeded vol-1 with the case-A skip-init-sync GI
+  on EVERY diskful replica (clean bitmap, NO UpToDate flag) and elected
+  no winner, so vol-1 came up Inconsistent on both replicas with no
+  SyncSource and never converged — verbatim operator repro:
+
+    linstor vd c test 1G   →  test  dev-worker-1  ...  Inconsistent
+                              test  dev-worker-3  ...  Inconsistent
+
+  Post-fix the satellite re-runs the lowest-node-id winner election
+  locally per fresh volume (seedFreshVolumes / isLateAddWinner): the
+  lowest-id replica seeds vol-1 Consistent+UpToDate, the rest take
+  case-A, and all_uptodate (which checks EVERY volume of EVERY replica)
+  converges.
+
+  Note: vd-late-create.yaml exercises the FIRST-volume late-add (vd c on
+  a VD-less RD) which routes through first-activation and was always
+  green; it does NOT cover this second-volume path.
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vol0
+    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-vol0-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: late-vd-create-vol1
+    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## What

Adding a volume to an already-initialized multi-replica resource left the **new** volume stuck `Inconsistent` on every replica, with no `SyncSource` and no convergence. Verbatim operator repro on a 2-diskful `lvm-thin` resource:

```
$ linstor vd c test 1G          # add vol-1 to existing 'test'
$ linstor v l
 test  dev-worker-1  lvm-thin  vol 0  ...  UpToDate
 test  dev-worker-1  lvm-thin  vol 1  ...  Inconsistent   ← stuck
 test  dev-worker-3  lvm-thin  vol 0  ...  UpToDate
 test  dev-worker-3  lvm-thin  vol 1  ...  Inconsistent   ← stuck
```

This is a P0 data-integrity issue and a class regression of the Bug 79 / Bug 332 family.

## Why

The late-add seed path (`seedFreshVolumes`) runs with `firstActivation=false` on the parent RD, because the RD has already flipped `Spec.Initialized=true` by the time `linstor vd c` lands. The dispatcher's first-activation winner election (the `auto-primary` flag) is gated on `!rdInitialized`, so it never fires for the late-added volume.

As a result the code passed `isWinner=false` unconditionally, and **every** diskful replica took the case-A skip-init-sync seed (shared `day0` current, clean per-peer bitmap, **no** `UpToDate` flag). With no replica electing itself the UpToDate source — and no `primary --force` on this path — DRBD had no authority to drive the freshly-carved volume out of `Inconsistent`, so it latched there forever.

The existing first-volume late-add coverage (`vd-late-create.yaml`, `multi-volume-late-vd-create.sh`) did not catch this: those add the **first** volume to a VD-less RD, which still routes through first-activation and elects a winner. Only a **second** volume added after the RD is initialized exposes the gap.

## Fix

Recompute the same lowest-node-id election locally per fresh volume (`isLateAddWinner`), using the node-id set the dispatcher already renders into the wire payload. Exactly one diskful replica (the lowest allocated node-id) seeds the new volume `Consistent+UpToDate` (case B) and becomes the SyncSource; the rest take case A. The election is deterministic (stable across reconciles) and split-brain-safe:

- `resolveVolumeSeed`'s `PeerHasData` / `AnyConnectedPeerHasDataForVolume` vetoes still fire **first**, so a relocate / migrate-disk target (a peer already holds data on this volume) never wins itself UpToDate-empty.
- The winner seed is byte-identical to the first-activation winner and shares the `day0` lineage anchor, so a staggered dual election agrees rather than split-brains.

No change to the dispatcher or `ensureTiebreaker`; the fix is confined to the satellite reconciler.

## Tests (CLI-bug-fix protocol)

- **L1** `pkg/satellite/reconciler_drbd_test.go`:
  - `TestApplyLateAddedVolumeWinnerSeedsUpToDate` — the lowest-id replica seeds the late vol-1 `Consistent+UpToDate` (positional `idx4=1`/`idx5=1` at `current=day0`); vol-0 is never re-seeded. Verified to fail pre-fix (case-A `<day0>:0:0:0` tuple).
  - `TestApplyLateAddedVolumeNonWinnerTakesSkipInitSync` — a non-lowest-id replica seeds case A and must NOT carry the `UpToDate` flag (split-brain guard).
- **L6** `tests/e2e/cli-matrix/bug-384-late-vd-thin-converges.sh` — 2-diskful thin RD, vol-0 UpToDate, then a second `vd c` adds vol-1; asserts vol-1 reaches UpToDate on both replicas plus a kernel-truth `drbdadm status` guard against the stuck-Inconsistent surface.
- **L7** `tests/operator-harness/replay/vd-late-create-second-volume.yaml` — operator sequence `rd c → vd c vol-0 → r c ×2 → wait all_uptodate → vd c vol-1`, asserting `all_uptodate` (every volume of every replica) after the late add.

`go build ./...`, `go test ./...` and `golangci-lint run pkg/satellite/...` are green.