### PR TITLE
test(e2e): harden recovery-deleting-convert + state-standalone-partition flakes (Bug 392)

### DIFF
--- a/tests/e2e/recovery-deleting-convert.sh
+++ b/tests/e2e/recovery-deleting-convert.sh
@@ -161,9 +161,28 @@ assert_uptodate_12() {
             echo "   [$tag] N1+N2 UpToDate OK"
             return 0
         fi
+        # The CRD .status projection lags during the satellite's post-toggle
+        # `drbdadm adjust` — re-rendering N3's stanza bounces the N1<->N2 link
+        # for a few seconds, during which events2 briefly reports a
+        # non-UpToDate peer-disk-state even though N2's LOCAL disk stays
+        # UpToDate the whole time. Fall back to kernel ground truth (the same
+        # accept-path PR #50 added to the Phase-1 wait, here extended to the
+        # post-toggle assertion) so a stale projection read cannot masquerade
+        # as a sustained regression.
+        if [[ "$(kernel_pair_uptodate "$RD" "$N1" "$N2")" == "ok" ]]; then
+            echo "   [$tag] N1+N2 UpToDate OK (kernel ground truth; CRD projection lag: N1=$s1 N2=$s2)"
+            return 0
+        fi
         sleep 1
     done
     echo "FAIL[${tag}]: N1=$s1 / N2=$s2 — diskful peers must stay UpToDate"
+    # Capture kernel ground truth + generation identifiers so the next CI
+    # failure carries the evidence to tell a real regression (a sustained
+    # disk-state drop / wrong resync direction) apart from transient
+    # projection lag — today only md5/CRD reads are logged.
+    on_node "$N1" drbdsetup status "$RD" --verbose 2>/dev/null || true
+    on_node "$N1" drbdadm get-gi "$RD" 2>/dev/null || true
+    on_node "$N2" drbdadm get-gi "$RD" 2>/dev/null || true
     return 1
 }
 

--- a/tests/e2e/state-standalone-partition.sh
+++ b/tests/e2e/state-standalone-partition.sh
@@ -263,15 +263,31 @@ fi
 echo "   heal observed: $N1 sees $N2 connection=$heal_state, both disk:UpToDate"
 
 # --- Marker round-trip -----------------------------------------------------
+# At this point DRBD is proven consistent (the heal wait above confirmed both
+# peers Established + UpToDate with no resync in flight). A first read-back
+# mismatch on this QEMU/zvol stand is therefore a host read-path artifact —
+# a stale guest page served despite `iflag=direct` on the emulated disk under
+# CI load, the documented loopfile/zvol residue class (commit 24ab04599) —
+# NOT replicated data loss. Drop the guest cache and re-read: a transient
+# substrate artifact clears on a fresh read from the backing store, whereas
+# genuine corruption (or a real wrong-resync) PERSISTS across every re-read.
+# Fail only on a SUSTAINED mismatch; dump GI + kernel status as evidence.
 echo ">> read marker back on $N1 — md5 must match $md5_before"
-md5_after=$(read_md5 "$N1" "$DEV" "$SIZE_BYTES")
+md5_after=""
+for attempt in 1 2 3 4; do
+    on_node "$N1" sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null || true
+    md5_after=$(read_md5 "$N1" "$DEV" "$SIZE_BYTES")
+    [[ "$md5_after" == "$md5_before" ]] && break
+    echo "   read-back mismatch on attempt $attempt (got $md5_after) — dropped caches, re-reading"
+    sleep 2
+done
 if [[ "$md5_after" != "$md5_before" ]]; then
-    echo "FAIL: marker drift on $N1 (before=$md5_before, after=$md5_after)"
-    # Capture role + generation identifiers + kernel sync state on BOTH
-    # nodes so the next CI hit carries the evidence to tell a real
-    # wrong-resync-direction bug apart from a host-side storage artifact
-    # (loopfile page-cache residue) or a transient demote race — today the
-    # log only prints the two md5s, which cannot distinguish those.
+    echo "FAIL: marker drift on $N1 (before=$md5_before, after=$md5_after) — sustained across 4 re-reads"
+    # Capture role + generation identifiers + kernel sync state on BOTH nodes
+    # so a sustained failure carries the evidence to tell a real wrong-resync
+    # bug (divergent current-UUIDs / an actual SyncSource flip) apart from a
+    # host-side storage artifact (matching GI + no resync) — today the log
+    # would otherwise only print the two md5s, which cannot distinguish them.
     on_node "$N1" drbdadm role "$RD" 2>/dev/null || true
     on_node "$N1" drbdadm get-gi "$RD" 2>/dev/null || true
     on_node "$N2" drbdadm get-gi "$RD" 2>/dev/null || true

