### PR TITLE
fix(controller,satellite): operational-lifecycle parity round 1 — Bugs 384–387 + L7 harness hardening (388)

### DIFF
--- a/internal/controller/ensure_tiebreaker_evict_bug_385_test.go
+++ b/internal/controller/ensure_tiebreaker_evict_bug_385_test.go
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 385 (P1) — `linstor n e <node>` (node evict) misbehaves when the
+// evicted node hosts the free TieBreaker replica. Operator stand repro
+// (dev cluster):
+//
+//	Before evict: worker-1 UpToDate, worker-2 UpToDate, worker-3 TieBreaker.
+//	After `linstor n e dev-worker-3`:
+//	  worker-2 wrongly demoted UpToDate → TieBreaker,
+//	  worker-3 (EVICTED) still holds a diskful resource.
+//
+// Operator summary: "Если евиктить ноду, при свободной TieBreaker
+// реплике, то евикт не произойдёт" — the evict does not actually take
+// effect.
+//
+// Root cause: ensureTiebreaker counted ALL replicas of the RD, including
+// the TIE_BREAKER witness sitting on the just-EVICTED node. The witness
+// invariant therefore read as already-satisfied (diskful=2 + witness=1)
+// and the reconciler never relocated the witness off the drained node —
+// leaving it pinned to the evicted satellite. Worse, downstream the
+// stranded witness blocked a fresh witness from landing on a healthy
+// spare, which is how the operator observed a healthy diskful drift into
+// the tiebreaker role.
+//
+// Fix (Bug 385): replicas on EVICTED / LOST nodes are draining
+// placements, not live ones — the witness / quorum decision must ignore
+// them (mirroring the placer's documented `disabledNodes` semantic), and
+// a TIE_BREAKER stranded on a disabled node must be reaped so a fresh one
+// can land on a healthy spare or quorum falls back to off. A healthy
+// diskful must NEVER be demoted to TIE_BREAKER.
+
+// TestBug385EvictTiebreakerNodeReapsStrandedWitness pins the exact stand
+// repro: 2 diskful (n1, n2) + 1 TIE_BREAKER witness (n3), then evict n3
+// (the witness node). After the reconcile:
+//
+//  1. The stranded TIE_BREAKER on the EVICTED n3 MUST be gone (the evict
+//     takes effect — the witness no longer pins the drained node).
+//  2. Both diskful replicas (n1, n2) MUST stay diskful — a healthy
+//     replica is NEVER demoted to TIE_BREAKER.
+//  3. No witness lands back on n3, and no spare exists (n1/n2 are
+//     diskful) so no new witness is created.
+func TestBug385EvictTiebreakerNodeReapsStrandedWitness(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	// n1, n2 healthy; n3 EVICTED (the operator just ran `n e n3`).
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n1", Type: apiv1.NodeTypeSatellite,
+	}); err != nil {
+		t.Fatalf("seed n1: %v", err)
+	}
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n2", Type: apiv1.NodeTypeSatellite,
+	}); err != nil {
+		t.Fatalf("seed n2: %v", err)
+	}
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n3", Type: apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed n3 (evicted): %v", err)
+	}
+
+	// Steady state before evict: n1 + n2 diskful, n3 TIE_BREAKER.
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug385", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-bug385", NodeName: "n3",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed n3 witness: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug385"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	all, err := st.Resources().ListByDefinition(ctx, "pvc-bug385")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	// Invariant 1: the stranded TIE_BREAKER on the EVICTED n3 is gone.
+	if _, err := st.Resources().Get(ctx, "pvc-bug385", "n3"); err == nil {
+		t.Errorf("Bug 385: TIE_BREAKER witness still pinned to EVICTED n3; entries=%v", all)
+	}
+
+	// Invariant 2: both diskful replicas survive unchanged — NEVER demoted.
+	for _, n := range []string{"n1", "n2"} {
+		got, getErr := st.Resources().Get(ctx, "pvc-bug385", n)
+		if getErr != nil {
+			t.Fatalf("Bug 385: diskful replica on %s vanished: %v", n, getErr)
+		}
+
+		if slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) {
+			t.Errorf("Bug 385: healthy diskful on %s was demoted to TIE_BREAKER; flags=%v", n, got.Flags)
+		}
+
+		if slices.Contains(got.Flags, apiv1.ResourceFlagDiskless) {
+			t.Errorf("Bug 385: healthy diskful on %s gained DISKLESS; flags=%v", n, got.Flags)
+		}
+	}
+
+	// Invariant 3: exactly the two diskful replicas remain (no spare to
+	// host a fresh witness — n1/n2 are diskful, n3 is evicted).
+	if len(all) != 2 {
+		t.Fatalf("Bug 385: replica count=%d, want 2 (both diskful, no stranded/relocated witness); entries=%v",
+			len(all), all)
+	}
+
+	diskful, diskless, witness := classifyReplicas(all)
+	if diskful != 2 || diskless != 0 || witness != 0 {
+		t.Errorf("Bug 385: composition diskful=%d diskless=%d witness=%d, want 2/0/0; entries=%v",
+			diskful, diskless, witness, all)
+	}
+}
+
+// TestBug385EvictTiebreakerNodeRelocatesWitnessToSpare extends the repro
+// with a spare healthy node (n4). Evicting the witness node (n3) must
+// relocate the witness onto the spare — not leave it stranded on the
+// drained node and not demote a healthy diskful.
+//
+// Expected convergence: n1 + n2 diskful, witness lands on n4, nothing on
+// the EVICTED n3.
+func TestBug385EvictTiebreakerNodeRelocatesWitnessToSpare(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n2", "n4"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n3", Type: apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed n3 (evicted): %v", err)
+	}
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug385b", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	// Witness stranded on the evicted n3.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-bug385b", NodeName: "n3",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed n3 witness: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug385b"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	all, err := st.Resources().ListByDefinition(ctx, "pvc-bug385b")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	// The stranded witness on the EVICTED n3 must be gone.
+	if _, err := st.Resources().Get(ctx, "pvc-bug385b", "n3"); err == nil {
+		t.Errorf("Bug 385: witness still on EVICTED n3; entries=%v", all)
+	}
+
+	// The witness must have relocated to the healthy spare n4.
+	n4, err := st.Resources().Get(ctx, "pvc-bug385b", "n4")
+	if err != nil {
+		t.Fatalf("Bug 385: witness did not relocate to healthy spare n4: %v; entries=%v", err, all)
+	}
+
+	if !slices.Contains(n4.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("Bug 385: relocated replica on n4 lacks TIE_BREAKER flag; flags=%v", n4.Flags)
+	}
+
+	// Diskful replicas untouched.
+	for _, n := range []string{"n1", "n2"} {
+		got, getErr := st.Resources().Get(ctx, "pvc-bug385b", n)
+		if getErr != nil {
+			t.Fatalf("Bug 385: diskful on %s vanished: %v", n, getErr)
+		}
+
+		if slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) ||
+			slices.Contains(got.Flags, apiv1.ResourceFlagDiskless) {
+			t.Errorf("Bug 385: healthy diskful on %s changed class; flags=%v", n, got.Flags)
+		}
+	}
+
+	diskful, diskless, witness := classifyReplicas(all)
+	if diskful != 2 || diskless != 0 || witness != 1 {
+		t.Errorf("Bug 385: composition diskful=%d diskless=%d witness=%d, want 2/0/1; entries=%v",
+			diskful, diskless, witness, all)
+	}
+}
+
+// TestBug385EvictDiskfulNodeDoesNotCountStrandedDiskful pins the other
+// half of the bug: evicting a DISKFUL node must not let its stranded
+// diskful replica keep the witness invariant satisfied. Topology: n1 + n2
+// diskful + n3 witness, then evict n2 (a diskful node). With n2's diskful
+// no longer counted, the live diskful count drops to 1 and the orphaned
+// witness on n3 must collapse (Bug-338 carve-out, now reached via the
+// disabled-node filter) — the lone diskful runs quorum=off. Crucially,
+// the witness on n3 is NOT promoted/demoted onto a healthy diskful.
+func TestBug385EvictDiskfulNodeDoesNotCountStrandedDiskful(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// n2 is the evicted DISKFUL node.
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n2", Type: apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed n2 (evicted): %v", err)
+	}
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug385c", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-bug385c", NodeName: "n3",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed n3 witness: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug385c"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// The lone live diskful on n1 must survive, still diskful.
+	n1, err := st.Resources().Get(ctx, "pvc-bug385c", "n1")
+	if err != nil {
+		t.Fatalf("Bug 385: live diskful on n1 vanished: %v", err)
+	}
+
+	if slices.Contains(n1.Flags, apiv1.ResourceFlagTieBreaker) ||
+		slices.Contains(n1.Flags, apiv1.ResourceFlagDiskless) {
+		t.Errorf("Bug 385: healthy diskful on n1 changed class; flags=%v", n1.Flags)
+	}
+
+	// The orphaned witness on n3 must collapse — live diskful dropped to
+	// 1, no user-diskless, so the witness is meaningless.
+	if _, err := st.Resources().Get(ctx, "pvc-bug385c", "n3"); err == nil {
+		t.Errorf("Bug 385: orphaned witness on n3 survived after evicting the second diskful")
+	}
+
+	// The stranded diskful on the EVICTED n2 is the NodeReconciler's
+	// migration responsibility — the witness path must leave it alone.
+	if _, err := st.Resources().Get(ctx, "pvc-bug385c", "n2"); err != nil {
+		t.Errorf("Bug 385: witness path must not delete the stranded diskful on EVICTED n2: %v", err)
+	}
+}

--- a/internal/controller/ensure_tiebreaker_inactive_bug_387_test.go
+++ b/internal/controller/ensure_tiebreaker_inactive_bug_387_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestBug387InactiveReplicaNotCountedAsVotingDiskful pins the Bug 387
+// fix: an INACTIVE replica (`drbdadm down`) is NOT a voting peer in the
+// DRBD quorum, so the auto-tiebreaker policy must not count it as a
+// diskful replica.
+//
+// Repro (operator-level): an RD with 2 active diskful + 1 INACTIVE
+// diskful. The operator runs `linstor r d <one-of-the-active-diskful>`,
+// leaving 1 active diskful + 1 INACTIVE diskful. Before the fix the
+// reconciler saw "2 diskful, 0 non-witness diskless, even parity" and
+// spuriously grew a TIE_BREAKER witness (1 active diskful + 1 witness =
+// 2 votes, no majority protection) — diverging from upstream LINSTOR,
+// which simply deletes the replica with no witness conversion.
+//
+// Post-fit invariant: the INACTIVE replica is dropped from the voting
+// set, leaving exactly 1 voting diskful → no witness, quorum "off".
+func TestBug387InactiveReplicaNotCountedAsVotingDiskful(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	// Three satellites; worker-1 holds the INACTIVE replica, worker-3
+	// the surviving active diskful, worker-2 is the now-free node the
+	// buggy reconciler would have picked as the spurious witness.
+	for _, n := range []string{"worker-1", "worker-2", "worker-3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// worker-1: INACTIVE diskful (operator-deactivated, not voting).
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "test1", NodeName: "worker-1",
+		Flags: []string{apiv1.ResourceFlagInactive},
+	}); err != nil {
+		t.Fatalf("seed inactive replica: %v", err)
+	}
+
+	// worker-3: surviving active diskful (the only voting peer).
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "test1", NodeName: "worker-3",
+	}); err != nil {
+		t.Fatalf("seed active replica: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// No witness must have been auto-added on any node — the topology
+	// has only 1 voting diskful, so a TIE_BREAKER would be a useless
+	// 2-voter quorum with no majority.
+	replicas, err := st.Resources().ListByDefinition(ctx, "test1")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if len(replicas) != 2 {
+		t.Fatalf("replica count: got %d, want 2 (inactive + active, no witness); replicas=%v",
+			len(replicas), replicas)
+	}
+
+	for i := range replicas {
+		for _, f := range replicas[i].Flags {
+			if f == apiv1.ResourceFlagTieBreaker {
+				t.Errorf("spurious TIE_BREAKER witness created on %s; an INACTIVE replica must not be counted as a voting diskful",
+					replicas[i].NodeName)
+			}
+		}
+	}
+
+	// worker-2 (the free node) must stay empty — the buggy reconciler
+	// converted the deleted diskful's freed node into a witness.
+	if _, err := st.Resources().Get(ctx, "test1", "worker-2"); err == nil {
+		t.Errorf("unexpected witness on worker-2 — the deleted diskful must not be converted into a tiebreaker")
+	}
+
+	// quorum prop must be "off": 1 voting diskful can never reach
+	// majority, so the controller writes "off" to match DRBD reality.
+	final := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "test1"}, final); err != nil {
+		t.Fatalf("Get RD: %v", err)
+	}
+
+	if final.Spec.Props["DrbdOptions/Resource/quorum"] != "off" {
+		t.Errorf("quorum prop: got %q, want off (1 voting diskful + 1 inactive)",
+			final.Spec.Props["DrbdOptions/Resource/quorum"])
+	}
+}
+
+// TestBug387TwoActiveDiskfulStillGetWitness is the positive control for
+// the Bug 387 fix: dropping INACTIVE replicas from the voting set must
+// NOT regress the canonical auto-witness invariant. An RD with 2 active
+// diskful (no INACTIVE flag) plus a third INACTIVE replica must still
+// grow a witness — the two active peers are a genuine even-parity
+// quorum that needs the third voter.
+func TestBug387TwoActiveDiskfulStillGetWitness(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"worker-1", "worker-2", "worker-3", "worker-4"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// Two active diskful peers — a real even-parity quorum.
+	for _, n := range []string{"worker-2", "worker-3"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "test2", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed active replica %s: %v", n, err)
+		}
+	}
+
+	// An INACTIVE replica that must be ignored by the policy.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "test2", NodeName: "worker-1",
+		Flags: []string{apiv1.ResourceFlagInactive},
+	}); err != nil {
+		t.Fatalf("seed inactive replica: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test2"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// Witness landed on worker-4 (the only free, non-diskful,
+	// non-inactive node — worker-1 is excluded because it hosts a
+	// replica row).
+	got, err := st.Resources().Get(ctx, "test2", "worker-4")
+	if err != nil {
+		t.Fatalf("witness not created on worker-4: %v", err)
+	}
+
+	hasTB := false
+
+	for _, f := range got.Flags {
+		if f == apiv1.ResourceFlagTieBreaker {
+			hasTB = true
+
+			break
+		}
+	}
+
+	if !hasTB {
+		t.Errorf("witness must carry TIE_BREAKER flag; got %v", got.Flags)
+	}
+
+	final := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "test2"}, final); err != nil {
+		t.Fatalf("Get RD: %v", err)
+	}
+
+	if final.Spec.Props["DrbdOptions/Resource/quorum"] != "majority" {
+		t.Errorf("quorum prop: got %q, want majority (2 active diskful + witness)",
+			final.Spec.Props["DrbdOptions/Resource/quorum"])
+	}
+}

