### PR TITLE
fix(controller): prune source replica after node evacuate completes (Bug 389)

### DIFF
--- a/internal/controller/bug_389_evacuate_prune_source_test.go
+++ b/internal/controller/bug_389_evacuate_prune_source_test.go
@@ -20,6 +20,7 @@ package controller_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -210,4 +211,227 @@ func TestNodeReconciler_EvictedPrunesSourceAfterReplacementUpToDate(t *testing.T
 	} else if err != nil && !errors.IsNotFound(err) {
 		t.Fatalf("Get source after prune: unexpected err %v", err)
 	}
+}
+
+// TestNodeReconciler_EvictedDfltRscGrpPlaceCountZeroNoDropWithoutAdd is the
+// Bug 389 REWORK regression: the original fix defaulted filter.PlaceCount
+// to 1 whenever the RG carried PlaceCount=0 (the default `DfltRscGrp`
+// ships PlaceCount=0 and CLI-created RDs inherit it). With place_count=1:
+//
+//   - placer.Place sees the surviving peer (n2) already holds 1 valid
+//     diskful → "satisfied" → it gap-fills NOTHING on n3;
+//   - evacuationReplacementReady counts n2 (1) >= place_count (1) → TRUE;
+//   - pruneSource deletes n1's source → the RD lands at ONE diskful.
+//
+// That is drop-without-add, strictly worse than the pre-fix bug (which at
+// least kept the source). The rework anchors the effective target to the
+// CURRENT diskful count (n1 + n2 = 2), so the placer MUST gap-fill n3 and
+// the source MUST NOT be pruned until n3 is UpToDate — ending at 2 diskful.
+//
+// This test FAILS against the defective (PlaceCount-defaults-to-1) fix:
+// either the source is pruned in phase 1 (no replacement placed) or the
+// RD ends at 1 diskful.
+func TestNodeReconciler_EvictedDfltRscGrpPlaceCountZeroNoDropWithoutAdd(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+
+	st := store.NewInMemory()
+
+	for _, name := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{Name: name, Type: apiv1.NodeTypeSatellite}); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: "pool",
+			NodeName:        name,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool: %v", err)
+		}
+	}
+
+	// The crux of the repro: the RG carries PlaceCount=0, exactly like the
+	// default DfltRscGrp. The drain target must come from the actual
+	// diskful replica count, not this zero/defaulted RG value.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "DfltRscGrp",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  0,
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "pvc-1",
+		ResourceGroupName: "DfltRscGrp",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Two diskful replicas: n1 (soon-to-be-evicted source) and n2.
+	for _, node := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-1", NodeName: node}); err != nil {
+			t.Fatalf("seed resource: %v", err)
+		}
+	}
+
+	if err := st.Nodes().Update(ctx, &apiv1.Node{
+		Name:  "n1",
+		Type:  apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("flag n1 evicted: %v", err)
+	}
+
+	srcCRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n1",
+		},
+	}
+
+	n2CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n2"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n2",
+		},
+	}
+
+	nodeCRD := &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: blockstoriov1alpha1.NodeSpec{
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: []string{apiv1.NodeFlagEvicted},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Resource{}).
+		WithObjects(nodeCRD, srcCRD, n2CRD).
+		Build()
+
+	// n2 already UpToDate so the gate hinges solely on the n3 replacement
+	// the placer is REQUIRED to create (it would not, under place_count=1).
+	n2CRD.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, n2CRD); err != nil {
+		t.Fatalf("status update n2: %v", err)
+	}
+
+	rec := &controllerpkg.NodeReconciler{Client: cli, Scheme: scheme, Store: st}
+
+	// ---- Phase 1: drain triggers; replacement must be gap-filled ----
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}}); err != nil {
+		t.Fatalf("Reconcile (phase 1): %v", err)
+	}
+
+	// The placer MUST have created a third diskful replica in the store on
+	// the only non-evacuated free node, n3. Under the defective fix
+	// (place_count defaults to 1) the surviving n2 makes the placer
+	// "satisfied" and NO replacement is placed here — the assertion below
+	// catches that drop-without-add precondition.
+	replicas, err := st.Resources().ListByDefinition(ctx, "pvc-1")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if !hasDiskfulOn(replicas, "n3") {
+		t.Fatalf("placer did not gap-fill a replacement on n3 (Bug 389 drop-without-add: RG PlaceCount=0 defaulted to 1, surviving peer treated as satisfied). replicas=%+v", replicas)
+	}
+
+	// Source on n1 MUST still be present — n3's replacement is not yet
+	// UpToDate (no CRD/status), so add-before-drop forbids the prune.
+	srcLive := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n1"}, srcLive); err != nil {
+		t.Fatalf("source pruned before replacement UpToDate (Bug 389 add-before-drop regression): %v", err)
+	}
+
+	// ---- Phase 2: n3 replacement reaches UpToDate ----
+	n3CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n3"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n3",
+		},
+	}
+	if err := cli.Create(ctx, n3CRD); err != nil {
+		t.Fatalf("create n3 replacement CRD: %v", err)
+	}
+
+	n3Live := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n3"}, n3Live); err != nil {
+		t.Fatalf("get n3: %v", err)
+	}
+
+	n3Live.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, n3Live); err != nil {
+		t.Fatalf("status update n3: %v", err)
+	}
+
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}}); err != nil {
+		t.Fatalf("Reconcile (phase 2): %v", err)
+	}
+
+	// Source on the evacuated node MUST now be pruned.
+	srcAfter := &blockstoriov1alpha1.Resource{}
+
+	err = cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n1"}, srcAfter)
+	if err == nil && srcAfter.DeletionTimestamp.IsZero() {
+		t.Fatalf("source replica on evacuated node NOT pruned after replacement UpToDate (Bug 389): still present %+v", srcAfter)
+	} else if err != nil && !errors.IsNotFound(err) {
+		t.Fatalf("Get source after prune: unexpected err %v", err)
+	}
+
+	// End state: exactly 2 diskful replicas remain on the NON-evacuated
+	// nodes (n2 + n3) — redundancy preserved, never dropped to 1.
+	replicas, err = st.Resources().ListByDefinition(ctx, "pvc-1")
+	if err != nil {
+		t.Fatalf("list replicas (end): %v", err)
+	}
+
+	diskfulOnHealthy := 0
+
+	for i := range replicas {
+		if replicas[i].NodeName == "n1" {
+			continue
+		}
+
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		diskfulOnHealthy++
+	}
+
+	if diskfulOnHealthy != 2 {
+		t.Fatalf("expected 2 diskful replicas on non-evacuated nodes after evacuate, got %d (Bug 389 drop-without-add). replicas=%+v", diskfulOnHealthy, replicas)
+	}
+}
+
+// hasDiskfulOn reports whether `replicas` contains a diskful (no DISKLESS
+// flag) replica pinned to `node`.
+func hasDiskfulOn(replicas []apiv1.Resource, node string) bool {
+	for i := range replicas {
+		if replicas[i].NodeName != node {
+			continue
+		}
+
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }

--- a/internal/controller/bug_389_evacuate_prune_source_test.go
+++ b/internal/controller/bug_389_evacuate_prune_source_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestNodeReconciler_EvictedPrunesSourceAfterReplacementUpToDate pins
+// Bug 389: `node evacuate` is an online drain that must, after placing
+// a replacement on a healthy peer and once that replacement is observed
+// UpToDate, DELETE the source diskful replica on the evacuated node —
+// leaving the node empty so `node delete` completes cleanly. The old
+// behaviour left the source pinned forever (place_count+1 diskful,
+// storage never reclaimed, drain never finished).
+//
+// Strict add-before-drop is enforced by a two-phase drill against one
+// fake client (mirroring the migration reconciler's Option-B test):
+//
+//  1. Replacement on n3 exists but its Resource CRD reports no UpToDate
+//     volume yet → the source on n1 MUST survive (redundancy preserved).
+//  2. Stamp the n3 replacement CRD Status UpToDate and reconcile again →
+//     the source Resource CRD on n1 MUST be deleted.
+func TestNodeReconciler_EvictedPrunesSourceAfterReplacementUpToDate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+
+	st := store.NewInMemory()
+
+	for _, name := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{Name: name, Type: apiv1.NodeTypeSatellite}); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: "pool",
+			NodeName:        name,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool: %v", err)
+		}
+	}
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  2,
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "pvc-1",
+		ResourceGroupName: "rg",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Diskful replicas on n1 (the soon-to-be-evicted source) and n2.
+	for _, node := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-1", NodeName: node}); err != nil {
+			t.Fatalf("seed resource: %v", err)
+		}
+	}
+
+	// Flag n1 EVICTED in both the store and the Node CRD.
+	if err := st.Nodes().Update(ctx, &apiv1.Node{
+		Name:  "n1",
+		Type:  apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("flag n1 evicted: %v", err)
+	}
+
+	// Resource CRDs for the existing replicas. n2 is the healthy peer
+	// that must reach place_count once n3's replacement is UpToDate;
+	// seed n2 UpToDate so the gate hinges solely on the new n3 copy.
+	srcCRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n1",
+		},
+	}
+
+	n2CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n2"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n2",
+		},
+	}
+
+	nodeCRD := &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: blockstoriov1alpha1.NodeSpec{
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: []string{apiv1.NodeFlagEvicted},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Resource{}).
+		WithObjects(nodeCRD, srcCRD, n2CRD).
+		Build()
+
+	// n2 already UpToDate.
+	n2CRD.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, n2CRD); err != nil {
+		t.Fatalf("status update n2: %v", err)
+	}
+
+	rec := &controllerpkg.NodeReconciler{Client: cli, Scheme: scheme, Store: st}
+
+	// ---- Phase 1: replacement on n3 not yet UpToDate ----
+	_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}})
+	if err != nil {
+		t.Fatalf("Reconcile (phase 1): %v", err)
+	}
+
+	// The placer created a store replica on n3; mirror it as a CRD so
+	// the readiness gate has something to inspect — but leave its
+	// Status empty (still syncing). The source on n1 MUST survive.
+	srcLive := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n1"}, srcLive); err != nil {
+		t.Fatalf("source pruned while replacement still syncing (Bug 389 add-before-drop regression): %v", err)
+	}
+
+	n3CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n3"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n3",
+		},
+		// No Status.Volumes — replacement still syncing.
+	}
+	if err := cli.Create(ctx, n3CRD); err != nil {
+		t.Fatalf("create n3 replacement CRD: %v", err)
+	}
+
+	_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}})
+	if err != nil {
+		t.Fatalf("Reconcile (phase 1b): %v", err)
+	}
+
+	srcLive = &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n1"}, srcLive); err != nil {
+		t.Fatalf("source pruned while replacement still syncing (Bug 389 add-before-drop regression): %v", err)
+	}
+
+	// ---- Phase 2: replacement on n3 reaches UpToDate ----
+	n3Live := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n3"}, n3Live); err != nil {
+		t.Fatalf("get n3: %v", err)
+	}
+
+	n3Live.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, n3Live); err != nil {
+		t.Fatalf("status update n3: %v", err)
+	}
+
+	_, err = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}})
+	if err != nil {
+		t.Fatalf("Reconcile (phase 2): %v", err)
+	}
+
+	// The source Resource CRD on the evacuated node MUST now be gone
+	// (or marked for deletion if it carried a finalizer).
+	srcAfter := &blockstoriov1alpha1.Resource{}
+
+	err = cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n1"}, srcAfter)
+	if err == nil && srcAfter.DeletionTimestamp.IsZero() {
+		t.Fatalf("source replica on evacuated node NOT pruned after replacement UpToDate (Bug 389): still present %+v", srcAfter)
+	} else if err != nil && !errors.IsNotFound(err) {
+		t.Fatalf("Get source after prune: unexpected err %v", err)
+	}
+}

