### PR TITLE
fix(controller): auto-diskful must ignore disabled-node and inactive replicas (Bug 390)

### DIFF
--- a/internal/controller/auto_diskful_controller.go
+++ b/internal/controller/auto_diskful_controller.go
@@ -116,7 +116,12 @@ func (r *AutoDiskfulReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	diskful, candidates := splitDiskfulAndCandidates(replicas)
+	disabled, err := r.disabledNodeSet(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	diskful, candidates := splitDiskfulAndCandidates(replicas, disabled)
 
 	if int32(len(diskful)) >= placeCount { //nolint:gosec // len of an in-memory slice fits int32
 		// Cluster is back at full diskful health — clear the timer.
@@ -432,18 +437,43 @@ func (r *AutoDiskfulReconciler) now() time.Time {
 	return time.Now()
 }
 
-// splitDiskfulAndCandidates partitions an RD's replicas. Diskful is
-// "no DISKLESS flag at all". Candidates are diskless replicas without
-// the TIE_BREAKER flag — promoting a witness defeats its sole purpose
+// splitDiskfulAndCandidates partitions an RD's replicas.
+//
+// A replica sitting on a disabled (EVICTED/LOST) node is dropped from
+// BOTH buckets: it must not be counted as a live diskful (Bug 390 #2 —
+// otherwise the deficit from the lost node is masked and the timer
+// never arms), and it must not be selected as a promotion candidate
+// (Bug 390 #4 — promoting onto a draining/gone node re-creates diskful
+// storage where the operator is trying to drain). This mirrors the
+// placer's countDiskfulReplicas / disabledNodes gating.
+//
+// Diskful is "no DISKLESS flag and not INACTIVE". An INACTIVE replica
+// (`drbdadm down`) serves no I/O and must not satisfy place_count for
+// auto-repair purposes (Bug 390 #3 — same miscount class Bug 387 fixed
+// at the tiebreaker entry).
+//
+// Candidates are active, non-disabled diskless replicas without the
+// TIE_BREAKER flag — promoting a witness defeats its sole purpose
 // (network presence for quorum) and would burn storage on what's
 // supposed to be a free vote.
-func splitDiskfulAndCandidates(replicas []apiv1.Resource) ([]apiv1.Resource, []apiv1.Resource) {
+func splitDiskfulAndCandidates(replicas []apiv1.Resource, disabled map[string]struct{}) ([]apiv1.Resource, []apiv1.Resource) {
 	var (
 		diskful    []apiv1.Resource
 		candidates []apiv1.Resource
 	)
 
 	for i := range replicas {
+		if _, off := disabled[replicas[i].NodeName]; off {
+			// Replica on an EVICTED/LOST node — treat as absent.
+			continue
+		}
+
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagInactive) {
+			// `drbdadm down` — serves no I/O, never counts toward
+			// place_count and is not a promotion candidate.
+			continue
+		}
+
 		if !slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
 			diskful = append(diskful, replicas[i])
 
@@ -458,6 +488,29 @@ func splitDiskfulAndCandidates(replicas []apiv1.Resource) ([]apiv1.Resource, []a
 	}
 
 	return diskful, candidates
+}
+
+// disabledNodeSet returns the EVICTED/LOST node names as a lookup set,
+// reusing the shared isDisabledNode predicate (defined alongside the
+// RD-controller tiebreaker path) so auto-diskful gates on exactly the
+// same disabled-node definition the placer uses. Eviction is the
+// operator's drain signal: a replica on such a node must not be counted
+// as live, and must never be a promotion target.
+func (r *AutoDiskfulReconciler) disabledNodeSet(ctx context.Context) (map[string]struct{}, error) {
+	nodes, err := r.Store.Nodes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]struct{}, len(nodes))
+
+	for i := range nodes {
+		if isDisabledNode(&nodes[i]) {
+			out[nodes[i].Name] = struct{}{}
+		}
+	}
+
+	return out, nil
 }
 
 // parsePositiveMinutes accepts the upstream-LINSTOR property shape:

--- a/internal/controller/auto_diskful_disabled_test.go
+++ b/internal/controller/auto_diskful_disabled_test.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// seedAutoDiskful390 builds a 3-node store (n1/n2/n3, each with a usable
+// pool) plus an RG (placeCount) and an RD parented to it carrying a
+// positive auto-diskful prop. Per-node flags let a caller mark a node
+// EVICTED/LOST. Replicas are created verbatim from the supplied specs so
+// the test controls the DISKLESS / INACTIVE / TIE_BREAKER mix exactly.
+func seedAutoDiskful390(
+	t *testing.T,
+	ctx context.Context,
+	st store.Store,
+	placeCount int32,
+	nodeFlags map[string][]string,
+	replicas []apiv1.Resource,
+) *apiv1.ResourceDefinition {
+	t.Helper()
+
+	for _, n := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name:  n,
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: nodeFlags[n],
+		}); err != nil {
+			t.Fatalf("seed node %q: %v", n, err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: "pool",
+			NodeName:        n,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool %q: %v", n, err)
+		}
+	}
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  apiv1.LaxInt32(placeCount),
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed rg: %v", err)
+	}
+
+	rd := &apiv1.ResourceDefinition{
+		Name:              "pvc-390",
+		ResourceGroupName: "rg",
+		Props:             map[string]string{apiv1.AutoDiskfulPropKey: "5"},
+	}
+	if err := st.ResourceDefinitions().Create(ctx, rd); err != nil {
+		t.Fatalf("seed rd: %v", err)
+	}
+
+	for i := range replicas {
+		rep := replicas[i]
+		rep.Name = rd.Name
+
+		if err := st.Resources().Create(ctx, &rep); err != nil {
+			t.Fatalf("seed replica on %q: %v", rep.NodeName, err)
+		}
+	}
+
+	return rd
+}
+
+// TestAutoDiskfulDeadlineArmsOnEvictedNode (Bug 390 #2): a replica on an
+// EVICTED node must NOT be counted as a live diskful. With placeCount=2,
+// one healthy diskful on n1 and one diskful on the EVICTED n2, the real
+// diskful count is 1 (< 2), so the deficit timer must arm rather than be
+// cleared. n3 carries a promotable diskless candidate.
+func TestAutoDiskfulDeadlineArmsOnEvictedNode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewInMemory()
+
+	rd := seedAutoDiskful390(t, ctx, st,
+		2,
+		map[string][]string{"n2": {apiv1.NodeFlagEvicted}},
+		[]apiv1.Resource{
+			{NodeName: "n1"},
+			{NodeName: "n2"}, // diskful, but on an EVICTED node
+			{NodeName: "n3", Flags: []string{apiv1.ResourceFlagDiskless}},
+		},
+	)
+
+	t0 := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	rec := &controllerpkg.AutoDiskfulReconciler{
+		Store: st,
+		Now:   func() time.Time { return t0 },
+	}
+
+	res, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rd.Name}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if res.RequeueAfter != 5*time.Minute {
+		t.Errorf("RequeueAfter: got %v, want 5m (timer must arm — EVICTED diskful does not count)", res.RequeueAfter)
+	}
+
+	got, err := st.ResourceDefinitions().Get(ctx, rd.Name)
+	if err != nil {
+		t.Fatalf("get rd: %v", err)
+	}
+
+	want := t0.Add(5 * time.Minute).Format(time.RFC3339)
+	if got.Annotations[apiv1.AutoDiskfulDeadlineAnnotation] != want {
+		t.Errorf("deadline annotation: got %q, want %q (EVICTED-node diskful masked the deficit)",
+			got.Annotations[apiv1.AutoDiskfulDeadlineAnnotation], want)
+	}
+}
+
+// TestAutoDiskfulDeadlineArmsOnInactiveReplica (Bug 390 #3): an INACTIVE
+// replica (`drbdadm down`) carries neither DISKLESS nor TIE_BREAKER but
+// serves no I/O. With placeCount=2, one healthy diskful on n1 and one
+// INACTIVE replica on n2, the live diskful count is 1 (< 2) and the
+// timer must arm.
+func TestAutoDiskfulDeadlineArmsOnInactiveReplica(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewInMemory()
+
+	rd := seedAutoDiskful390(t, ctx, st,
+		2,
+		nil,
+		[]apiv1.Resource{
+			{NodeName: "n1"},
+			{NodeName: "n2", Flags: []string{apiv1.ResourceFlagInactive}},
+			{NodeName: "n3", Flags: []string{apiv1.ResourceFlagDiskless}},
+		},
+	)
+
+	t0 := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	rec := &controllerpkg.AutoDiskfulReconciler{
+		Store: st,
+		Now:   func() time.Time { return t0 },
+	}
+
+	res, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rd.Name}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if res.RequeueAfter != 5*time.Minute {
+		t.Errorf("RequeueAfter: got %v, want 5m (timer must arm — INACTIVE replica does not count)", res.RequeueAfter)
+	}
+
+	got, err := st.ResourceDefinitions().Get(ctx, rd.Name)
+	if err != nil {
+		t.Fatalf("get rd: %v", err)
+	}
+
+	want := t0.Add(5 * time.Minute).Format(time.RFC3339)
+	if got.Annotations[apiv1.AutoDiskfulDeadlineAnnotation] != want {
+		t.Errorf("deadline annotation: got %q, want %q (INACTIVE replica masked the deficit)",
+			got.Annotations[apiv1.AutoDiskfulDeadlineAnnotation], want)
+	}
+}
+
+// TestAutoDiskfulHealthyClustersStripDeadline guards against a
+// false-positive: when placeCount=2 is genuinely satisfied by two live,
+// active, non-disabled diskful replicas, the timer must NOT arm (and any
+// stale deadline is stripped). This pins that the Bug 390 gating does not
+// over-count absence.
+func TestAutoDiskfulHealthyClustersStripDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewInMemory()
+
+	rd := seedAutoDiskful390(t, ctx, st,
+		2,
+		nil,
+		[]apiv1.Resource{
+			{NodeName: "n1"},
+			{NodeName: "n2"},
+			{NodeName: "n3", Flags: []string{apiv1.ResourceFlagDiskless}},
+		},
+	)
+
+	t0 := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	rec := &controllerpkg.AutoDiskfulReconciler{
+		Store: st,
+		Now:   func() time.Time { return t0 },
+	}
+
+	res, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rd.Name}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if res.RequeueAfter != 0 {
+		t.Errorf("RequeueAfter: got %v, want 0 (cluster healthy — no deficit)", res.RequeueAfter)
+	}
+
+	got, err := st.ResourceDefinitions().Get(ctx, rd.Name)
+	if err != nil {
+		t.Fatalf("get rd: %v", err)
+	}
+
+	if _, ok := got.Annotations[apiv1.AutoDiskfulDeadlineAnnotation]; ok {
+		t.Errorf("deadline stamped on a healthy cluster: %v", got.Annotations)
+	}
+}
+
+// TestAutoDiskfulPromotesOnHealthyNotDisabled (Bug 390 #4): when the
+// deadline fires, promoteOne must never select a candidate on a disabled
+// (EVICTED/LOST) node. Here n1 is the surviving diskful, n2 is a diskless
+// replica on a LOST node (must be skipped), and n3 is a diskless replica
+// on a healthy node (the only legal promotion target). The fix must
+// promote n3 and leave the LOST n2 untouched.
+func TestAutoDiskfulPromotesOnHealthyNotDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewInMemory()
+
+	rd := seedAutoDiskful390(t, ctx, st,
+		2,
+		map[string][]string{"n2": {apiv1.NodeFlagLost}},
+		[]apiv1.Resource{
+			{NodeName: "n1"},
+			{NodeName: "n2", Flags: []string{apiv1.ResourceFlagDiskless}}, // on a LOST node
+			{NodeName: "n3", Flags: []string{apiv1.ResourceFlagDiskless}}, // healthy candidate
+		},
+	)
+
+	t0 := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	rec := &controllerpkg.AutoDiskfulReconciler{
+		Store: st,
+		Now:   func() time.Time { return t0 },
+	}
+
+	// Arm.
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rd.Name}}); err != nil {
+		t.Fatalf("Reconcile (arm): %v", err)
+	}
+
+	// Fire.
+	rec.Now = func() time.Time { return t0.Add(6 * time.Minute) }
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rd.Name}}); err != nil {
+		t.Fatalf("Reconcile (fire): %v", err)
+	}
+
+	// The LOST-node replica must stay diskless — never promoted onto a
+	// draining/gone node.
+	lost, err := st.Resources().Get(ctx, rd.Name, "n2")
+	if err != nil {
+		t.Fatalf("get n2: %v", err)
+	}
+
+	if !slices.Contains(lost.Flags, apiv1.ResourceFlagDiskless) {
+		t.Errorf("LOST-node replica promoted to diskful: flags=%v", lost.Flags)
+	}
+
+	if lost.Props["StorPoolName"] != "" {
+		t.Errorf("LOST-node replica got a StorPoolName stamp: %v", lost.Props)
+	}
+
+	// The healthy n3 replica is the legal target — it must be promoted.
+	healthy, err := st.Resources().Get(ctx, rd.Name, "n3")
+	if err != nil {
+		t.Fatalf("get n3: %v", err)
+	}
+
+	if slices.Contains(healthy.Flags, apiv1.ResourceFlagDiskless) {
+		t.Errorf("healthy candidate not promoted: flags=%v", healthy.Flags)
+	}
+
+	if healthy.Props["StorPoolName"] != "pool" {
+		t.Errorf("healthy candidate StorPoolName: got %q, want pool", healthy.Props["StorPoolName"])
+	}
+}