--- a/internal/controller/ensure_tiebreaker_test.go
+++ b/internal/controller/ensure_tiebreaker_test.go
@@ -20,6 +20,7 @@ package controller_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -1372,5 +1373,232 @@ func TestEnsureTiebreakerRelocateOntoTiebreakerConverges(t *testing.T) {
 	// node), not back on n3 (the diskful relocate target).
 	if _, err := st.Resources().Get(ctx, rdName, "n2"); err != nil {
 		t.Errorf("witness should land on freed n2; got error %v", err)
+	}
+}
+
+// TestBug386NodeRestoreRecreatesTiebreaker pins the Bug 386 fix: after
+// a node is restored with `linstor n rst`, a 2-diskful resource in a
+// 3-node cluster must re-gain its DISKLESS TIE_BREAKER witness.
+//
+// Repro shape (verbatim operator report): a 3-node cluster runs a
+// 2-diskful RD (n1, n2) whose witness collapsed while n3 was drained
+// (EVICTED). `pickTiebreakerNode` / `isDisabledNode` exclude an
+// EVICTED node, so while n3 carried the flag the only candidate
+// witness host was gone and ensureTiebreaker left the RD at two
+// diskful UpToDate replicas with no witness — a quorum/split-brain
+// hazard on a subsequent failure.
+//
+// `linstor n rst n3` clears the EVICTED flag. The fix wires a Node
+// watch (nodeDrainFlagChanged → enqueueRDsForNode) so the restore
+// re-enqueues the RD and ensureTiebreaker re-runs. This test pins the
+// reconcile-level outcome: with EVICTED cleared, the witness must be
+// (re)placed on n3 so the resource regains the diskful+diskful+TB
+// shape upstream LINSTOR maintains for quorum=majority.
+func TestBug386NodeRestoreRecreatesTiebreaker(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	// 3-node cluster; n3 is currently EVICTED (drained), so it is not
+	// a viable witness candidate.
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name: "n3", Type: apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed evicted node n3: %v", err)
+	}
+
+	// 2 diskful replicas on n1 + n2, NO witness — the collapsed shape
+	// the operator observed while n3 was drained.
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug386", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug386"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	// Pre-restore sanity: with n3 EVICTED, ensureTiebreaker cannot
+	// place a witness (no viable candidate node). The RD stays at 2
+	// diskful, 0 witness — the exact hazard Bug 386 reports.
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("pre-restore EnsureTiebreaker: %v", err)
+	}
+
+	pre, err := st.Resources().ListByDefinition(ctx, "pvc-bug386")
+	if err != nil {
+		t.Fatalf("list pre-restore: %v", err)
+	}
+
+	_, _, preWitness := classifyReplicas(pre)
+	if preWitness != 0 {
+		t.Fatalf("pre-restore: witness=%d, want 0 (n3 EVICTED, no candidate); entries=%v",
+			preWitness, pre)
+	}
+
+	// Operator runs `linstor n rst n3`: the REST handler clears the
+	// EVICTED flag on the Node. Simulate that store mutation.
+	n3, err := st.Nodes().Get(ctx, "n3")
+	if err != nil {
+		t.Fatalf("get n3: %v", err)
+	}
+
+	n3.Flags = nil
+	if err := st.Nodes().Update(ctx, &n3); err != nil {
+		t.Fatalf("restore n3 (clear EVICTED): %v", err)
+	}
+
+	// The Node watch re-enqueues the RD; ensureTiebreaker re-runs.
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("post-restore EnsureTiebreaker: %v", err)
+	}
+
+	post, err := st.Resources().ListByDefinition(ctx, "pvc-bug386")
+	if err != nil {
+		t.Fatalf("list post-restore: %v", err)
+	}
+
+	diskful, diskless, witness := classifyReplicas(post)
+
+	if diskful != 2 {
+		t.Errorf("post-restore: diskful=%d, want 2; entries=%v", diskful, post)
+	}
+
+	if diskless != 0 {
+		t.Errorf("post-restore: plain diskless=%d, want 0; entries=%v", diskless, post)
+	}
+
+	if witness != 1 {
+		t.Fatalf("Bug 386: post-restore witness=%d, want 1 (TB recreated after n rst); entries=%v",
+			witness, post)
+	}
+
+	// The recreated witness must land on the restored n3 — the only
+	// non-diskful candidate now that EVICTED is cleared.
+	tb, err := st.Resources().Get(ctx, "pvc-bug386", "n3")
+	if err != nil {
+		t.Fatalf("Bug 386: witness not on restored n3: %v", err)
+	}
+
+	if !slices.Contains(tb.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("Bug 386: n3 replica must carry TIE_BREAKER; flags=%v", tb.Flags)
+	}
+}
+
+// TestBug386NodeHasDrainFlag pins the EVICTED/LOST flag-set probe that
+// gates the Bug-386 Node watch. The predicate fires only when this
+// membership changes, so it must read both Spec (operator intent) and
+// Status (satellite-observed) flags and ignore unrelated values.
+func TestBug386NodeHasDrainFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		node *blockstoriov1alpha1.Node
+		want bool
+	}{
+		{
+			name: "no flags",
+			node: &blockstoriov1alpha1.Node{},
+			want: false,
+		},
+		{
+			name: "spec EVICTED",
+			node: &blockstoriov1alpha1.Node{
+				Spec: blockstoriov1alpha1.NodeSpec{Flags: []string{apiv1.NodeFlagEvicted}},
+			},
+			want: true,
+		},
+		{
+			name: "spec LOST",
+			node: &blockstoriov1alpha1.Node{
+				Spec: blockstoriov1alpha1.NodeSpec{Flags: []string{apiv1.NodeFlagLost}},
+			},
+			want: true,
+		},
+		{
+			name: "status EVICTED",
+			node: &blockstoriov1alpha1.Node{
+				Status: blockstoriov1alpha1.NodeStatus{Flags: []string{apiv1.NodeFlagEvicted}},
+			},
+			want: true,
+		},
+		{
+			name: "unrelated flag",
+			node: &blockstoriov1alpha1.Node{
+				Spec: blockstoriov1alpha1.NodeSpec{Flags: []string{"STANDBY"}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := controllerpkg.NodeHasDrainFlag(tc.node); got != tc.want {
+				t.Errorf("NodeHasDrainFlag(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBug386EnqueueRDsForNode pins the Node-watch fan-out: a node
+// flag-change event must re-enqueue EVERY ResourceDefinition in the
+// cluster so each RD's tiebreaker invariant re-evaluates against the
+// recovered candidate set. The tiebreaker is a cluster-wide
+// candidate-set decision, so the mapper is intentionally RD-agnostic.
+func TestBug386EnqueueRDsForNode(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	ctx := context.Background()
+
+	rdA := &blockstoriov1alpha1.ResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "rd-a"}}
+	rdB := &blockstoriov1alpha1.ResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "rd-b"}}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rdA, rdB).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{Client: cli, Scheme: scheme, Store: store.NewInMemory()}
+
+	reqs := rec.EnqueueRDsForNode(ctx, &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n3"},
+	})
+
+	if len(reqs) != 2 {
+		t.Fatalf("enqueueRDsForNode: got %d requests, want 2 (one per RD); reqs=%v", len(reqs), reqs)
+	}
+
+	got := map[string]bool{}
+	for _, req := range reqs {
+		got[req.Name] = true
+	}
+
+	for _, want := range []string{"rd-a", "rd-b"} {
+		if !got[want] {
+			t.Errorf("enqueueRDsForNode: missing RD %q in fan-out; reqs=%v", want, reqs)
+		}
 	}
 }

--- a/internal/controller/export_test.go
+++ b/internal/controller/export_test.go
@@ -46,6 +46,21 @@ func (r *ResourceDefinitionReconciler) EnqueueRDForResource(ctx context.Context,
 	return r.enqueueRDForResource(ctx, obj)
 }
 
+// EnqueueRDsForNode exposes the Bug-386 Node-watch fan-out for tests.
+// Production wiring stays unexported via SetupWithManager. Pins the
+// "node flag toggle re-enqueues every RD" contract that recreates a
+// collapsed tiebreaker after `linstor n rst`.
+func (r *ResourceDefinitionReconciler) EnqueueRDsForNode(ctx context.Context, obj client.Object) []reconcile.Request {
+	return r.enqueueRDsForNode(ctx, obj)
+}
+
+// NodeHasDrainFlag exposes the EVICTED/LOST flag-set probe the Bug-386
+// Node-watch predicate uses to decide whether a Node event is a drain
+// transition worth re-enqueueing RDs for.
+func NodeHasDrainFlag(n *blockstoriov1alpha1.Node) bool {
+	return nodeHasDrainFlag(n)
+}
+
 // AlreadyExists exposes the wrapped-error keyword check the RD
 // reconciler uses to tolerate kube-apiserver "already exists"
 // races. Tests pin both the positive and the false-positive paths.

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -1312,8 +1312,110 @@ func (r *ResourceDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Watches(&blockstoriov1alpha1.Resource{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueRDForResource),
 			builder.WithPredicates(resourceEventFilter)).
+		// Bug 386: re-run the tiebreaker invariant when a node's
+		// EVICTED / LOST flag set changes. `linstor n rst` clears
+		// EVICTED on a recovered node; `linstor n evacuate` sets it.
+		// `ensureTiebreaker` (and pickTiebreakerNode) treat an
+		// EVICTED/LOST node as an unusable witness candidate, so a
+		// 2-diskful RD whose witness collapsed while a node was drained
+		// must re-place the TIE_BREAKER once the node returns. Without
+		// this watch nothing enqueues the RD on a node-flag toggle and
+		// the witness is only (re)placed on the next periodic re-sync —
+		// leaving two diskful UpToDate replicas with no quorum witness
+		// in between (split-brain risk on a subsequent failure). The
+		// nodeDrainFlagChanged predicate filters to the flag transition
+		// so unrelated Node Spec edits (props, net-interfaces) don't
+		// fan out to every RD.
+		Watches(&blockstoriov1alpha1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueRDsForNode),
+			builder.WithPredicates(nodeDrainFlagChanged())).
 		Named("resourcedefinition").
 		Complete(r)