--- a/internal/controller/eviction_test.go
+++ b/internal/controller/eviction_test.go
@@ -119,11 +119,14 @@ func TestNodeReconciler_EvictedTriggersMigration(t *testing.T) {
 		t.Fatalf("list: %v", err)
 	}
 
-	// EVICTED is the soft "drain me" hint: the migration adds a
-	// replacement on a healthy node but leaves the source replica
-	// in place — the operator decides when to actually remove it
-	// (typically once the new replica is UpToDate). For LOST, the
-	// source is deleted in the same reconcile pass.
+	// EVICTED is an online drain with strict add-before-drop ordering
+	// (Bug 389): the migration adds a replacement on a healthy node but
+	// the source replica on the evacuated node is NOT dropped until the
+	// replacement is observed UpToDate. Here the replacement on n3 has
+	// no Resource CRD reporting UpToDate yet, so the source on n1 must
+	// survive this pass — redundancy never dips mid-drain. The actual
+	// source prune (once the replacement converges) is exercised by
+	// TestNodeReconciler_EvictedPrunesSourceAfterReplacementUpToDate.
 	//
 	// So after one EVICTED reconcile we expect 3 replicas: original
 	// n1 + n2 + the freshly placed replacement on n3.

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -158,13 +158,12 @@ func (r *NodeReconciler) migrateResource(ctx context.Context, victim *apiv1.Reso
 		return err
 	}
 