--- a/tests/e2e/cli-matrix/auto-diskful-evicted-node.sh
+++ b/tests/e2e/cli-matrix/auto-diskful-evicted-node.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# usage: auto-diskful-evicted-node.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 390.
+#
+# The auto-diskful controller partitions an RD's replicas to decide
+# whether place_count is satisfied. Pre-fix the partition was blind to
+# node state: a diskful replica on an EVICTED/LOST node was still
+# counted as a live diskful, so the deficit created by draining a node
+# was masked — the timer never armed and the lost diskful was never
+# replaced. Worse, promoteOne could re-stamp StorPoolName onto a
+# replica whose node was being drained, re-creating diskful storage on
+# a node the operator is trying to evict.
+#
+# Reproduction (operator-CLI level):
+#
+#   $ linstor rd c <rd>; linstor vd c <rd> 128M
+#   $ linstor r c <n1> <rd> -s stand
+#   $ linstor r c <n2> <rd> -s stand
+#   $ linstor r c <n3> <rd> -s stand          # 3 diskful, UpToDate
+#   $ linstor controller set-property DrbdOptions/auto-diskful 1
+#   $ linstor node evacuate <n3>              # n3 → EVICTED
+#
+# Expected (post-fix): the evicted node's diskful no longer counts
+# toward place_count, so the controller refills a diskful replica on a
+# HEALTHY node and the cluster reconverges to 3 diskful — and crucially
+# NONE of the resulting diskful replicas sits on the evicted node.
+#
+# Pre-fix: the cluster stayed "satisfied" at 2 live + 1 evicted diskful
+# (the evicted one masked the deficit), or a replacement was stamped
+# back onto the evicted node.
+#
+# Contract: after evacuate + convergence, assert there are >= 3 diskful
+# replicas AND the evicted node hosts no diskful replica.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-390
+POOL=${POOL:-stand}
+
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    # Best-effort restore of the evicted node so the stand is reusable
+    # by later cells. `node evacuate --restore` (or re-create) is
+    # idempotent; ignore failures.
+    "${LCTL[@]}" node evacuate --restore "$N3" >/dev/null 2>&1 || true
+    "${LCTL[@]}" controller set-property DrbdOptions/auto-diskful "" >/dev/null 2>&1 || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 390] 3-replica diskful RD on $N1+$N2+$N3"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 128M >/dev/null
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N3" "$RD" --storage-pool="$POOL" >/dev/null
+
+echo ">> wait for all three diskful UpToDate"
+# wait_uptodate asserts a pair at a time; chain the two pairs that
+# cover all three replicas (n1↔n2 and n2↔n3).
+wait_uptodate "$RD" "$N1" "$N2"
+wait_uptodate "$RD" "$N2" "$N3"
+
+echo ">> arm auto-diskful (1 minute) at controller scope"
+"${LCTL[@]}" controller set-property DrbdOptions/auto-diskful 1 >/dev/null
+
+echo ">> linstor node evacuate $N3 (Bug 390 trigger — drains/evicts the node)"
+err_file=$(mktemp)
+if ! "${LCTL[@]}" node evacuate "$N3" 2>"$err_file"; then
+    rc=$?
+    echo "FAIL (Bug 390): node evacuate $N3 exited $rc" >&2
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    exit 1
+fi
+rm -f "$err_file"
+
+# Give the auto-diskful timer (1m) + the placer refill time to fire.
+# 180s budget covers the 1-minute deadline plus replacement create +
+# initial sync to UpToDate.
+echo ">> wait up to 180s for the cluster to refill to 3 diskful on healthy nodes"
+deadline=$(( $(date +%s) + 180 ))
+ok=0
+while (( $(date +%s) < deadline )); do
+    # Diskful nodes excluding the evicted one.
+    mapfile -t diskful < <(linstor_diskful_nodes "$RD")
+    healthy_diskful=0
+    evicted_diskful=0
+    for n in "${diskful[@]}"; do
+        [[ -z "$n" ]] && continue
+        if [[ "$n" == "$N3" ]]; then
+            evicted_diskful=1
+        else
+            healthy_diskful=$(( healthy_diskful + 1 ))
+        fi
+    done
+
+    if (( healthy_diskful >= 3 && evicted_diskful == 0 )); then
+        ok=1
+        break
+    fi
+    sleep 5
+done
+
+if (( ok != 1 )); then
+    echo "FAIL (Bug 390 regression): cluster did not refill to 3 diskful on healthy nodes" >&2
+    echo "  evicted node:  $N3" >&2
+    echo "  diskful nodes: $(linstor_diskful_nodes "$RD" | tr '\n' ' ')" >&2
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." '$1 ~ "^"rd' >&2 || true
+    exit 1
+fi
+
+# Defensive double-check: the evicted node must host NO diskful replica
+# (promoteOne must never select / re-stamp a disabled node — Bug 390 #4).
+if linstor_diskful_nodes "$RD" | grep -qx "$N3"; then
+    echo "FAIL (Bug 390 #4): a diskful replica was placed/kept on the EVICTED node $N3" >&2
+    exit 1
+fi
+
+echo ">> auto-diskful-evicted-node OK (Bug 390 pinned: evicted diskful does not count; refill lands on a healthy node)"