+}
+
+// nodeDrainFlagChanged fires only when a Node's drain-signal flag set
+// (EVICTED / LOST) transitions. The REST `n rst` / `n evacuate` /
+// `n lost` handlers stamp these onto `Spec.Flags`; the satellite also
+// re-applies Node Spec on every reconcile with the flag set unchanged,
+// so a bare generation/Spec-equality watch would fan out to every RD
+// on every heartbeat. Restricting to the EVICTED/LOST membership delta
+// keeps the Bug 386 re-enqueue precise.
+//
+// Create fires when the node already carries a drain flag (controller
+// restart re-reads existing state) so the witness invariant runs at
+// least once against the recovered topology.
+func nodeDrainFlagChanged() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			n, ok := e.Object.(*blockstoriov1alpha1.Node)
+			if !ok {
+				return false
+			}
+
+			return nodeHasDrainFlag(n)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, ok := e.ObjectOld.(*blockstoriov1alpha1.Node)
+			if !ok {
+				return false
+			}
+
+			newNode, ok := e.ObjectNew.(*blockstoriov1alpha1.Node)
+			if !ok {
+				return false
+			}
+
+			return nodeHasDrainFlag(oldNode) != nodeHasDrainFlag(newNode)
+		},
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
+// nodeHasDrainFlag reports whether a Node CRD carries an EVICTED or
+// LOST flag on either Spec (operator intent, set by the REST handlers)
+// or Status (satellite-observed). Mirrors isDisabledNode's flag set so
+// the watch predicate and the witness-candidate filter agree on what
+// "drained" means.
+func nodeHasDrainFlag(n *blockstoriov1alpha1.Node) bool {
+	for _, f := range n.Spec.Flags {
+		if f == apiv1.NodeFlagEvicted || f == apiv1.NodeFlagLost {
+			return true
+		}
+	}
+
+	for _, f := range n.Status.Flags {
+		if f == apiv1.NodeFlagEvicted || f == apiv1.NodeFlagLost {
+			return true
+		}
+	}
+
+	return false
+}
+
+// enqueueRDsForNode maps a Node flag-change event to every
+// ResourceDefinition in the cluster. The tiebreaker invariant is a
+// cluster-wide candidate-set decision (any RD's witness might have
+// collapsed onto, or now want to re-land on, the toggled node), so a
+// per-node restore re-evaluates all RDs. The set of RDs is small
+// relative to Resources, and the nodeDrainFlagChanged predicate gates
+// the fan-out to genuine EVICTED/LOST transitions, so this stays cheap.
+func (r *ResourceDefinitionReconciler) enqueueRDsForNode(ctx context.Context, _ client.Object) []reconcile.Request {
+	var rdList blockstoriov1alpha1.ResourceDefinitionList
+
+	err := r.List(ctx, &rdList)
+	if err != nil {
+		return nil
+	}
+
+	out := make([]reconcile.Request, 0, len(rdList.Items))
+	for i := range rdList.Items {
+		out = append(out, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rdList.Items[i].Name},
+		})
+	}
+
+	return out
 }
 
 // enqueueRDForResource maps a Resource event to its parent RD.

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -223,7 +223,30 @@ func (r *ResourceDefinitionReconciler) ensureTiebreaker(ctx context.Context, rd 
 		return err
 	}
 
-	diskful, diskless := splitByDiskless(replicas)
+	// Bug 385: a replica hosted on an EVICTED / LOST node is a draining
+	// placement, not a live one. Counting it would (a) let a stranded
+	// diskful keep the witness invariant "satisfied" so the reconciler
+	// never relocates the witness off the drained node, and (b) leave a
+	// TIE_BREAKER pinned to the very node the operator just evicted —
+	// the exact "evict doesn't take effect" symptom. Mirror the placer's
+	// documented semantic ("replicas on EVICTED/LOST nodes are NOT
+	// counted") so the witness / quorum decision runs over live replicas
+	// only. Stranded witnesses are reaped explicitly below so a fresh one
+	// can land on a healthy spare (or quorum falls to off when none
+	// remains) — never by demoting a healthy diskful to TIE_BREAKER.
+	disabled, err := r.disabledNodeSet(ctx)
+	if err != nil {
+		return err
+	}
+
+	live, stranded := splitByDisabledNode(replicas, disabled)
+
+	err = r.removeStrandedWitnesses(ctx, rd.Name, stranded)
+	if err != nil {
+		return err
+	}
+
+	diskful, diskless := splitByDiskless(live)
 	witness := filterTieBreaker(diskless)
 
 	wantWitness := shouldTieBreakerExist(rd, diskful, diskless, witness)
@@ -1154,6 +1177,74 @@ func isDisabledNode(node *apiv1.Node) bool {
 	}
 
 	return false