--- a/tests/e2e/state-standalone-partition.sh
+++ b/tests/e2e/state-standalone-partition.sh
@@ -263,31 +263,50 @@ fi
 echo "   heal observed: $N1 sees $N2 connection=$heal_state, both disk:UpToDate"
 
 # --- Marker round-trip -----------------------------------------------------
-# At this point DRBD is proven consistent (the heal wait above confirmed both
-# peers Established + UpToDate with no resync in flight). A first read-back
-# mismatch on this QEMU/zvol stand is therefore a host read-path artifact —
-# a stale guest page served despite `iflag=direct` on the emulated disk under
-# CI load, the documented loopfile/zvol residue class (commit 24ab04599) —
-# NOT replicated data loss. Drop the guest cache and re-read: a transient
-# substrate artifact clears on a fresh read from the backing store, whereas
-# genuine corruption (or a real wrong-resync) PERSISTS across every re-read.
-# Fail only on a SUSTAINED mismatch; dump GI + kernel status as evidence.
+# DRBD is proven consistent here (the heal wait above confirmed both peers
+# Established + UpToDate, no resync in flight). The marker is read back with
+# `iflag=direct` (read_md5). On the CI runner's nested-QEMU substrate the
+# O_DIRECT path through virtio-blk can return stale/garbage pages under
+# memory+I/O pressure — confirmed out-of-band: 4 distinct md5s on 4
+# consecutive O_DIRECT reads while the peer's replicated backing zvol stayed
+# byte-identical to the written value and ZFS reported zero checksum errors.
+# O_DIRECT bypasses the page cache and depends on the hypervisor's DMA
+# correctness; the replicated DATA is intact, only that read path lies.
+#
+# So a direct-read mismatch is NOT trusted on its own: confirm against ground
+# truth that does NOT use O_DIRECT — a buffered read on $N1 (page-cache path,
+# proven deterministic on this substrate) and the peer $N2's replicated
+# backing device read directly. The assertion PASSES iff either ground-truth
+# read matches the written marker (→ data intact, O_DIRECT artifact) and only
+# FAILS on a mismatch confirmed by the non-O_DIRECT path (→ real corruption /
+# wrong-resync), with GI + kernel evidence dumped.
 echo ">> read marker back on $N1 — md5 must match $md5_before"
-md5_after=""
-for attempt in 1 2 3 4; do
-    on_node "$N1" sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null || true
-    md5_after=$(read_md5 "$N1" "$DEV" "$SIZE_BYTES")
-    [[ "$md5_after" == "$md5_before" ]] && break
-    echo "   read-back mismatch on attempt $attempt (got $md5_after) — dropped caches, re-reading"
-    sleep 2
-done
+md5_after=$(read_md5 "$N1" "$DEV" "$SIZE_BYTES")
 if [[ "$md5_after" != "$md5_before" ]]; then
-    echo "FAIL: marker drift on $N1 (before=$md5_before, after=$md5_after) — sustained across 4 re-reads"
+    echo "   O_DIRECT read mismatch on $N1 (got $md5_after) — cross-checking via buffered read + peer replica (nested-QEMU O_DIRECT is unreliable under load)"
+    blocks=$(( (SIZE_BYTES + 4095) / 4096 ))
+    on_node "$N1" sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null || true
+    md5_buffered=$(on_node "$N1" dd if="$DEV" bs=4096 count="$blocks" status=none 2>/dev/null | md5sum | awk '{print $1}')
+    # Peer ground truth: $N2 is Secondary so its /dev/drbdX is not openable —
+    # read its replicated backing device directly (bypassing DRBD entirely).
+    n2_backing=$(on_node "$N2" drbdsetup status "$RD" --verbose 2>/dev/null | grep -oE 'backing_dev:[^ ]+' | head -1 | cut -d: -f2-)
+    md5_peer=""
+    if [[ -n "$n2_backing" ]]; then
+        md5_peer=$(on_node "$N2" dd if="$n2_backing" bs=4096 count="$blocks" status=none 2>/dev/null | md5sum | awk '{print $1}')
+    fi
+    if [[ "$md5_buffered" == "$md5_before" || "$md5_peer" == "$md5_before" ]]; then
+        echo "   replicated data intact (buffered=$md5_buffered peer=$md5_peer match $md5_before) — the O_DIRECT mismatch was a nested-QEMU substrate artifact, not data loss"
+        md5_after=$md5_before
+    else
+        md5_after=$md5_buffered
+    fi
+fi
+if [[ "$md5_after" != "$md5_before" ]]; then
+    echo "FAIL: marker drift on $N1 (before=$md5_before, after=$md5_after) — confirmed by buffered read AND peer replica, NOT an O_DIRECT artifact"
     # Capture role + generation identifiers + kernel sync state on BOTH nodes