--- a/tests/operator-harness/replay/auto-diskful-evicted-node.yaml
+++ b/tests/operator-harness/replay/auto-diskful-evicted-node.yaml
@@ -1,0 +1,77 @@
+name: auto-diskful-evicted-node
+description: |
+  Bug-390 catcher. The auto-diskful controller partitions an RD's
+  replicas to decide whether place_count is satisfied. Pre-fix the
+  partition was blind to node state: a diskful replica on an
+  EVICTED/LOST node was still counted as a live diskful, so the deficit
+  created by draining a node was masked and never repaired.
+
+  Workflow: autoplace 3 diskful replicas, arm DrbdOptions/auto-diskful,
+  then `node evacuate {{node3}}`. The evicted node's diskful must stop
+  counting toward place_count, so the controller refills a replacement
+  diskful on a HEALTHY node and the cluster reconverges to 3 UpToDate
+  replicas — none stuck on the draining node (a replica stranded on the
+  evicted node could never report UpToDate, so all_uptodate is the
+  convergence gate here).
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: place-n1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool=stand"]
+    expect_exit: 0
+  - name: place-n2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool=stand"]
+    expect_exit: 0
+  - name: place-n3
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool=stand"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 3
+      timeout_s: 120
+  - name: wait-all-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: arm-auto-diskful
+    cmd: ["controller", "set-property", "DrbdOptions/auto-diskful", "1"]
+    expect_exit: 0
+  - name: evacuate-n3
+    cmd: ["node", "evacuate", "{{node3}}"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 3
+      timeout_s: 240
+  - name: wait-refill-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["node", "evacuate", "--restore", "{{node3}}"]
+  - cmd: ["controller", "set-property", "DrbdOptions/auto-diskful", ""]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

The auto-diskful controller's replica partition (`splitDiskfulAndCandidates`) split purely on the `DISKLESS`/`TIE_BREAKER` flag, with zero node-state or activation awareness. This clustered three related defects that all let a real diskful-replica deficit go unrepaired:

1. **Blind to EVICTED/LOST nodes (counting).** A diskful replica on an evicted/lost node was still counted as a live diskful, so `Reconcile` saw `len(diskful) >= placeCount` and cleared the deficit timer — the deficit from the drained node was never repaired.
2. **Blind to INACTIVE replicas.** An `INACTIVE` replica (`drbdadm down`) carries neither `DISKLESS` nor `TIE_BREAKER` and so landed in the diskful bucket, even though it serves no I/O. This is the same miscount class Bug 387 fixed at the tiebreaker entry.
3. **Blind to EVICTED/LOST nodes (promotion).** `promoteOne` could strip `DISKLESS` and stamp `StorPoolName` onto a replica whose node was being drained, re-creating diskful storage on a gone/draining node.

## Fix

`splitDiskfulAndCandidates` now takes the disabled-node set and:

- drops replicas on EVICTED/LOST nodes from **both** buckets (so they neither mask the deficit nor become promotion targets), and
- excludes `INACTIVE` replicas from the diskful count.

The disabled-node set is built by reusing the existing `isDisabledNode` predicate (already shared with the RD-controller tiebreaker path) — no duplicated logic. Because candidates are filtered in the same partition, `promoteOne` can no longer select a disabled-node replica.

The change is confined to `internal/controller/auto_diskful_controller.go` plus tests.

## Tests

- **L1 unit** (`internal/controller/auto_diskful_disabled_test.go`): an EVICTED-node diskful does not count (timer arms); an INACTIVE replica does not count (timer arms); `promoteOne` refills a healthy candidate and never promotes onto a LOST node; a healthy cluster still strips the timer. All three negative tests fail against the pre-fix controller.
- **L6 cli-matrix** (`tests/e2e/cli-matrix/auto-diskful-evicted-node.sh`): real CLI — 3 diskful replicas, arm `DrbdOptions/auto-diskful`, `node evacuate` one node, assert refill to 3 diskful on healthy nodes with no diskful left on the evicted node.
- **L7 replay** (`tests/operator-harness/replay/auto-diskful-evicted-node.yaml`): same operator sequence with `replica_count` + `all_uptodate` convergence awaits.

`go build ./...`, `go test ./...`, and `golangci-lint run ./internal/controller/...` all green. Live-stand replay not run from this branch (handled by the launcher).