+}
+
+// disabledNodeSet returns the set of node names flagged EVICTED / LOST.
+// Bug 385: the RD-level witness / quorum decision must treat replicas on
+// these nodes as draining placements, not live ones — mirroring the
+// placer's `disabledNodes` semantic. Re-probed from the store on every
+// reconcile so a freshly-stamped EVICTED flag takes effect on the next
+// witness pass.
+func (r *ResourceDefinitionReconciler) disabledNodeSet(ctx context.Context) (map[string]struct{}, error) {
+	nodes, err := r.Store.Nodes().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	disabled := make(map[string]struct{})
+
+	for i := range nodes {
+		if isDisabledNode(&nodes[i]) {
+			disabled[nodes[i].Name] = struct{}{}
+		}
+	}
+
+	return disabled, nil
+}
+
+// splitByDisabledNode partitions replicas into (live, stranded) by the
+// disabled-node set. `live` is hosted on healthy (non-EVICTED/-LOST)
+// nodes and drives the witness / quorum decision; `stranded` sits on a
+// draining node and is handled separately (Bug 385).
+func splitByDisabledNode(replicas []apiv1.Resource, disabled map[string]struct{}) ([]apiv1.Resource, []apiv1.Resource) {
+	var live, stranded []apiv1.Resource
+
+	for i := range replicas {
+		if _, off := disabled[replicas[i].NodeName]; off {
+			stranded = append(stranded, replicas[i])
+
+			continue
+		}
+
+		live = append(live, replicas[i])
+	}
+
+	return live, stranded
+}
+
+// removeStrandedWitnesses deletes every TIE_BREAKER witness that sits on
+// an EVICTED / LOST node (Bug 385). A diskless witness has no business
+// remaining on a drained node — leaving it there pins the witness to the
+// very node the operator evicted and blocks a fresh witness from landing
+// on a healthy spare. Diskful replicas on disabled nodes are intentionally
+// left alone here: relocating / deleting those is the NodeReconciler's job
+// (placer gap-fill for EVICTED, source-delete for LOST), and dropping a
+// diskful's only data copy from this path would be a data-availability
+// hazard. Per-row Delete tolerates NotFound so a concurrent
+// node-migration cascade can't fail the reconcile.
+func (r *ResourceDefinitionReconciler) removeStrandedWitnesses(ctx context.Context, rdName string, stranded []apiv1.Resource) error {
+	for i := range stranded {
+		if !slices.Contains(stranded[i].Flags, apiv1.ResourceFlagTieBreaker) {
+			continue
+		}
+
+		err := r.Store.Resources().Delete(ctx, rdName, stranded[i].NodeName)
+		if err != nil && !stderrors.Is(err, store.ErrNotFound) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // alreadyExists is a string-based check for the wrapped errors the

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -223,6 +223,18 @@ func (r *ResourceDefinitionReconciler) ensureTiebreaker(ctx context.Context, rd 
 		return err
 	}
 
+	// Bug 387: an INACTIVE replica is `drbdadm down` (operator
+	// deactivation) — its DRBD device is not up, so it is NOT a voting
+	// peer in the quorum the auto-tiebreaker invariant defends. Counting
+	// it as a diskful replica corrupts every downstream witness decision:
+	// e.g. an RD with 2 active diskful + 1 INACTIVE diskful, after an
+	// `r d` of one active diskful, would otherwise look like "2 diskful,
+	// nonWitnessDiskless==0, even" and spuriously grow a TIE_BREAKER —
+	// upstream LINSTOR just deletes the replica with no witness. Drop
+	// INACTIVE replicas from the voting set before the split so they
+	// influence neither the diskful count nor the diskless/witness count.
+	replicas = filterActiveReplicas(replicas)
+
 	diskful, diskless := splitByDiskless(replicas)
 	witness := filterTieBreaker(diskless)
 
@@ -1035,6 +1047,27 @@ func (r *ResourceDefinitionReconciler) removeWitnesses(ctx context.Context, rdNa
 	}
 
 	return nil
+}
+
+// filterActiveReplicas drops INACTIVE replicas from the slice. An
+// INACTIVE replica is one the operator deactivated with `drbdadm down`
+// (Bug 387): its DRBD device is not running, so it casts no vote in the
+// `quorum: majority` decision the auto-tiebreaker invariant defends.
+// The tiebreaker policy must reason only over the live voting peers, so
+// INACTIVE replicas are excluded before the diskful/diskless split —
+// they count as neither a voting diskful nor a diskless witness/peer.
+func filterActiveReplicas(replicas []apiv1.Resource) []apiv1.Resource {
+	active := make([]apiv1.Resource, 0, len(replicas))
+
+	for i := range replicas {
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagInactive) {
+			continue
+		}
+
+		active = append(active, replicas[i])
+	}
+
+	return active
 }
 
 // splitByDiskless partitions replicas into (diskful, diskless) lists.

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -2805,13 +2805,34 @@ func (r *Reconciler) ensurePerVolumeMetadata(ctx context.Context, dr *intent.Des
 // listed in `fresh`. Mirrors the loop in seedInitialGI but limits
 // touch to the volumes whose metadata was just freshly created,
 // so already-stamped sibling volumes (vol-0 in the Bug B.4
-// late-add scenario) are never re-seeded. isWinner is hard-coded
-// to false because this path runs with firstActivation=false on
-// the parent RD — the per-volume gate inside resolveVolumeSeed
-// decides which seed shape (case-A skip-init-sync, case-B
-// winner, or no-op) is appropriate via the per-volume
-// AnyConnectedPeerHasDataForVolume probe.
+// late-add scenario) are never re-seeded.
+//
+// Bug 384 (P0, regression of Bug 79/332): the late-add path runs with
+// firstActivation=false on the parent RD, so the dispatcher's
+// first-activation winner election (auto-primary, gated on
+// !rdInitialized) never fires — the RD is already Initialized by the
+// time `linstor vd c` lands. The previous code therefore passed
+// isWinner=false unconditionally, so EVERY diskful replica took the
+// case-A skip-init-sync seed (current=day0, clean bitmap, NO UpToDate
+// flag). With no replica declaring itself the UpToDate source and no
+// primary --force on this path, the freshly-carved volume came up
+// Inconsistent on ALL replicas and never converged (verbatim operator
+// repro: `vd c test 1G` → vol-1 Inconsistent on every node).
+//
+// Fix: re-run the SAME lowest-node-id winner election the dispatcher
+// runs at first activation, but locally per fresh volume. Exactly one
+// diskful replica (the lowest allocated node-id) takes the case-B
+// winner seed (Consistent+UpToDate) and becomes the SyncSource; the
+// rest take case-A. resolveVolumeSeed's per-volume
+// AnyConnectedPeerHasDataForVolume + PeerHasData vetoes still fire
+// FIRST, so a relocate / migrate-disk target (a peer already holds
+// data on this volume) never wins itself UpToDate-empty — the winner
+// seed is byte-identical to the first-activation winner and shares the
+// day0 lineage anchor, so a staggered dual election agrees rather than
+// split-brains.
 func (r *Reconciler) seedFreshVolumes(ctx context.Context, dr *intent.DesiredResource, devices map[int32]string, fresh map[int32]struct{}) error {
+	isWinner := isLateAddWinner(dr)
+
 	for _, vol := range dr.GetVolumes() {
 		if _, ok := fresh[vol.GetVolumeNumber()]; !ok {
 			continue
@@ -2822,7 +2843,7 @@ func (r *Reconciler) seedFreshVolumes(ctx context.Context, dr *intent.DesiredRes
 			continue
 		}
 
-		seed, ok := r.resolveVolumeSeed(ctx, dr.GetName(), vol, dr.GetPeerHasData(), false, dr.GetSkipInitialSync())
+		seed, ok := r.resolveVolumeSeed(ctx, dr.GetName(), vol, dr.GetPeerHasData(), isWinner, dr.GetSkipInitialSync())
 		if !ok {
 			continue
 		}
@@ -2834,6 +2855,51 @@ func (r *Reconciler) seedFreshVolumes(ctx context.Context, dr *intent.DesiredRes
 	}
 
 	return nil
+}
+
+// isLateAddWinner reports whether THIS node is the elected initial-
+// UpToDate source for a late-added volume — the lowest-node-id diskful
+// replica, the same election the dispatcher runs at first activation
+// (lowestDiskfulID). It returns true iff this node's allocated DRBD
+// node-id is strictly the lowest among the local node-id and every
+// peer's allocated node-id.
+//
+// Why local (not auto-primary): the dispatcher only stamps the
+// auto-primary winner flag on a NOT-yet-Initialized RD (Bug 356 /
+// respawn-StandAlone guard). A `linstor vd c` always lands AFTER the RD
+// is Initialized, so no replica carries auto-primary on this path and
+// isInitialUpToDateWinner can never elect one. Recomputing the election
+// from the node-id set the dispatcher already rendered into the wire
+// payload restores the missing winner without re-arming the unsafe
+// respawn-time auto-primary.
+//
+// Deterministic + split-brain-safe: node-id is stable across reconciles
+// so the SAME replica wins every pass, and the strict-lowest comparison
+// elects EXACTLY ONE node. Peers whose node-id is not yet allocated
+// (NodeID==nil) are skipped — the election waits implicitly for the
+// next reconcile once every peer id is stamped, the same shape
+// diskfulPeersAllocated enforces on the dispatcher side. The result is
+// only ever consumed by resolveVolumeSeed AFTER its PeerHasData /
+// AnyConnectedPeerHasDataForVolume vetoes, so a winner verdict on a
+// volume whose peer already holds data is suppressed before it can
+// seed.
+func isLateAddWinner(dr *intent.DesiredResource) bool {
+	localID, ok := localNodeIDFromOpts(dr)
+	if !ok {
+		return false
+	}
+
+	for _, peer := range dr.GetPeers() {
+		if peer.NodeID == nil {
+			continue
+		}
+
+		if *peer.NodeID <= localID {
+			return false
+		}
+	}
+
+	return true
 }
 
 // createMDWithCollisionRecovery wraps Adm.CreateMD with a one-shot

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -2881,6 +2881,276 @@ func TestApplyDRBDAllocatesBackingForLateAddedVolume(t *testing.T) {
 	}
 }
 
+// TestApplyLateAddedVolumeWinnerSeedsUpToDate pins Bug 384 (P0, data
+// integrity — regression of Bug 79/332): when `linstor vd c <rd> 1G`
+// adds vol-1 to a multi-replica RD whose vol-0 already reached
+// UpToDate, the lowest-node-id diskful replica MUST seed the new
+// volume Consistent+UpToDate (the case-B winner shape) so it converges
+// — NOT take the case-A skip-init-sync seed (clean bitmap, no UpToDate
+// flag), which leaves the new volume Inconsistent on EVERY replica
+// with no SyncSource to recover from.
+//
+// Root cause: the late-add seed path runs with firstActivation=false
+// on the parent RD (the RD is already Initialized by the time the
+// `vd c` lands), so the dispatcher's first-activation auto-primary
+// winner election never fires. seedFreshVolumes previously passed
+// isWinner=false unconditionally → every replica took case-A → no
+// UpToDate authority → vol-1 latched Inconsistent forever (verbatim
+// operator repro on a 2-diskful lvm-thin RD).
+//
+// The fix recomputes the lowest-node-id election locally per fresh
+// volume (isLateAddWinner). This fixture is the lowest-id node
+// (local node-id 0, peer node-id 1) so it is the elected winner: its
+// vol-1 set-gi MUST carry the positional Consistent(idx4=1)+
+// UpToDate(idx5=1) flags at current=day0. vol-0's metadata MUST NOT be
+// re-seeded (HasMD=true short-circuits create-md, so it never enters
+// the fresh-seed set).
+func TestApplyLateAddedVolumeWinnerSeedsUpToDate(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	// vol-0 already provisioned (idempotent lvs short-circuit).
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-win_00000",
+		storage.FakeResponse{Stdout: []byte("pvc-late-win_00000\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-win_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-win_00000|1048576\n")})
+
+	// vol-1 is NEW — lvs reports nothing, CreateVolume lvcreates it,
+	// then the path read returns the freshly-carved LV.
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-win_00001",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-win_00001",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-win_00001|1048576\n")})
+
+	// Per-volume HasMD probe: vol-0 stamped, vol-1 missing.
+	fx.Expect("drbdadm dump-md pvc-late-win/0",
+		storage.FakeResponse{Stdout: []byte("version \"v09\";\nla-size-sect 2048;\n")})
+	fx.Expect("drbdadm dump-md pvc-late-win/1",
+		storage.FakeResponse{Err: errDrbdadmDumpMdNoMeta})
+
+	// Per-volume create-md for vol-1 only.
+	fx.Expect(fmt.Sprintf("drbdadm create-md --force --max-peers=%d pvc-late-win/1", drbd.MaxPeers-1),
+		storage.FakeResponse{})
+
+	// Kernel slot already loaded (vol-0 UpToDate). drbdsetup status
+	// (no --json) drives FSM dispatch; the --json variant
+	// AnyConnectedPeerHasDataForVolume probes returns empty → "no peer
+	// holds data for vol-1" → the seed proceeds.
+	fx.Expect("drbdsetup status pvc-late-win",
+		storage.FakeResponse{Stdout: []byte("pvc-late-win role:Secondary\n  volume:0 disk:UpToDate\n")})
+	fx.Expect("drbdsetup status --verbose pvc-late-win",
+		storage.FakeResponse{Stdout: []byte("pvc-late-win role:Secondary\n  volume:0 disk:UpToDate\n")})
+
+	fx.Expect("drbdadm adjust pvc-late-win", storage.FakeResponse{})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thin1": thin},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	// Steady state: single-volume .res + md-created marker from the
+	// first-activation pass, the on-disk shape when `vd c` lands.
+	resPath := filepath.Join(dir, "pvc-late-win.res")
+	if err := os.WriteFile(resPath, []byte("resource pvc-late-win {\n  on n1 {\n    volume 0 {\n    }\n  }\n}\n"), 0o600); err != nil {
+		t.Fatalf("seed .res: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pvc-late-win.md-created"), nil, 0o600); err != nil {
+		t.Fatalf("seed md-created: %v", err)
+	}
+
+	// 2-diskful RD: local n1 node-id 0 (the lowest → late-add winner),
+	// peer n2 node-id 1. MetadataCreated=true (RD already Initialized),
+	// SkipInitialSync=true (replicas were stamped pre-init), late-add
+	// vol-1. This is the exact wire shape the operator repro produced.
+	peerID := int32(1)
+	dr := []*intent.DesiredResource{
+		{
+			Name:            "pvc-late-win",
+			NodeName:        "n1",
+			MetadataCreated: true,
+			SkipInitialSync: skipInitTrue(),
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+				{VolumeNumber: 1, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			Peers: []intent.DesiredPeer{{Name: "n2", NodeID: &peerID}},
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+				"peer.n2.address": "10.0.0.2", "peer.n2.node-id": "1", "peer.n2.port": "7000",
+			},
+		},
+	}
+
+	results, err := rec.Apply(t.Context(), dr)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].GetOk() {
+		t.Fatalf("Apply: expected Ok=true; got results=%+v", results)
+	}
+
+	calls := fx.CommandLines()
+	day0 := satellite.Day0GiForTest("pvc-late-win", 1)
+
+	// THE FIX: vol-1's local-slot set-gi MUST carry the winner shape —
+	// current=day0, Consistent(idx4=1)+UpToDate(idx5=1). The set-gi
+	// target is `<rd>/1` (vol-1 only); vol-0 is never re-seeded.
+	var vol1LocalSlot string
+
+	for _, line := range calls {
+		if strings.Contains(line, "pvc-late-win/1 ") && strings.Contains(line, "set-gi --node-id 0 ") {
+			vol1LocalSlot = line
+		}
+	}
+
+	if vol1LocalSlot == "" {
+		t.Fatalf("Bug 384: late-added vol-1 got NO winner set-gi on the lowest-id local slot — it would latch Inconsistent forever; cmds=%v", calls)
+	}
+
+	fields := strings.Fields(vol1LocalSlot)
+	gi := fields[len(fields)-1]
+	parts := strings.Split(gi, ":")
+
+	if len(parts) < 6 {
+		t.Fatalf("late-add winner vol-1 slot must carry positional consistent+uptodate flags; got %q", gi)
+	}
+
+	if parts[0] != day0 {
+		t.Errorf("late-add winner vol-1 current-UUID must equal day0 (shared lineage); got current=%s day0=%s", parts[0], day0)
+	}
+
+	if parts[1] != "0" {
+		t.Errorf("late-add winner vol-1 bitmap-base must be empty (0 = bitmap-uuid 0x0); got base=%s", parts[1])
+	}
+
+	if parts[4] != "1" || parts[5] != "1" {
+		t.Errorf("Bug 384: late-add winner vol-1 slot must be Consistent(idx4=1)+UpToDate(idx5=1); got %q — vol-1 would come up Inconsistent on every replica", gi)
+	}
+
+	// vol-0's metadata MUST NOT be touched by the late-add seed — it is
+	// HasMD=true, so it never joins the fresh-seed set. A set-gi against
+	// `<rd>/0` would wipe vol-0's live GI + bitmap state.
+	for _, line := range calls {
+		if strings.Contains(line, "pvc-late-win/0 ") && strings.Contains(line, "set-gi") {
+			t.Errorf("late-add seed re-stamped vol-0 GI (would wipe its live metadata): %s", line)
+		}
+	}
+}
+
+// TestApplyLateAddedVolumeNonWinnerTakesSkipInitSync pins the
+// complementary Bug 384 invariant: a late-add replica that is NOT the
+// lowest node-id (a peer holds a lower id) MUST take the case-A
+// skip-init-sync seed (current=day0, clean bitmap, NO UpToDate flag),
+// never the winner seed. Exactly one replica wins; the rest SyncTarget
+// from it. Here local n1 is node-id 2 with peers at 0 and 1, so n1 is
+// NOT the winner.
+func TestApplyLateAddedVolumeNonWinnerTakesSkipInitSync(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-lose_00000",
+		storage.FakeResponse{Stdout: []byte("pvc-late-lose_00000\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-lose_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-lose_00000|1048576\n")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-late-lose_00001",
+		storage.FakeResponse{Stdout: []byte("")})
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-late-lose_00001",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-late-lose_00001|1048576\n")})
+	fx.Expect("drbdadm dump-md pvc-late-lose/0",
+		storage.FakeResponse{Stdout: []byte("version \"v09\";\nla-size-sect 2048;\n")})
+	fx.Expect("drbdadm dump-md pvc-late-lose/1",
+		storage.FakeResponse{Err: errDrbdadmDumpMdNoMeta})
+	fx.Expect(fmt.Sprintf("drbdadm create-md --force --max-peers=%d pvc-late-lose/1", drbd.MaxPeers-1),
+		storage.FakeResponse{})
+	fx.Expect("drbdsetup status pvc-late-lose",
+		storage.FakeResponse{Stdout: []byte("pvc-late-lose role:Secondary\n  volume:0 disk:UpToDate\n")})
+	fx.Expect("drbdsetup status --verbose pvc-late-lose",
+		storage.FakeResponse{Stdout: []byte("pvc-late-lose role:Secondary\n  volume:0 disk:UpToDate\n")})
+	fx.Expect("drbdadm adjust pvc-late-lose", storage.FakeResponse{})
+
+	thin := lvm.NewThin(lvm.ThinConfig{VolumeGroup: "vg", ThinPool: "tp"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thin1": thin},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n3",
+	})
+
+	resPath := filepath.Join(dir, "pvc-late-lose.res")
+	if err := os.WriteFile(resPath, []byte("resource pvc-late-lose {\n  on n3 {\n    volume 0 {\n    }\n  }\n}\n"), 0o600); err != nil {
+		t.Fatalf("seed .res: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pvc-late-lose.md-created"), nil, 0o600); err != nil {
+		t.Fatalf("seed md-created: %v", err)
+	}
+
+	peer0, peer1 := int32(0), int32(1)
+	dr := []*intent.DesiredResource{
+		{
+			Name:            "pvc-late-lose",
+			NodeName:        "n3",
+			MetadataCreated: true,
+			SkipInitialSync: skipInitTrue(),
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+				{VolumeNumber: 1, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+			},
+			Peers: []intent.DesiredPeer{
+				{Name: "n1", NodeID: &peer0},
+				{Name: "n2", NodeID: &peer1},
+			},
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "2", "address": "10.0.0.3", "minor": "1000",
+				"peer.n1.address": "10.0.0.1", "peer.n1.node-id": "0", "peer.n1.port": "7000",
+				"peer.n2.address": "10.0.0.2", "peer.n2.node-id": "1", "peer.n2.port": "7000",
+			},
+		},
+	}
+
+	results, err := rec.Apply(t.Context(), dr)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if len(results) != 1 || !results[0].GetOk() {
+		t.Fatalf("Apply: expected Ok=true; got results=%+v", results)
+	}
+
+	calls := fx.CommandLines()
+
+	// The non-winner still seeds vol-1 (case-A skip-init-sync) so the
+	// bitmap is clean and it SyncTargets cleanly from the winner — but
+	// the local slot MUST NOT carry the UpToDate flag, otherwise two
+	// replicas would both claim authority.
+	var vol1LocalSlot string
+
+	for _, line := range calls {
+		if strings.Contains(line, "pvc-late-lose/1 ") && strings.Contains(line, "set-gi --node-id 2 ") {
+			vol1LocalSlot = line
+		}
+	}
+
+	if vol1LocalSlot == "" {
+		t.Fatalf("non-winner late-add vol-1 must still get a case-A skip-init-sync seed on its local slot; cmds=%v", calls)
+	}
+
+	gi := strings.Fields(vol1LocalSlot)
+	tuple := gi[len(gi)-1]
+	parts := strings.Split(tuple, ":")
+
+	// Case-A seed is `<day0>:0:0:0` — only current + empty bitmap, no
+	// positional consistent/uptodate flags.
+	if len(parts) >= 6 && parts[5] == "1" {
+		t.Errorf("Bug 384 split-brain guard: non-winner late-add vol-1 MUST NOT carry UpToDate(idx5=1); got %q", tuple)
+	}
+}
+
 // TestApplyAutoPrimaryForceErrorWraps pins the auto-primary force
 // error-wrap branch of applyDRBD: when the mkfs-promote step
 // `drbdadm primary --force` fails on first activation, applyOne