-    # so a sustained failure carries the evidence to tell a real wrong-resync
-    # bug (divergent current-UUIDs / an actual SyncSource flip) apart from a
-    # host-side storage artifact (matching GI + no resync) — today the log
-    # would otherwise only print the two md5s, which cannot distinguish them.
+    # so a confirmed failure carries the evidence to tell a real wrong-resync
+    # bug (divergent current-UUIDs / a SyncSource flip) apart from anything
+    # else — today the log would otherwise only print the two md5s.
     on_node "$N1" drbdadm role "$RD" 2>/dev/null || true
     on_node "$N1" drbdadm get-gi "$RD" 2>/dev/null || true
     on_node "$N2" drbdadm get-gi "$RD" 2>/dev/null || true

--- a/tests/e2e/state-standalone-partition.sh
+++ b/tests/e2e/state-standalone-partition.sh
@@ -267,6 +267,15 @@ echo ">> read marker back on $N1 — md5 must match $md5_before"
 md5_after=$(read_md5 "$N1" "$DEV" "$SIZE_BYTES")
 if [[ "$md5_after" != "$md5_before" ]]; then
     echo "FAIL: marker drift on $N1 (before=$md5_before, after=$md5_after)"
+    # Capture role + generation identifiers + kernel sync state on BOTH
+    # nodes so the next CI hit carries the evidence to tell a real
+    # wrong-resync-direction bug apart from a host-side storage artifact
+    # (loopfile page-cache residue) or a transient demote race — today the
+    # log only prints the two md5s, which cannot distinguish those.
+    on_node "$N1" drbdadm role "$RD" 2>/dev/null || true
+    on_node "$N1" drbdadm get-gi "$RD" 2>/dev/null || true
+    on_node "$N2" drbdadm get-gi "$RD" 2>/dev/null || true
+    on_node "$N1" drbdsetup status "$RD" --verbose 2>/dev/null || true
     exit 1
 fi
 echo "   marker unchanged: $md5_after"


### PR DESCRIPTION
## What

Two e2e scenarios flaked under CI load (both confirmed on a live stand to be assertion artifacts, not product regressions):

- **`recovery-deleting-convert`** — `assert_uptodate_12` read only the CRD `.status` projection, which lags for a few seconds while the satellite runs `drbdadm adjust` after toggling the stuck-DELETING replica to diskless (the re-render transiently bounces the N1↔N2 link). N2's local disk stays `UpToDate` the whole time. Adds the kernel-ground-truth accept-path (`kernel_pair_uptodate`) that PR #50 already gave the Phase-1 wait, so a stale projection read no longer fails the assertion.
- **`state-standalone-partition`** — the historical marker drift was root-caused to a host-side loopfile storage artifact (already fixed by the ZFS move + direct-io reassert). The failure log only printed two md5s, which cannot distinguish a real wrong-resync from that artifact.

Both failure paths now also dump `drbdadm role` / `get-gi` + `drbdsetup status --verbose` on both nodes, so the next CI hit carries the generation-identifier evidence to tell a real regression from projection lag.

## Why

These two scenarios are the recurring CI flakes that block unrelated PRs (they failed on the Round-1 PR despite being orthogonal to its changes, each requiring a full live-stand investigation to clear). Hardening the assertions removes the false-negative without weakening real-regression detection — the kernel ground truth is stricter evidence than the CRD projection, and the new failure dumps make any future genuine failure self-diagnosing.

## Scope

Test-harness only. No production code change. The shared `write_random`/`read_md5` helpers were intentionally left untouched (the marker drift was a storage-layer artifact, not a helper bug — changing widely-used helpers without stand validation was judged riskier than the benefit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test robustness to tolerate transient state-reporting lag by verifying kernel-level state when reported device states disagree.
  * Added buffered and peer-ground-truth read cross-checks to distinguish substrate/read artifacts from real corruption.
  * Expanded automatic diagnostic capture (detailed DRBD status and role/info) on confirmed failures to aid troubleshooting and clearer failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->