-	// No RG → no SelectFilter → no topology/place_count to migrate
-	// against. The previous fallback of PlaceCount=1 silently
-	// half-migrated: with 1, the placer treats "1 valid replica
-	// elsewhere" as sufficient, so even when the EVICTED node hosts
-	// the only diskful replica the gap-fill never fires. Fail-safe:
-	// refuse the migration and stamp the RD so an operator sees the
-	// gap. They can attach an RG and re-trigger the eviction.
+	// No RG → no SelectFilter → no topology constraints to migrate
+	// against (which pools, which failure domains the replacement is
+	// allowed to land on). Fail-safe: refuse the migration and stamp the
+	// RD so an operator sees the gap rather than us placing a replacement
+	// blind to the original placement constraints. They can attach an RG
+	// and re-trigger the eviction.
 	if rd.ResourceGroupName == "" {
 		return r.annotateMigrationBlocked(ctx, rdName, MigrationBlockedReasonNoRG)
 	}
@@ -176,8 +175,28 @@ func (r *NodeReconciler) migrateResource(ctx context.Context, victim *apiv1.Reso
 		filter = rg.SelectFilter
 	}
 
-	if filter.PlaceCount == 0 {
-		filter.PlaceCount = 1
+	// Derive the effective diskful target the drain must preserve.
+	//
+	// The RG's PlaceCount can be 0 — the default `DfltRscGrp` ships with
+	// PlaceCount=0 and most CLI-created RDs inherit it. The previous
+	// fallback of PlaceCount=1 was actively harmful: with 1, the placer
+	// sees the surviving peer as "satisfied" and gap-fills NOTHING, while
+	// evacuationReplacementReady is satisfied by that same surviving peer
+	// — so pruneSource drops the source on the evacuated node and the RD
+	// lands one diskful short (drop-without-add, worse than the original
+	// bug). Anchor the target to the CURRENT diskful redundancy instead:
+	// count the diskful replicas this RD has right now (INCLUDING the one
+	// being evacuated, so it gets replaced; EXCLUDING diskless/tiebreaker
+	// witnesses and replicas already pinned to other EVICTED/LOST nodes).
+	// max() so an explicit, larger RG PlaceCount still wins, but a
+	// zero/defaulted RG can never let redundancy silently drop.
+	currentDiskful, err := r.currentDiskfulTarget(ctx, rdName, victim.NodeName)
+	if err != nil {
+		return err
+	}
+
+	if int(filter.PlaceCount) < currentDiskful {
+		filter.PlaceCount = apiv1.LaxInt32(currentDiskful) //nolint:gosec // diskful count of an in-memory slice fits int32
 	}
 
 	_, _, err = placer.New(r.Store).Place(ctx, rdName, &filter)
@@ -215,6 +234,86 @@ func (r *NodeReconciler) migrateResource(ctx context.Context, victim *apiv1.Reso
 	return r.pruneSource(ctx, rdName, victim.NodeName)
 }
 
+// currentDiskfulTarget returns the diskful redundancy the evacuation
+// drain must preserve: the number of diskful replicas this RD holds
+// right now, INCLUDING the one on the evacuated node (it must be
+// replaced, so it counts toward the target) but EXCLUDING:
+//   - diskless / TIE_BREAKER witnesses — they carry no data, the same
+//     exclusion splitDiskfulAndCandidates / placer.countDiskfulReplicas
+//     apply (place_count is a diskful-replica target);
+//   - replicas already pinned to OTHER draining (EVICTED / LOST) nodes —
+//     those placements are themselves on the way out and can't backstop
+//     redundancy.
+//
+// The evacuated node itself is the one exception to the disabled-node
+// exclusion: its replica still serves data until pruneSource runs, so it
+// must be counted so the placer is told to reach the SAME diskful count
+// on a non-evacuated peer before the source is dropped.
+//
+// The raw count is capped at the number of non-disabled nodes available
+// to host a diskful replica. This keeps the target STABLE across the
+// requeue loop: once the placer has gap-filled the replacement on a
+// healthy peer, that replacement is itself a diskful-on-a-healthy-node
+// and would otherwise be counted IN ADDITION to the still-present source
+// on the evacuated node — inflating the target every pass and demanding
+// more diskful than there are nodes to host them (the placer would then
+// report a capacity shortfall and the drain would never complete). The
+// drain only needs to re-establish the pre-drain diskful count on healthy
+// nodes; it can never need more diskful than non-disabled nodes exist.
+func (r *NodeReconciler) currentDiskfulTarget(ctx context.Context, rdName, evictedNode string) (int, error) {
+	drained, err := r.drainingNodes(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	nodes, err := r.Store.Nodes().List(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	healthyNodes := 0
+
+	for i := range nodes {
+		if _, off := drained[nodes[i].Name]; off {
+			continue
+		}
+
+		healthyNodes++
+	}
+
+	replicas, err := r.Store.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+
+	for i := range replicas {
+		node := replicas[i].NodeName
+
+		// Other draining nodes don't count; the evacuated node does (it
+		// is the replica we are replacing).
+		if node != evictedNode {
+			if _, off := drained[node]; off {
+				continue
+			}
+		}
+
+		// Diskless replicas / tiebreaker witnesses carry no data.
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		count++
+	}
+
+	if count > healthyNodes {
+		count = healthyNodes
+	}
+
+	return count, nil
+}
+
 // pruneSource deletes the Resource CRD for `rdName` on the evacuated /
 // lost node via the K8s API path so the Resource controller's
 // finalizer drives satellite teardown (or times out, for an
@@ -234,11 +333,17 @@ func (r *NodeReconciler) pruneSource(ctx context.Context, rdName, node string) e
 // evacuationReplacementReady reports whether the drain of `evictedNode`
 // may now safely drop the source replica of `rdName`. It is the
 // add-before-drop gate for the EVICTED path: true only once there are
-// at least place_count diskful replicas on healthy (non-evicted,
+// at least filter.PlaceCount diskful replicas on healthy (non-evicted,
 // non-lost) nodes AND every one of them is observed UpToDate via the
 // Resource CRD Status (the same DiskState gate the migration
-// controller uses for `r td --migrate-from`). Until then the source on
-// the evacuated node must live so redundancy never dips.
+// controller uses for `r td --migrate-from`). filter.PlaceCount here is
+// the effective target migrateResource derived — max(RG place_count,
+// current diskful count) — NOT the raw RG value, so a zero/defaulted RG
+// still demands the pre-drain diskful count be re-established on healthy
+// peers before the source goes. The evacuated node's own replica is
+// explicitly NOT counted toward satisfaction (it is being drained).
+// Until the gate passes the source on the evacuated node must live so
+// redundancy never dips.
 func (r *NodeReconciler) evacuationReplacementReady(ctx context.Context, filter *apiv1.AutoSelectFilter, rdName, evictedNode string) (bool, error) {
 	drained, err := r.drainingNodes(ctx)
 	if err != nil {

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -184,22 +185,145 @@ func (r *NodeReconciler) migrateResource(ctx context.Context, victim *apiv1.Reso
 		return err
 	}
 
-	if !lost {
+	if lost {
+		// LOST node never returns. Delete the Resource on it via the
+		// K8s API path unconditionally; the Resource controller's
+		// finalizer will best-effort RPC-Delete to the (gone)
+		// satellite, time out, and clear. There is no replacement to
+		// wait on — the source is already gone, so redundancy cannot
+		// be lowered by dropping a replica that no longer serves data.
+		return r.pruneSource(ctx, rdName, victim.NodeName)
+	}
+
+	// EVICTED (online drain): mirror upstream LINSTOR's add-before-drop
+	// ordering. The placer above gap-filled a replacement on a healthy
+	// peer; we must NOT drop the source on the evacuated node until that
+	// replacement is observed UpToDate, or redundancy would dip below
+	// place_count mid-drain. Once enough healthy replicas are UpToDate,
+	// prune the source so the node is left empty and `node delete`
+	// completes cleanly. If the replacement is still syncing, leave the
+	// source in place — the eviction requeue retries until it converges.
+	ready, err := r.evacuationReplacementReady(ctx, &filter, rdName, victim.NodeName)
+	if err != nil {
+		return err
+	}
+
+	if !ready {
 		return nil
 	}
 
-	// LOST node never returns. Delete the Resource on it via the
-	// K8s API path; the Resource controller's finalizer will
-	// best-effort RPC-Delete to the (gone) satellite, time out,
-	// and clear.
+	return r.pruneSource(ctx, rdName, victim.NodeName)
+}
+
+// pruneSource deletes the Resource CRD for `rdName` on the evacuated /
+// lost node via the K8s API path so the Resource controller's
+// finalizer drives satellite teardown (or times out, for an
+// unreachable node). A NotFound is swallowed — a previous reconcile
+// pass may have already removed it.
+func (r *NodeReconciler) pruneSource(ctx context.Context, rdName, node string) error {
 	resCRD := &blockstoriov1alpha1.Resource{}
 
-	err = r.Get(ctx, client.ObjectKey{Name: resourceCRDName(rdName, victim.NodeName)}, resCRD)
+	err := r.Get(ctx, client.ObjectKey{Name: resourceCRDName(rdName, node)}, resCRD)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
 	return r.Delete(ctx, resCRD)
+}
+
+// evacuationReplacementReady reports whether the drain of `evictedNode`
+// may now safely drop the source replica of `rdName`. It is the
+// add-before-drop gate for the EVICTED path: true only once there are
+// at least place_count diskful replicas on healthy (non-evicted,
+// non-lost) nodes AND every one of them is observed UpToDate via the
+// Resource CRD Status (the same DiskState gate the migration
+// controller uses for `r td --migrate-from`). Until then the source on
+// the evacuated node must live so redundancy never dips.
+func (r *NodeReconciler) evacuationReplacementReady(ctx context.Context, filter *apiv1.AutoSelectFilter, rdName, evictedNode string) (bool, error) {
+	drained, err := r.drainingNodes(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	replicas, err := r.Store.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		return false, err
+	}
+
+	healthyUpToDate := 0
+
+	for i := range replicas {
+		node := replicas[i].NodeName
+
+		// Skip the source on the evacuated node and any replica still
+		// pinned to a draining (EVICTED / LOST) peer — neither counts
+		// toward the post-drain redundancy we must reach first.
+		if node == evictedNode {
+			continue
+		}
+
+		if _, off := drained[node]; off {
+			continue
+		}
+
+		// Diskless replicas (tiebreakers) carry no data; they don't
+		// satisfy the diskful redundancy the drain has to preserve.
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		ready, err := r.replicaUpToDate(ctx, rdName, node)
+		if err != nil {
+			return false, err
+		}
+
+		if ready {
+			healthyUpToDate++
+		}
+	}
+
+	return healthyUpToDate >= int(filter.PlaceCount), nil
+}
+
+// replicaUpToDate reads the Resource CRD Status for `rdName` on `node`
+// and reports whether every volume is UpToDate. A missing CRD or an
+// empty Volumes slice returns false — we have no evidence the new copy
+// is durable, so the source must not be dropped yet.
+func (r *NodeReconciler) replicaUpToDate(ctx context.Context, rdName, node string) (bool, error) {
+	resCRD := &blockstoriov1alpha1.Resource{}
+
+	err := r.Get(ctx, client.ObjectKey{Name: resourceCRDName(rdName, node)}, resCRD)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return allVolumesUpToDate(resCRD), nil
+}
+
+// drainingNodes returns the set of node names currently flagged EVICTED
+// or LOST. Replicas pinned to these nodes cannot count toward the
+// post-drain redundancy target, so they are excluded from the
+// add-before-drop readiness check.
+func (r *NodeReconciler) drainingNodes(ctx context.Context) (map[string]struct{}, error) {
+	nodes, err := r.Store.Nodes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := map[string]struct{}{}
+
+	for i := range nodes {
+		if slices.Contains(nodes[i].Flags, apiv1.NodeFlagEvicted) ||
+			slices.Contains(nodes[i].Flags, apiv1.NodeFlagLost) {
+			out[nodes[i].Name] = struct{}{}
+		}
+	}
+
+	return out, nil
 }
 
 // resourceCRDName mirrors the encoding used by the k8s store —

--- a/tests/e2e/cli-matrix/n-evacuate-prunes-source.sh
+++ b/tests/e2e/cli-matrix/n-evacuate-prunes-source.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# usage: n-evacuate-prunes-source.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 389 (user-reported, P1).
+#
+# `linstor node evacuate <node>` is an online drain: it must place a
+# replacement diskful replica on a healthy peer, wait for it to reach
+# UpToDate, then DELETE the source replica on the evacuated node — so
+# the node is left empty and `linstor node delete` completes cleanly.
+#
+# Pre-fix blockstor behaviour: the NodeReconciler gap-filled the
+# replacement but NEVER deleted the source on the evacuated node
+# (`if !lost { return nil }`). Result: the RD ran at place_count+1
+# diskful forever with one copy pinned to an EVICTED node, storage was
+# never reclaimed, and the drain never completed.
+#
+# This cell drives the real CLI against a 3-node stand:
+#   1. rd c + vd c + r c --auto-place=2  -> 2 diskful replicas.
+#   2. pick one diskful node as the evacuation target.
+#   3. linstor node evacuate <target>.
+#   4. assert: a replacement diskful replica appears on the third node
+#      and reaches UpToDate, AND the source replica on the evacuated
+#      node is GONE (the node is drained empty).
+#
+# The add-before-drop ordering is also implicitly checked: the
+# replacement must be UpToDate before the source disappears (we wait
+# for the replacement UpToDate first, then assert the source is gone).
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-389
+POOL=${POOL:-lvm-thin}
+
+EVAC_NODE=""
+
+cleanup() {
+    # Un-evacuate the node so the stand is left in a usable state for
+    # the next cell (restore-flag is best-effort; a fresh EVICTED flag
+    # would otherwise leak across cells).
+    if [[ -n "$EVAC_NODE" ]]; then
+        "${LCTL[@]}" node restore "$EVAC_NODE" >/dev/null 2>&1 || true
+    fi
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Pre-flight: need the named pool on at least 3 nodes so autoplace=2
+# leaves a third node free for the evacuation replacement to land on.
+echo ">> pre-flight: 3 healthy $POOL SPs"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+ok_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( ok_nodes < 3 )); then
+    echo "SKIP: $POOL SP not on 3 nodes (got $ok_nodes) — Bug 389 fixture not available"
+    exit 0
+fi
+
+echo ">> [Bug 389] rd c + vd c + r c --auto-place=2 -s $POOL"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+"${LCTL[@]}" resource create --auto-place=2 --storage-pool="$POOL" "$RD" >/dev/null
+
+echo ">> wait for 2 diskful replicas, both UpToDate"
+wait_replica_count "$RD" 2 90
+mapfile -t diskful < <(linstor_diskful_nodes "$RD")
+if (( ${#diskful[@]} != 2 )); then
+    die "[Bug 389] expected 2 diskful replicas after autoplace=2, got ${#diskful[@]}: ${diskful[*]}"
+fi
+
+for n in "${diskful[@]}"; do
+    wait_status_state "$RD" "$n" "UpToDate|UpToDate\\(100%\\)" 240
+done
+
+EVAC_NODE="${diskful[0]}"
+KEEP_NODE="${diskful[1]}"
+echo ">> [Bug 389] evacuating $EVAC_NODE (keeping $KEEP_NODE)"
+
+# The replacement must land on the one node that has the pool but no
+# replica yet.
+SPARE_NODE=$(linstor_pick_free_node "$RD" "$EVAC_NODE" "$KEEP_NODE")
+if [[ -z "$SPARE_NODE" ]]; then
+    echo "SKIP: no spare $POOL node free for the evacuation replacement"
+    exit 0
+fi
+echo "   replacement expected on $SPARE_NODE"
+
+"${LCTL[@]}" node evacuate "$EVAC_NODE" >/dev/null
+
+echo ">> [Bug 389] wait for replacement on $SPARE_NODE to reach UpToDate"
+# The replacement Resource CRD must appear and converge before the
+# source is allowed to drop (strict add-before-drop).
+deadline=$(( $(date +%s) + 120 ))
+while (( $(date +%s) < deadline )); do
+    if kubectl get "resources.blockstor.cozystack.io/${RD}.${SPARE_NODE}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 3
+done
+if ! kubectl get "resources.blockstor.cozystack.io/${RD}.${SPARE_NODE}" >/dev/null 2>&1; then
+    die "[Bug 389] evacuate never placed a replacement replica on $SPARE_NODE"
+fi
+wait_status_state "$RD" "$SPARE_NODE" "UpToDate|UpToDate\\(100%\\)" 240
+
+echo ">> [Bug 389] assert source replica on $EVAC_NODE is pruned"
+# THE BUG: pre-fix, this replica lived forever. Post-fix, once the
+# replacement is UpToDate the NodeReconciler deletes it.
+if ! wait_replica_absent "$RD" "$EVAC_NODE" 120; then
+    die "[Bug 389 REGRESSION] source replica ${RD}.${EVAC_NODE} still present after evacuate completed — node never drained"
+fi
+
+echo ">> [Bug 389] assert redundancy preserved: $KEEP_NODE + $SPARE_NODE both UpToDate"
+wait_status_state "$RD" "$KEEP_NODE" "UpToDate|UpToDate\\(100%\\)" 60
+wait_status_state "$RD" "$SPARE_NODE" "UpToDate|UpToDate\\(100%\\)" 60
+
+# Final shape: exactly 2 diskful replicas, neither on the evacuated node.
+mapfile -t final < <(linstor_diskful_nodes "$RD")
+for n in "${final[@]}"; do
+    if [[ "$n" == "$EVAC_NODE" ]]; then
+        die "[Bug 389] diskful replica still on evacuated node $EVAC_NODE: ${final[*]}"
+    fi
+done
+if (( ${#final[@]} != 2 )); then
+    die "[Bug 389] expected 2 diskful replicas after drain, got ${#final[@]}: ${final[*]}"
+fi
+
+echo ">> n-evacuate-prunes-source OK (Bug 389 pinned: evacuate placed replacement, drained source on $EVAC_NODE)"

--- a/tests/operator-harness/replay/n-evacuate-prune-source.yaml
+++ b/tests/operator-harness/replay/n-evacuate-prune-source.yaml
@@ -10,11 +10,25 @@ description: |
   ran at place_count+1 diskful forever with one copy pinned to an
   EVICTED node and the drain never finished.
 
+  REWORK (round 2): the first fix added an add-before-drop gate but
+  derived the drain target from the RG's place_count. This RD is created
+  with a bare `resource-definition create` (no --resource-group), so it
+  inherits the default DfltRscGrp whose place_count is 0. The first fix
+  then defaulted place_count to 1 — which made the placer treat the
+  single surviving peer as "satisfied" (no replacement placed) and the
+  readiness gate pass at 1 healthy replica, so the source was pruned and
+  the RD dropped to ONE diskful (drop-without-add, worse than the
+  original bug). This replay reproduces exactly that DfltRscGrp /
+  place_count=0 path: two manual `resource create <node>` replicas on a
+  zero-place_count RD. The rework derives the target from the CURRENT
+  diskful count (2), so a replacement MUST land before the source goes.
+
   Scenario (3-node): place 2 diskful replicas on node1 + node2, then
   evacuate node1. The placer gap-fills on node3 (the only free pool
   node). Assert: node3 reaches UpToDate (add-before-drop), the source
   on node1 is pruned (resource_absent), and node2 + node3 are both
-  UpToDate so redundancy was preserved throughout.
+  UpToDate so redundancy was preserved throughout (still 2 diskful,
+  never 1).
 
 prerequisites:
   min_nodes: 3
@@ -66,6 +80,19 @@ steps:
       kind: resource_absent
       rd: "{{rd}}"
       node: "{{node1}}"
+      timeout_s: 120
+  - name: assert-two-diskful-remain
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # REWORK assertion: the drain must leave the SAME diskful
+      # redundancy it started with (2), NOT drop to 1. The defective
+      # round-1 fix (place_count defaulted to 1 on the DfltRscGrp path)
+      # pruned the source without placing a replacement → exactly 1
+      # diskful, which this min:2 check catches.
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 2
       timeout_s: 120
   - name: wait-redundancy-preserved
     cmd: ["resource", "list", "--resources", "{{rd}}"]

--- a/tests/operator-harness/replay/n-evacuate-prune-source.yaml
+++ b/tests/operator-harness/replay/n-evacuate-prune-source.yaml
@@ -1,0 +1,85 @@
+name: n-evacuate-prune-source
+description: |
+  Bug 389: `linstor node evacuate <node>` is an online drain that must
+  place a replacement diskful replica on a healthy peer, wait for it to
+  reach UpToDate, then DELETE the source replica on the evacuated node —
+  leaving that node empty so `node delete` would complete cleanly.
+
+  Pre-fix blockstor gap-filled the replacement but NEVER pruned the
+  source (`if !lost { return nil }` in node_controller.go), so the RD
+  ran at place_count+1 diskful forever with one copy pinned to an
+  EVICTED node and the drain never finished.
+
+  Scenario (3-node): place 2 diskful replicas on node1 + node2, then
+  evacuate node1. The placer gap-fills on node3 (the only free pool
+  node). Assert: node3 reaches UpToDate (add-before-drop), the source
+  on node1 is pruned (resource_absent), and node2 + node3 are both
+  UpToDate so redundancy was preserved throughout.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-initial-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: node-evacuate-node1
+    cmd: ["node", "evacuate", "{{node1}}"]
+    expect_exit: 0
+  - name: wait-replacement-on-node3
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # Add-before-drop: the replacement on the free pool node must
+      # reach UpToDate before the source is allowed to drop.
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node3}}"
+      expected: "UpToDate"
+      timeout_s: 240
+  - name: wait-source-pruned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # THE Bug 389 ASSERTION: once the replacement is UpToDate the
+      # source replica on the evacuated node must be deleted.
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 120
+  - name: wait-redundancy-preserved
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # After the drain settles, every surviving replica (node2 +
+      # node3) is UpToDate — redundancy never dipped below place_count.
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 120
+
+teardown:
+  - cmd: ["node", "restore", "{{node1}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

`linstor node evacuate <node>` is an online drain. Upstream LINSTOR places a replacement diskful replica on a healthy peer, waits for it to reach UpToDate, then deletes the replica from the evacuated node — leaving the node empty so `node delete` completes cleanly.

blockstor's `NodeReconciler` gap-filled the replacement but, on the EVICTED (non-LOST) path, returned early without ever deleting the source replica (`if !lost { return nil }`). The RD then ran at `place_count+1` diskful forever with one copy pinned to an EVICTED node — storage was never reclaimed and the drain never finished.

## Fix

The EVICTED path now prunes the source replica on the evacuated node, gated by a strict add-before-drop check that mirrors the resource-migration controller (`r td --migrate-from`): the source is dropped only once at least `place_count` diskful replicas on healthy (non-evicted, non-lost) nodes are observed UpToDate via the Resource CRD Status. Until then the source lives, so redundancy never dips mid-drain.

- LOST path is unchanged (no replacement to wait on — the source is already gone).
- An evacuated-but-unreachable node still prunes the CRD through the same finalizer path the LOST case uses.

## Tests

- **L1** `internal/controller/bug_389_evacuate_prune_source_test.go` — two-phase: source survives while the replacement is still syncing; source CRD is deleted once the replacement is UpToDate. Existing eviction test updated to reflect the add-before-drop semantics.
- **L6** `tests/e2e/cli-matrix/n-evacuate-prunes-source.sh` — real `linstor node evacuate` on a 3-node stand; asserts replacement UpToDate and source drained empty.
- **L7** `tests/operator-harness/replay/n-evacuate-prune-source.yaml` — evacuate node1, assert replacement on node3 reaches UpToDate, source on node1 `resource_absent`, both survivors UpToDate.

## Validation

`go build ./...`, `go test ./internal/controller/... ./...`, and `golangci-lint run ./internal/controller/...` are all green. Live-stand replay is run by the launcher.