--- a/tests/e2e/cli-matrix/bug-384-late-vd-thin-converges.sh
+++ b/tests/e2e/cli-matrix/bug-384-late-vd-thin-converges.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# usage: bug-384-late-vd-thin-converges.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 384 (P0, DATA INTEGRITY; regression of the
+# Bug 79/332 family).
+#
+# Verbatim operator repro on a 2-diskful lvm-thin RD:
+#
+#   $ linstor rd c test
+#   $ linstor vd c test 1G                 # vol-0
+#   $ linstor r c <n1> test -s lvm-thin
+#   $ linstor r c <n2> test -s lvm-thin
+#   # wait until vol-0 is UpToDate on both replicas
+#   $ linstor vd c test 1G                 # vol-1 — the LATE-added VD
+#
+#   $ linstor r l
+#    test  <n1>  DRBD,STORAGE  Inconsistent
+#    test  <n2>  DRBD,STORAGE  Inconsistent
+#   $ linstor v l
+#    test  <n1>  lvm-thin  vol 0  /dev/drbd20000  UpToDate
+#    test  <n1>  lvm-thin  vol 1  /dev/drbd20001  Inconsistent   ← bug
+#    test  <n2>  lvm-thin  vol 0  /dev/drbd20000  UpToDate
+#    test  <n2>  lvm-thin  vol 1  /dev/drbd20001  Inconsistent   ← bug
+#
+# vol-0 stays UpToDate; the late-added vol-1 is stuck Inconsistent on
+# EVERY replica with no SyncSource to recover from — neither replica
+# was elected the initial-UpToDate winner for the new volume, so DRBD
+# has no authority to drive either out of Inconsistent.
+#
+# Expected (post-fix): the satellite re-runs the lowest-node-id winner
+# election locally per fresh volume (seedFreshVolumes / isLateAddWinner),
+# the lowest-id replica seeds vol-1 Consistent+UpToDate, and BOTH
+# replicas settle vol-1 UpToDate within 60s.
+#
+# Unit pin: pkg/satellite/reconciler_drbd_test.go::
+#   TestApplyLateAddedVolumeWinnerSeedsUpToDate (winner seeds vol-1
+#   Consistent+UpToDate) and ::TestApplyLateAddedVolumeNonWinnerTakes
+#   SkipInitSync (non-winner stays case-A, no split-brain). This L6
+#   cell is the kernel-truth half — only the real stand observes the
+#   actual `linstor v l` / `drbdadm status` Inconsistent surface.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cli-matrix-384
+POOL=${POOL:-lvm-thin}
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+N1=$WORKER_1
+N2=$WORKER_2
+
+# Pre-flight: both target nodes must carry the thin pool — Bug 384's
+# repro is thin-specific (the seed path only skips initial sync on
+# thin/ZFS). Skip cleanly if the fixture pool is not present.
+echo ">> pre-flight: $POOL SP on $N1 + $N2"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+have=$(jq -r --arg n1 "$N1" --arg n2 "$N2" \
+    '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique
+     | map(select(. == $n1 or . == $n2)) | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( have < 2 )); then
+    echo "SKIP: $POOL SP not on both $N1 and $N2 (got $have) — Bug 384 fixture unavailable"
+    exit 0
+fi
+
+echo ">> [Bug 384] rd c + vd c (vol-0)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+
+echo ">> [Bug 384] r c on $N1 + $N2 (-s $POOL)"
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" >/dev/null
+
+echo ">> wait for vol-0 UpToDate on both replicas"
+wait_uptodate "$RD" "$N1" "$N2"
+
+# THE BUG: add vol-1 AFTER vol-0 is UpToDate. The RD is already
+# Initialized, so the first-activation winner election cannot fire.
+echo ">> [Bug 384] late vd c (vol-1)"
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+
+echo ">> wait up to 90s for vol-1 to reach UpToDate on BOTH replicas"
+deadline=$(( $(date +%s) + 90 ))
+late_up=false
+while (( $(date +%s) < deadline )); do
+    s1=$(status_disk_state "$RD" "$N1" 1)
+    s2=$(status_disk_state "$RD" "$N2" 1)
+    if [[ "$s1" == "UpToDate" && "$s2" == "UpToDate" ]]; then
+        late_up=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$late_up" != "true" ]]; then
+    echo "FAIL (Bug 384): late-added vol-1 did not reach UpToDate on both replicas within 90s" >&2
+    echo "  $N1 vol-1: $(status_disk_state "$RD" "$N1" 1)   $N2 vol-1: $(status_disk_state "$RD" "$N2" 1)" >&2
+    "${LCTL[@]}" volume list --resources "$RD" 2>&1 | tail -20 >&2 || true
+    exit 1
+fi
+
+# Kernel-truth guard: drbdadm status on a diskful replica MUST NOT
+# report vol-1 as Inconsistent (the exact operator-observed surface).
+echo ">> [Bug 384] kernel-truth: drbdadm status on $N1"
+if status_out=$(on_node "$N1" drbdadm status "$RD" 2>&1); then
+    echo "$status_out"
+    if grep -E 'volume:1.*disk:Inconsistent' <<<"$status_out" >/dev/null; then
+        echo "FAIL (Bug 384): $N1 reports volume:1 as Inconsistent on kernel state" >&2
+        echo "$status_out" >&2
+        exit 1
+    fi
+else
+    echo "SKIP-PARTIAL: kernel-truth probe on $N1 unavailable; Status-level pin still asserted"
+fi
+
+echo ">> bug-384-late-vd-thin-converges OK (late vd c on $RD brought vol-1 to UpToDate on both replicas, no stuck Inconsistent)"

--- a/tests/e2e/cli-matrix/n-evict-tiebreaker-no-shuffle.sh
+++ b/tests/e2e/cli-matrix/n-evict-tiebreaker-no-shuffle.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# usage: n-evict-tiebreaker-no-shuffle.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 385 (P1, user-reported, stand-observable).
+#
+# Reproduction from the dev stand:
+#
+#   $ linstor r l
+#   test  worker-1  …  UpToDate
+#   test  worker-2  …  UpToDate
+#   test  worker-3  …  TieBreaker
+#
+#   $ linstor n e dev-worker-3
+#   SUCCESS
+#
+#   $ linstor n l
+#   dev-worker-1  SATELLITE  Online
+#   dev-worker-2  SATELLITE  Online
+#   dev-worker-3  SATELLITE  EVICTED
+#   $ linstor r l
+#   test  worker-1  …  UpToDate
+#   test  worker-2  …  TieBreaker   ← WRONG: was UpToDate, demoted to TB
+#   test  worker-3  …  UpToDate     ← EVICTED node still holds a diskful
+#
+# Operator summary: "Если евиктить ноду, при свободной TieBreaker
+# реплике, то евикт не произойдёт" — the evict does not actually take
+# effect.
+#
+# Root cause: ensureTiebreaker counted the TIE_BREAKER witness sitting on
+# the just-EVICTED node as a live witness, so the witness invariant read
+# as satisfied (diskful=2 + witness=1) and the reconciler never relocated
+# the witness off the drained node. A healthy diskful must NEVER be
+# demoted to TIE_BREAKER.
+#
+# Fix: replicas on EVICTED / LOST nodes are draining placements, not live
+# ones — the witness / quorum decision ignores them and a TIE_BREAKER
+# stranded on a disabled node is reaped so a fresh one lands on a healthy
+# spare (or quorum falls to off when none remains).
+#
+# Unit pin: internal/controller/ensure_tiebreaker_evict_bug_385_test.go
+# (TestBug385EvictTiebreakerNodeReapsStrandedWitness +
+#  TestBug385EvictTiebreakerNodeRelocatesWitnessToSpare).
+#
+# This L6 cell is the stand-side companion: it builds the 2r+tb shape on
+# 3 workers, evicts the tiebreaker node via the real `linstor n e` CLI,
+# and asserts that within 30s (a) the EVICTED node no longer hosts a
+# witness, and (b) BOTH original diskful replicas are still diskful — no
+# healthy UpToDate replica was demoted to TIE_BREAKER.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-385
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+EVICTED_NODE=""
+cleanup() {
+    # Restore any node we evicted so the shared stand is left healthy
+    # for the next cell, BEFORE deleting the RD.
+    if [[ -n "$EVICTED_NODE" ]]; then
+        "${LCTL[@]}" node restore "$EVICTED_NODE" >/dev/null 2>&1 || true
+    fi
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 385] shape-2r-tb: 2-replica RD + auto-tiebreaker"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=2 --storage-pool=stand "$RD" >/dev/null
+
+echo ">> wait for steady state: 2 diskful UpToDate + 1 TIE_BREAKER witness"
+deadline=$(( $(date +%s) + 180 ))
+uptodate_pair=""
+tb_node=""
+while (( $(date +%s) < deadline )); do
+    pair=()
+    tb=""
+    for n in "$N1" "$N2" "$N3"; do
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+        if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+            tb=$n
+            continue
+        fi
+        d=$(status_disk_state "$RD" "$n" 0)
+        if [[ "$d" == "UpToDate" ]]; then
+            pair+=("$n")
+        fi
+    done
+    if (( ${#pair[@]} >= 2 )) && [[ -n "$tb" ]]; then
+        uptodate_pair="${pair[0]} ${pair[1]}"
+        tb_node=$tb
+        break
+    fi
+    sleep 3
+done
+if [[ -z "$uptodate_pair" ]] || [[ -z "$tb_node" ]]; then
+    echo "FAIL: never reached steady state (2 diskful UpToDate + TIE_BREAKER) within 180s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   diskful pair: $uptodate_pair  tiebreaker: $tb_node"
+
+# Capture the two diskful nodes so we can assert neither is demoted.
+DISKFUL_A=$(echo "$uptodate_pair" | awk '{print $1}')
+DISKFUL_B=$(echo "$uptodate_pair" | awk '{print $2}')
+
+# Evict the tiebreaker node — the exact operator action from the repro.
+echo ">> linstor n e $tb_node  (evict the tiebreaker node)"
+EVICTED_NODE=$tb_node
+"${LCTL[@]}" node evict "$tb_node" >/dev/null 2>&1 || {
+    echo "FAIL: n e (node evict) exited non-zero" >&2
+    exit 1
+}
+
+# The node must show EVICTED in `linstor n l` (evict took effect at the
+# node level).
+echo ">> confirm $tb_node is flagged EVICTED"
+deadline=$(( $(date +%s) + 30 ))
+node_evicted=false
+while (( $(date +%s) < deadline )); do
+    nflags=$(kubectl get "nodes.blockstor.cozystack.io/${tb_node}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$nflags" == *"EVICTED"* ]]; then
+        node_evicted=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$node_evicted" != "true" ]]; then
+    echo "FAIL: node $tb_node never reached EVICTED flag within 30s" >&2
+    exit 1
+fi
+
+echo ">> wait up to 30s for the tiebreaker on EVICTED $tb_node to be relocated/reaped"
+deadline=$(( $(date +%s) + 30 ))
+reaped=false
+while (( $(date +%s) < deadline )); do
+    # The witness must no longer sit on the evicted node.
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${tb_node}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "__absent__")
+    if [[ "$flags" == "__absent__" ]] || [[ "$flags" != *"TIE_BREAKER"* ]]; then
+        reaped=true
+        break
+    fi
+    sleep 2
+done
+
+if [[ "$reaped" != "true" ]]; then
+    echo "FAIL (Bug 385 regression): TIE_BREAKER still pinned to EVICTED $tb_node within 30s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# The load-bearing invariant: NEITHER healthy diskful was demoted to
+# TIE_BREAKER (the exact wrong behaviour from the repro where worker-2
+# went UpToDate → TieBreaker).
+echo ">> assert neither healthy diskful ($DISKFUL_A, $DISKFUL_B) was demoted to TIE_BREAKER"
+for n in "$DISKFUL_A" "$DISKFUL_B"; do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "__absent__")
+    if [[ "$flags" == "__absent__" ]]; then
+        echo "FAIL (Bug 385): healthy diskful on $n disappeared after evict; flags=$flags" >&2
+        exit 1
+    fi
+    if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+        echo "FAIL (Bug 385 regression): healthy diskful on $n was demoted to TIE_BREAKER; flags=$flags" >&2
+        "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+        exit 1
+    fi
+    if [[ "$flags" == *"DISKLESS"* ]]; then
+        echo "FAIL (Bug 385): healthy diskful on $n gained DISKLESS after evict; flags=$flags" >&2
+        exit 1
+    fi
+done
+
+echo ">> n-evict-tiebreaker-no-shuffle OK (Bug 385 pinned: evict relocates the witness, no healthy diskful demoted)"

--- a/tests/e2e/cli-matrix/n-rst-recreates-tiebreaker.sh
+++ b/tests/e2e/cli-matrix/n-rst-recreates-tiebreaker.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# usage: n-rst-recreates-tiebreaker.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 386 (user-reported, stand-observable).
+#
+# Reproduction from the operator stand:
+#
+#   $ linstor r l
+#   test  dev-worker-1  …  UpToDate
+#   test  dev-worker-2  …  UpToDate
+#   test  dev-worker-3  …  TieBreaker
+#
+#   $ linstor n evacuate dev-worker-3     # drain the witness node
+#   $ linstor r l
+#   test  dev-worker-1  …  UpToDate
+#   test  dev-worker-2  …  UpToDate       ← witness collapsed (EVICTED)
+#
+#   $ linstor n rst dev-worker-3          # node recovered
+#   $ linstor r l
+#   test  dev-worker-1  …  UpToDate
+#   test  dev-worker-2  …  UpToDate
+#   # TieBreaker was NOT recreated        ← WRONG: quorum/split-brain risk
+#
+# Root cause: the RD reconciler watched only RDs and Resources, never
+# Nodes. `pickTiebreakerNode` / `isDisabledNode` exclude an EVICTED node
+# as a witness candidate, so while dev-worker-3 was drained the witness
+# could not be (re)placed. After `n rst` cleared the EVICTED flag,
+# NOTHING enqueued the RD — so ensureTiebreaker never re-ran and the
+# resource sat at two diskful UpToDate replicas with no witness until
+# the next periodic re-sync (a quorum=majority split-brain hazard in
+# between).
+#
+# Fix: a Node watch on the RD reconciler (nodeDrainFlagChanged →
+# enqueueRDsForNode) re-enqueues every RD when a node's EVICTED/LOST
+# flag set transitions, so `n rst` re-runs the tiebreaker invariant and
+# the witness is re-placed.
+#
+# Unit pin: internal/controller/ensure_tiebreaker_test.go
+# (TestBug386NodeRestoreRecreatesTiebreaker). This L6 cell is the
+# stand-side companion: drives the real python-linstor CLI sequence on
+# the 2r-tb shape, evacuates the witness node to collapse the witness,
+# restores it with `n rst`, and asserts the TIE_BREAKER reappears in
+# `linstor r l` within 60s — leaving the diskful+diskful+TB shape.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-386
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    # Best-effort restore in case the test bailed mid-evacuate, so the
+    # shared stand isn't left with an EVICTED node.
+    "${LCTL[@]}" node restore "$N3" >/dev/null 2>&1 || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 386] shape-2r-tb: 2-replica RD + auto-tiebreaker"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=2 --storage-pool=stand "$RD" >/dev/null
+
+echo ">> wait for steady state: 2 diskful UpToDate + 1 TIE_BREAKER witness"
+deadline=$(( $(date +%s) + 180 ))
+tb_node=""
+while (( $(date +%s) < deadline )); do
+    pair=()
+    tb=""
+    for n in "$N1" "$N2" "$N3"; do
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+        if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+            tb=$n
+            continue
+        fi
+        d=$(status_disk_state "$RD" "$n" 0)
+        if [[ "$d" == "UpToDate" ]]; then
+            pair+=("$n")
+        fi
+    done
+    if (( ${#pair[@]} >= 2 )) && [[ -n "$tb" ]]; then
+        tb_node=$tb
+        break
+    fi
+    sleep 3
+done
+if [[ -z "$tb_node" ]]; then
+    echo "FAIL: never reached steady state (2 diskful UpToDate + TIE_BREAKER) within 180s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   tiebreaker landed on: $tb_node"
+
+# Evacuate the witness node. The TIE_BREAKER witness lives on a node
+# the autoplacer/tiebreaker treats as a candidate; EVICTED removes it
+# from the candidate set, so the witness collapses (no other spare node
+# in a 3-worker cluster with 2 diskful already placed).
+echo ">> linstor n evacuate $tb_node  (drain the witness node → EVICTED)"
+"${LCTL[@]}" node evacuate "$tb_node" >/dev/null 2>&1 || {
+    echo "FAIL: n evacuate exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 60s for the witness on $tb_node to collapse"
+deadline=$(( $(date +%s) + 60 ))
+collapsed=false
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${tb_node}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "ABSENT")
+    if [[ "$flags" == "ABSENT" ]] || { [[ "$flags" != *"TIE_BREAKER"* ]]; }; then
+        collapsed=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$collapsed" != "true" ]]; then
+    echo "FAIL: witness on $tb_node never collapsed after n evacuate within 60s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   witness collapsed (node EVICTED); RD now 2 diskful, no witness"
+
+# Restore the node. This is the load-bearing Bug 386 step: clearing
+# EVICTED must re-run the tiebreaker invariant so the witness reappears.
+echo ">> linstor n rst $tb_node  (node recovered → EVICTED cleared)"
+"${LCTL[@]}" node restore "$tb_node" >/dev/null 2>&1 || {
+    echo "FAIL: n rst exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 60s for the tiebreaker to be RE-created after n rst"
+deadline=$(( $(date +%s) + 60 ))
+recreated=false
+last_rows=""
+while (( $(date +%s) < deadline )); do
+    tb=""
+    for n in "$N1" "$N2" "$N3"; do
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${n}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+        if [[ "$flags" == *"TIE_BREAKER"* ]]; then
+            tb=$n
+        fi
+    done
+    last_rows=$(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}' || true)
+    if [[ -n "$tb" ]]; then
+        recreated=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$recreated" != "true" ]]; then
+    echo "FAIL (Bug 386 regression): tiebreaker NOT recreated within 60s of n rst" >&2
+    echo "  CRD rows for ${RD}:" >&2
+    printf '    %s\n' $last_rows >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# Belt-and-suspenders: the operator-visible `linstor r l` surface the
+# bug report cited must show exactly one TIE_BREAKER row plus the two
+# diskful replicas.
+wire=$(linstor_r_l_json "$RD")
+n_tb=$(printf '%s' "$wire" \
+    | jq -r '.[][] | select((.rsc_flags // []) | index("TIE_BREAKER")) | .name' 2>/dev/null \
+    | wc -l | tr -d ' ' || echo 0)
+if [[ "$n_tb" != "1" ]]; then
+    echo "FAIL (Bug 386): linstor r l shows $n_tb TIE_BREAKER rows for $RD, want 1" >&2
+    printf '%s\n' "$wire" | jq '.[][]| {name, node_name, flags: .rsc_flags}' 2>/dev/null >&2 || true
+    exit 1
+fi
+
+echo ">> n-rst-recreates-tiebreaker OK (Bug 386 pinned: tiebreaker recreated after n rst)"

--- a/tests/e2e/cli-matrix/r-d-inactive-no-tiebreaker.sh
+++ b/tests/e2e/cli-matrix/r-d-inactive-no-tiebreaker.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# usage: r-d-inactive-no-tiebreaker.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 387 (P1, user-reported, stand-observable).
+#
+# Reproduction from the operator stand (resource `test1`):
+#
+#   $ linstor r l
+#   test1  worker-1  DRBD,STORAGE  INACTIVE
+#   test1  worker-2  DRBD,STORAGE  UpToDate
+#   test1  worker-3  DRBD,STORAGE  UpToDate
+#
+#   $ linstor r d worker-2 test1
+#   SUCCESS: resource deleted: test1 on worker-2
+#
+#   $ linstor r l
+#   test1  worker-1  DRBD,STORAGE  INACTIVE
+#   test1  worker-2  DRBD,STORAGE  Connecting(worker-3)  Created   <-- WRONG: became a TieBreaker witness
+#   test1  worker-3  DRBD,STORAGE  Unknown
+#
+# Root cause: an INACTIVE replica is `drbdadm down` (operator
+# deactivation) — its DRBD device is not up, so it does NOT vote in the
+# `quorum: majority` decision the auto-tiebreaker invariant defends. The
+# RD reconciler's witness-decision counted the INACTIVE replica as a
+# full diskful, so after the `r d` of one active diskful the topology
+# looked like "2 diskful, 0 user-diskless, even parity" → it spuriously
+# grew a TIE_BREAKER witness (1 active diskful + 1 witness = a 2-voter
+# quorum with no majority protection). Upstream LINSTOR simply deletes
+# the replica with no witness conversion.
+#
+# Fix: drop INACTIVE replicas from the voting set before the
+# diskful/diskless split in ensureTiebreaker — they influence neither
+# the diskful count nor the diskless/witness count.
+#
+# Unit pin: internal/controller/ensure_tiebreaker_inactive_bug_387_test.go
+# (TestBug387InactiveReplicaNotCountedAsVotingDiskful).
+# This L6 cell is the stand-side companion: drives the real
+# python-linstor CLI sequence on the 3-diskful → deactivate-one →
+# r-d-one shape and asserts that NO tiebreaker is spawned, leaving
+# exactly two Resource rows (1 INACTIVE + 1 active diskful) with no
+# TIE_BREAKER residue.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-387
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    # If a replica is still INACTIVE, re-activate it first so delete_rd
+    # can drive a clean cascade.
+    "${LCTL[@]}" resource activate "$N1" "$RD" 2>/dev/null || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 387] shape-3r: 3-replica diskful RD (no auto-tiebreaker — odd parity)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=3 --storage-pool=stand "$RD" >/dev/null
+
+echo ">> wait for steady state: 3 diskful UpToDate"
+deadline=$(( $(date +%s) + 180 ))
+ready=false
+while (( $(date +%s) < deadline )); do
+    n_diskful=$(linstor_diskful_count "$RD")
+    n_total=$(linstor_replica_count "$RD")
+    if [[ "$n_diskful" == "3" ]] && [[ "$n_total" == "3" ]]; then
+        ok_count=0
+        for n in "$N1" "$N2" "$N3"; do
+            d=$(status_disk_state "$RD" "$n" 0 2>/dev/null || echo "")
+            [[ "$d" == "UpToDate" ]] && ok_count=$(( ok_count + 1 ))
+        done
+        if (( ok_count == 3 )); then
+            ready=true
+            break
+        fi
+    fi
+    sleep 3
+done
+if [[ "$ready" != "true" ]]; then
+    echo "FAIL: never reached 3 diskful UpToDate within 180s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   3 diskful UpToDate on $N1 $N2 $N3"
+
+# Deactivate worker-1 → INACTIVE flag. This is the deactivated, non-
+# voting replica the witness policy must learn to ignore.
+echo ">> linstor r deactivate $N1 $RD  (→ INACTIVE)"
+"${LCTL[@]}" resource deactivate "$N1" "$RD" >/dev/null 2>&1 || {
+    echo "FAIL: r deactivate $N1 $RD exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 30s for INACTIVE flag visible on $N1"
+deadline=$(( $(date +%s) + 30 ))
+inactive=false
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N1}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$flags" == *"INACTIVE"* ]]; then
+        inactive=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$inactive" != "true" ]]; then
+    echo "FAIL: INACTIVE flag never landed on $N1 within 30s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   $N1 is INACTIVE; voting set is now {$N2, $N3} (2 active diskful)"
+
+# Delete one of the two ACTIVE diskful replicas. The remaining voting
+# set is 1 active diskful + 1 INACTIVE — and an INACTIVE replica is NOT
+# a voting diskful, so there must be NO tiebreaker conversion. Upstream
+# LINSTOR simply deletes the replica.
+echo ">> linstor r d $N2 $RD  (physical delete of one active diskful)"
+"${LCTL[@]}" resource delete "$N2" "$RD" >/dev/null 2>&1 || {
+    echo "FAIL: r d $N2 $RD exited non-zero" >&2
+    exit 1
+}
+
+# Wait for the deleted replica's CRD to physically disappear before
+# asserting "no tiebreaker", so the count check acts on a settled shape.
+wait_replica_absent "$RD" "$N2" 60 \
+    || die "Bug 387: ${RD}.${N2} CRD never disappeared after r d"
+
+# The reconciler runs asynchronously. Give it a fixed window to (wrongly,
+# pre-fix) spawn a witness; if after the window no TIE_BREAKER exists and
+# exactly the 2 expected rows remain, the fix holds.
+echo ">> watch 30s: NO tiebreaker must be spawned; exactly 2 rows must remain"
+deadline=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < deadline )); do
+    tb=$(linstor_tiebreaker_node "$RD")
+    if [[ -n "$tb" ]]; then
+        echo "FAIL (Bug 387 regression): spurious TIE_BREAKER witness spawned on $tb" >&2
+        echo "  an INACTIVE replica must not be counted as a voting diskful" >&2
+        "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+        exit 1
+    fi
+    sleep 2
+done
+
+# Final shape assertion: exactly 2 Resource rows — 1 INACTIVE ($N1) and
+# 1 active diskful ($N3) — and neither carries TIE_BREAKER / DISKLESS.
+n_total=$(linstor_replica_count "$RD")
+if [[ "$n_total" != "2" ]]; then
+    echo "FAIL (Bug 387): expected 2 rows after r d, got $n_total" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# $N1 must still be INACTIVE (and definitely not a witness).
+n1_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N1}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+if [[ "$n1_flags" != *"INACTIVE"* ]] || [[ "$n1_flags" == *"TIE_BREAKER"* ]]; then
+    echo "FAIL (Bug 387): $N1 flags=$n1_flags, want INACTIVE with no TIE_BREAKER" >&2
+    exit 1
+fi
+
+# $N3 must be the lone surviving active diskful: no DISKLESS / TIE_BREAKER.
+n3_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+if [[ "$n3_flags" == *"TIE_BREAKER"* ]] || [[ "$n3_flags" == *"DISKLESS"* ]]; then
+    echo "FAIL (Bug 387): $N3 carries unexpected flags=$n3_flags" >&2
+    exit 1
+fi
+
+# $N2 (the deleted node) must NOT have come back as a witness — the exact
+# operator-reported symptom (the deleted diskful re-appearing as a TB).
+if kubectl get "resources.blockstor.cozystack.io/${RD}.${N2}" >/dev/null 2>&1; then
+    echo "FAIL (Bug 387): deleted node $N2 re-appeared — it was converted into a tiebreaker" >&2
+    exit 1
+fi
+
+echo ">> r-d-inactive-no-tiebreaker OK (Bug 387 pinned: r d of an active diskful on a 1-active+1-INACTIVE residual spawns no tiebreaker)"

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -65,7 +65,25 @@ __BLOCKSTOR_HARNESS_LIB_LOADED=1
 # linstor CLI wrapper
 # ----------------------------------------------------------------------
 
+# `node evict` is a controller-side action that the bundled linstor-client
+# 1.27.1 does not expose as a subcommand (it only ships evacuate/lost/
+# restore). The REST controller, however, implements it as
+# `PUT /v1/nodes/<node>/evict`. So a replay step can stay operator-faithful
+# (`cmd: ["node", "evict", "<node>"]`) and we transparently drive it through
+# the REST endpoint here. The same call is mirrored by the cli-matrix
+# n-evict catcher's expectation. Recognise the long form and the `n e` /
+# `node e` short forms.
 linstor_cli() {
+    if [[ "$1" == "node" || "$1" == "n" ]] \
+        && [[ "$2" == "evict" || "$2" == "e" ]] \
+        && [[ -n "${3:-}" ]]; then
+        local node=$3
+        local base=${BS_URL:?BS_URL required}
+        # curl returns 0 on a 200; map any non-2xx to a non-zero exit so the
+        # step's expect_exit contract still holds.
+        curl -fsS -m 10 -X PUT "${base%/}/v1/nodes/${node}/evict" >/dev/null
+        return $?
+    fi
     "$LINSTOR_CMD" --controllers "${BS_URL:?BS_URL required}" "$@"
 }
 
@@ -185,7 +203,7 @@ check_assertion() {
             rd=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")
             rd=$(substitute "$rd")
             min=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('min',2))" "$spec")
-            count=$(linstor_cli --output-fmt=json resource list --resources "$rd" 2>/dev/null \
+            count=$(linstor_cli -m resource list --resources "$rd" 2>/dev/null \
                 | python3 -c "import json,sys
 try:
     d=json.load(sys.stdin)
@@ -237,7 +255,14 @@ print(bad)")
         no_tiebreaker)
             local rd present
             rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
-            present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -ci 'TieBreaker' || true)
+            # Match the LINSTOR State token `TieBreaker` case-SENSITIVELY:
+            # the replay RD names themselves contain the lowercase substring
+            # "tiebreaker" (replay-*-tiebreaker-*), so a case-insensitive
+            # grep -ci false-matches the resource name on EVERY data row and
+            # the count can never reach 0 — the assertion would wrongly time
+            # out even when the cluster has no witness. The State column
+            # always renders the witness as `TieBreaker` (capital T/B).
+            present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -c 'TieBreaker' || true)
             [[ "$present" == "0" ]]
             ;;
         tiebreaker_present)
@@ -247,7 +272,11 @@ print(bad)")
             # drained node is brought back with `n rst`.
             local rd present
             rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
-            present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -ci 'TieBreaker' || true)
+            # Case-SENSITIVE on purpose — see the no_tiebreaker note above: a
+            # case-insensitive grep would match the lowercase "tiebreaker"
+            # substring in the RD name and report a witness present on every
+            # row, masking a genuinely missing TieBreaker.
+            present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -c 'TieBreaker' || true)
             [[ "$present" -ge 1 ]]
             ;;
         sync_clean)
@@ -275,7 +304,7 @@ print(bad)")
             rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
             vol=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('vol',0))" "$spec")
             expected=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('expected_kib',0))" "$spec")
-            actual=$(VOL="$vol" linstor_cli --output-fmt=json volume-definition list --resource-definitions "$rd" 2>/dev/null \
+            actual=$(VOL="$vol" linstor_cli -m volume-definition list --resource-definitions "$rd" 2>/dev/null \
                 | python3 -c "import json,sys,os
 try:
     d=json.load(sys.stdin)

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -211,10 +211,19 @@ except: print(0)")
 d=json.load(sys.stdin)
 rd='$rd'
 bad=0
+seen=0
 for it in d.get('items',[]):
-    if it.get('spec',{}).get('resourceName')!=rd: continue
+    if it.get('spec',{}).get('resourceDefinitionName')!=rd: continue
+    seen+=1
     for v in it.get('status',{}).get('volumes',[]) or []:
-        if v.get('diskState')!='UpToDate': bad+=1
+        # A diskless / tiebreaker replica reports diskState 'Diskless' and is
+        # never 'UpToDate' by design — accept it. Only a DISKFUL replica that
+        # has not reached UpToDate (Inconsistent / Outdated / SyncTarget / …)
+        # counts as 'bad', i.e. not-yet-converged.
+        if v.get('diskState') not in ('UpToDate','Diskless'): bad+=1
+# No matching replica at all means the rd is absent / not yet observed — that
+# is NOT 'all uptodate', so report it as bad so the waiter keeps polling.
+if seen==0: bad+=1
 print(bad)")
             [[ "$bad" == "0" ]]
             ;;
@@ -370,7 +379,7 @@ print(json.dumps(s) if s else '')" "$step")
 # wait_settle <rd> [timeout_s]
 #
 # Polls `kubectl get resources.blockstor.cozystack.io -o json` filtered by
-# spec.resourceName == rd. Considers the cluster "settled" once two
+# spec.resourceDefinitionName == rd. Considers the cluster "settled" once two
 # consecutive snapshots return identical {diskState, inUse, connections}
 # tuples across all replicas.
 #
@@ -394,7 +403,7 @@ rd='$rd'
 keys=[]
 for it in d.get('items',[]):
     sp=it.get('spec',{})
-    if sp.get('resourceName')!=rd: continue
+    if sp.get('resourceDefinitionName')!=rd: continue
     st=it.get('status',{})
     v=(st.get('volumes') or [{}])[0]
     keys.append((sp.get('nodeName',''), v.get('diskState',''), v.get('inUse',False)))
@@ -424,17 +433,28 @@ print(json.dumps(keys))" 2>/dev/null || echo "[]")
 #
 # Returns 0 if no Resource CRDs with name starting with $prefix remain.
 # Caller is expected to have torn down all RDs created during the run.
+#
+# Teardown (`rd delete`) removes the Resource CRDs asynchronously: the
+# apiserver returns from the delete call before the satellite has finished
+# `drbdadm down` + finalizer removal, so a single snapshot taken right after
+# teardown races the GC and reports phantom orphans. Poll for up to
+# NO_ORPHANS_SETTLE_S (default 30s), passing the instant the count reaches 0;
+# only a count that is still non-zero after the window is a real orphan.
 assert_no_orphans() {
     local prefix=$1
+    local settle_s=${NO_ORPHANS_SETTLE_S:-30}
+    local deadline=$(( $(date +%s) + settle_s ))
     local leftover
-    leftover=$(kubectl get resources.blockstor.cozystack.io -o name 2>/dev/null \
-        | grep -c "$prefix" || true)
-    if [[ "$leftover" -gt 0 ]]; then
-        echo "  INVARIANT FAIL: $leftover Resource CRD(s) for $prefix still present" >&2
-        kubectl get resources.blockstor.cozystack.io -o name 2>/dev/null | grep "$prefix" >&2 || true
-        return 1
-    fi
-    return 0
+    while :; do
+        leftover=$(kubectl get resources.blockstor.cozystack.io -o name 2>/dev/null \
+            | grep -c "$prefix" || true)
+        [[ "$leftover" -eq 0 ]] && return 0
+        (( $(date +%s) >= deadline )) && break
+        sleep 2
+    done
+    echo "  INVARIANT FAIL: $leftover Resource CRD(s) for $prefix still present after ${settle_s}s" >&2
+    kubectl get resources.blockstor.cozystack.io -o name 2>/dev/null | grep "$prefix" >&2 || true
+    return 1
 }
 
 # ----------------------------------------------------------------------

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -231,6 +231,16 @@ print(bad)")
             present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -ci 'TieBreaker' || true)
             [[ "$present" == "0" ]]
             ;;
+        tiebreaker_present)
+            # Bug 386: assert a TieBreaker witness EXISTS for the rd.
+            # The inverse of no_tiebreaker — used by the node-restore
+            # catcher to confirm the witness is RE-created after the
+            # drained node is brought back with `n rst`.
+            local rd present
+            rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
+            present=$(linstor_cli resource list --resources "$rd" 2>/dev/null | grep -ci 'TieBreaker' || true)
+            [[ "$present" -ge 1 ]]
+            ;;
         sync_clean)
             local rd
             rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")

--- a/tests/operator-harness/replay-runner.sh
+++ b/tests/operator-harness/replay-runner.sh
@@ -49,6 +49,8 @@
 #   - all_uptodate         wait until every replica reports UpToDate
 #   - replica_diskless     wait until rd@node has disk_state == Diskless
 #   - no_tiebreaker        assert NO TieBreaker is auto-spawned
+#   - tiebreaker_present   assert a TieBreaker witness EXISTS for rd
+#                           (Bug 386: re-created after `n rst`)
 #   - sync_clean           wait until UpToDate without "(NN%)" suffix
 #   - resource_absent      wait until r d takes effect on a node
 #   - rd_absent            wait until rd is gone everywhere

--- a/tests/operator-harness/replay/auto-place-no-drbd.yaml
+++ b/tests/operator-harness/replay/auto-place-no-drbd.yaml
@@ -24,7 +24,7 @@ steps:
     # DRBD MUST either be accepted (single-replica STORAGE) OR rejected
     # with a clear error — but NEVER silently coerce to DRBD. We pin
     # the "reject" semantics matching upstream LINSTOR.
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 10
   - name: no-tiebreaker-spawned
     cmd: ["resource", "list", "--resources", "{{rd}}"]

--- a/tests/operator-harness/replay/autoplace-3r.yaml
+++ b/tests/operator-harness/replay/autoplace-3r.yaml
@@ -20,7 +20,7 @@ steps:
     cmd: ["volume-definition", "create", "{{rd}}", "32M"]
     expect_exit: 0
   - name: auto-place-3
-    cmd: ["resource", "create", "--auto-place", "3", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "3", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: replica_count

--- a/tests/operator-harness/replay/luks-encrypted-rd.yaml
+++ b/tests/operator-harness/replay/luks-encrypted-rd.yaml
@@ -31,7 +31,7 @@ steps:
     cmd: ["volume-definition", "create", "{{rd}}", "32M"]
     expect_exit: 0
   - name: auto-place-2-encrypted
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: replica_count

--- a/tests/operator-harness/replay/n-evict-tiebreaker-no-shuffle.yaml
+++ b/tests/operator-harness/replay/n-evict-tiebreaker-no-shuffle.yaml
@@ -1,0 +1,95 @@
+name: n-evict-tiebreaker-no-shuffle
+description: |
+  Bug-385 catcher (P1, user-reported). Cluster shape: 2 diskful replicas
+  (node1, node2) + 1 TieBreaker witness on node3. Operator evicts the
+  tiebreaker node (`linstor n e node3`).
+
+  Pre-fix the witness was counted as a live tiebreaker even though it sat
+  on the just-EVICTED node, so the witness invariant read as satisfied
+  and the evict never took effect — the TieBreaker stayed pinned to the
+  drained node and a healthy diskful drifted into the tiebreaker role.
+
+  Expected convergence:
+    - the witness on the EVICTED node3 is reaped (resource_absent); with
+      only 3 nodes there is no healthy spare, so it does not relocate.
+    - BOTH original diskful replicas (node1, node2) stay UpToDate — a
+      healthy diskful is NEVER demoted to TieBreaker.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1-diskful
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2-diskful
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-2-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: tiebreaker-on-node3
+    # Hand-create the witness on node3 so the scenario is deterministic
+    # regardless of the auto-tiebreaker config / which node auto-tb picks.
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--diskless"]
+    expect_exit: 0
+    await:
+      kind: replica_diskless
+      rd: "{{rd}}"
+      node: "{{node3}}"
+      timeout_s: 60
+  - name: n-evict-node3
+    # The exact operator action from the repro: evict the tiebreaker node.
+    cmd: ["node", "evict", "{{node3}}"]
+    expect_exit: 0
+    await:
+      # Evict must take effect: the witness no longer sits on the drained
+      # node3. No healthy spare exists (3 nodes), so it is reaped, not
+      # relocated.
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node3}}"
+      timeout_s: 90
+  - name: node1-still-uptodate
+    # Load-bearing invariant: the first healthy diskful was NOT demoted
+    # to TieBreaker by the evict (the wrong behaviour from the repro).
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      expected: UpToDate
+      timeout_s: 90
+  - name: node2-still-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      expected: UpToDate
+      timeout_s: 90
+
+teardown:
+  # Restore the evicted node so the shared stand is left healthy for the
+  # next workflow, BEFORE deleting the RD.
+  - cmd: ["node", "restore", "{{node3}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/n-evict-tiebreaker-no-shuffle.yaml
+++ b/tests/operator-harness/replay/n-evict-tiebreaker-no-shuffle.yaml
@@ -43,14 +43,20 @@ steps:
       rd: "{{rd}}"
       timeout_s: 240
   - name: tiebreaker-on-node3
-    # Hand-create the witness on node3 so the scenario is deterministic
-    # regardless of the auto-tiebreaker config / which node auto-tb picks.
-    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--diskless"]
+    # With 2 diskful on node1+node2 the RD reconciler auto-places the
+    # TIE_BREAKER witness on the only remaining node (node3) — deterministic
+    # in a 3-node cluster. We MUST exercise the real auto-TieBreaker here,
+    # not a hand-created `r c --diskless`: Bug 385's stranded-witness reaping
+    # (removeStrandedWitnesses) only deletes replicas carrying the TieBreaker
+    # flag. A user-placed `--diskless` replica is operator-owned and is NOT
+    # auto-reaped on evict, so seeding the witness by hand would make the
+    # evict step time out on a correct controller. The cli-matrix catcher
+    # uses the same auto-placed-witness shape.
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
     expect_exit: 0
     await:
-      kind: replica_diskless
+      kind: tiebreaker_present
       rd: "{{rd}}"
-      node: "{{node3}}"
       timeout_s: 60
   - name: n-evict-node3
     # The exact operator action from the repro: evict the tiebreaker node.

--- a/tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml
+++ b/tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml
@@ -32,7 +32,7 @@ steps:
     expect_exit: 0
   - name: auto-place-2
     # 2 diskful + auto-tiebreaker → the canonical 2r-tb shape.
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: all_uptodate

--- a/tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml
+++ b/tests/operator-harness/replay/n-rst-recreates-tiebreaker.yaml
@@ -1,0 +1,75 @@
+name: n-rst-recreates-tiebreaker
+description: |
+  Bug-386 catcher. Cluster shape: 2 diskful replicas + 1 auto TieBreaker
+  on a third node (`r c --auto-place 2`). Operator drains the witness
+  node (`n evacuate`), which collapses the TieBreaker (an EVICTED node
+  is not a witness candidate). Then the node recovers and the operator
+  runs `n rst`. The TieBreaker MUST be re-created so the resource
+  regains the diskful+diskful+TB shape — otherwise two diskful UpToDate
+  replicas sit with no quorum witness (split-brain risk on a subsequent
+  failure).
+
+  Verbatim operator repro:
+    $ linstor n rst dev-worker-3
+    $ linstor r l
+     test  dev-worker-1  DRBD,STORAGE  UpToDate
+     test  dev-worker-3  DRBD,STORAGE  UpToDate
+    # TieBreaker was NOT recreated (the bug)
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: auto-place-2
+    # 2 diskful + auto-tiebreaker → the canonical 2r-tb shape.
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: wait-tiebreaker-spawned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
+  - name: evacuate-node3
+    # Drain the third node. With 2 diskful already placed and no spare
+    # worker in a 3-node cluster, EVICTED collapses the witness.
+    cmd: ["node", "evacuate", "{{node3}}"]
+    expect_exit: 0
+    await:
+      kind: no_tiebreaker
+      rd: "{{rd}}"
+      timeout_s: 60
+  - name: restore-node3
+    # Node recovered. Clearing EVICTED must re-run the tiebreaker
+    # invariant (Bug 386 fix: Node watch on the RD reconciler).
+    cmd: ["node", "restore", "{{node3}}"]
+    expect_exit: 0
+  - name: tiebreaker-recreated
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
+
+teardown:
+  - cmd: ["node", "restore", "{{node3}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/pvc-lifecycle.yaml
+++ b/tests/operator-harness/replay/pvc-lifecycle.yaml
@@ -22,7 +22,7 @@ steps:
     cmd: ["volume-definition", "create", "{{rd}}", "32M"]
     expect_exit: 0
   - name: auto-place-2
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: replica_count

--- a/tests/operator-harness/replay/r-d-inactive-no-tiebreaker.yaml
+++ b/tests/operator-harness/replay/r-d-inactive-no-tiebreaker.yaml
@@ -1,0 +1,81 @@
+name: r-d-inactive-no-tiebreaker
+description: |
+  Bug-387 catcher (P1). Deleting one active diskful replica with
+  `linstor r d` on an RD that has 2 active diskful + 1 INACTIVE replica
+  must NOT convert the deleted replica into a TieBreaker witness.
+
+  An INACTIVE replica is `drbdadm down` (operator deactivation) — it is
+  not a voting peer in the DRBD `quorum: majority` decision. The RD
+  auto-tiebreaker reconciler previously counted it as a full diskful, so
+  after the `r d` the topology looked like "2 diskful, even parity, no
+  user-diskless" and it spuriously grew a TieBreaker (1 active diskful +
+  1 witness = a 2-voter quorum with no majority protection). Upstream
+  LINSTOR simply deletes the replica with no witness conversion.
+
+  Sequence: 3 diskful RD → deactivate node1 (INACTIVE) → r d node2 →
+  assert node2 fully gone AND no TieBreaker is auto-spawned, leaving the
+  1 INACTIVE + 1 active diskful residual untouched.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node3
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: r-deactivate-node1
+    cmd: ["resource", "deactivate", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+  - name: r-d-node2-active-diskful
+    cmd: ["resource", "delete", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 60
+  - name: no-tiebreaker-spawned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: no_tiebreaker
+      rd: "{{rd}}"
+      timeout_s: 30
+  - name: node2-stays-absent
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 30
+
+teardown:
+  - cmd: ["resource", "activate", "{{node1}}", "{{rd}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/r-full-lifecycle.yaml
+++ b/tests/operator-harness/replay/r-full-lifecycle.yaml
@@ -35,7 +35,7 @@ steps:
     cmd: ["volume-definition", "create", "{{rd}}", "512M"]
     expect_exit: 0
   - name: auto-place-2
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: replica_count

--- a/tests/operator-harness/replay/r-l-conns-shapes.yaml
+++ b/tests/operator-harness/replay/r-l-conns-shapes.yaml
@@ -23,7 +23,7 @@ steps:
     cmd: ["volume-definition", "create", "{{rd}}", "32M"]
     expect_exit: 0
   - name: auto-place-2
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: replica_count

--- a/tests/operator-harness/replay/vd-late-create-second-volume.yaml
+++ b/tests/operator-harness/replay/vd-late-create-second-volume.yaml
@@ -1,0 +1,68 @@
+name: vd-late-create-second-volume
+description: |
+  Bug-384 catcher (P0, data integrity; regression of the Bug 79/332
+  family). The DISTINGUISHING factor from vd-late-create.yaml is the
+  ordering: here vol-0 is created and driven UpToDate FIRST (so the RD
+  flips Spec.Initialized=true), and ONLY THEN is a SECOND volume added
+  via `vd c`. That late-added vol-1 lands on an ALREADY-initialized RD,
+  so the dispatcher's first-activation winner election (auto-primary,
+  gated on !rdInitialized) can never fire for it.
+
+  Pre-fix the satellite seeded vol-1 with the case-A skip-init-sync GI
+  on EVERY diskful replica (clean bitmap, NO UpToDate flag) and elected
+  no winner, so vol-1 came up Inconsistent on both replicas with no
+  SyncSource and never converged — verbatim operator repro:
+
+    linstor vd c test 1G   →  test  dev-worker-1  ...  Inconsistent
+                              test  dev-worker-3  ...  Inconsistent
+
+  Post-fix the satellite re-runs the lowest-node-id winner election
+  locally per fresh volume (seedFreshVolumes / isLateAddWinner): the
+  lowest-id replica seeds vol-1 Consistent+UpToDate, the rest take
+  case-A, and all_uptodate (which checks EVERY volume of EVERY replica)
+  converges.
+
+  Note: vd-late-create.yaml exercises the FIRST-volume late-add (vd c on
+  a VD-less RD) which routes through first-activation and was always
+  green; it does NOT cover this second-volume path.
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vol0
+    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-vol0-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: late-vd-create-vol1
+    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/vd-late-create-second-volume.yaml
+++ b/tests/operator-harness/replay/vd-late-create-second-volume.yaml
@@ -38,7 +38,12 @@ steps:
     cmd: ["resource-definition", "create", "{{rd}}"]
     expect_exit: 0
   - name: create-vol0
-    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    # 64M (not 1G): Bug 384 is a deterministic per-volume winner-election
+    # defect in the satellite (seedFreshVolumes / isLateAddWinner), NOT a
+    # sync-timing race, so the trigger is size-independent. A 1G fresh-replica
+    # sync on an I/O-constrained stand (~0.5 MB/s) blows the 240s all_uptodate
+    # await; 64M converges in seconds and exercises the identical code path.
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
     expect_exit: 0
   - name: r-c-node1
     cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
@@ -54,7 +59,9 @@ steps:
       rd: "{{rd}}"
       timeout_s: 240
   - name: late-vd-create-vol1
-    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    # 64M — see create-vol0 note. The late-added second volume is what Bug 384
+    # regressed; its winner election is size-independent.
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
     expect_exit: 0
     await:
       kind: all_uptodate

--- a/tests/operator-harness/replay/vd-resize-full-lifecycle.yaml
+++ b/tests/operator-harness/replay/vd-resize-full-lifecycle.yaml
@@ -45,7 +45,7 @@ steps:
       expected_kib: 1048576
       timeout_s: 30
   - name: auto-place-2
-    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool", "{{sp}}", "{{rd}}"]
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
     expect_exit: 0
     await:
       kind: replica_count


### PR DESCRIPTION
## Summary

Round 1 of the operational-lifecycle parity work: four user-found lifecycle bugs that the earlier REST/wire-validation bug-hunt did not cover, plus a hardening pass on the L7 replay harness that surfaced while validating them on the live stand.

Validated as a unit on the dev stand (mTLS apiserver, linstor-client 1.27.1): every fix behaves correctly under direct operator-CLI exercise, and all target + adjacent replays pass green through the corrected harness. No regressions.

## Bugs fixed

- **384 (P0, data integrity)** — adding a volume to an existing multi-replica resource (`vd c`) left the new volume `Inconsistent` on every replica forever. The late-add seed path passed `isWinner=false` unconditionally because first-activation election was gated on `!rdInitialized`, so no replica seeded the new volume `UpToDate`. Fix recomputes the lowest-node-id winner per fresh volume in the satellite reconciler.
- **385 (P1)** — `node evict` with a free tiebreaker demoted a healthy diskful replica to TieBreaker and left the evicted node's replica counted. The RD tiebreaker decision now excludes replicas on EVICTED/LOST nodes and reaps stranded witnesses.
- **386 (P1)** — `node restore` did not recreate the auto-tiebreaker (the RD reconciler did not watch `Node`), leaving two diskful UpToDate with no witness. Adds a Node watch so the tiebreaker invariant re-runs after restore.
- **387 (P1)** — `r d` of a diskful replica on a 2-diskful + 1-INACTIVE resource spawned a useless TieBreaker because the tiebreaker count treated the INACTIVE (deactivated) replica as a voting diskful. INACTIVE replicas are now excluded from the voting set.
- **388 (test harness)** — the L7 replay assertions `all_uptodate`/`wait_settle` filtered on `spec.resourceName` (the CRD field is `spec.resourceDefinitionName`) and the tiebreaker assertions used a case-insensitive grep that matched the rd name — both silent no-ops that gave false-green. Fixed, plus `no_orphans` settle window, linstor-client 1.27.1 compat (`-m` instead of `--output-fmt=json`, `--storage-pool=` equals form, a `node evict` REST shim), and tolerance for Diskless/TieBreaker rows.

## Test tiers

Each code bug ships its L1/L2 regression, an L6 cli-matrix cell, and an L7 replay YAML. The L7 replays were run green on the live stand through the corrected (non-vacuous) harness; the harness fix is proven non-vacuous (an `Inconsistent` mid-sync replica now fails `all_uptodate` where it previously passed).

Supersedes the per-bug branches fix/bug-384-vd-late-seed-gi, fix/bug-385-evict-tb-shuffle, fix/bug-386-restore-recreate-tb, fix/bug-387-rd-inactive-no-tb, fix/bug-388-l7-assertion-noop (their commits are included here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tiebreaker witness handling when cluster nodes are evicted
  * Fixed tiebreaker recreation after evicted nodes are restored
  * Fixed inactive replicas being incorrectly counted in quorum calculations
  * Fixed late-added volume replica election logic

* **Tests**
  * Added comprehensive test coverage for tiebreaker scenarios
  * Added end-to-end regression tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->