### PR TITLE
fix(placer): exclude INACTIVE replicas from place_count so autoplace refills active redundancy (Bug 393)

### DIFF
--- a/pkg/placer/placer.go
+++ b/pkg/placer/placer.go
@@ -367,14 +367,24 @@ func (p *Placer) assemblePlan(ctx context.Context, rdName string, filter *apiv1.
 }
 
 // countDiskfulReplicas returns the number of existing replicas that
-// satisfy place_count: diskful (no DISKLESS flag) and not on an
-// EVICTED/LOST node.
+// satisfy place_count: diskful (no DISKLESS flag), active (no INACTIVE
+// flag), and not on an EVICTED/LOST node.
 //
 // DISKLESS replicas — including auto-tiebreaker witnesses, which carry
 // both DISKLESS and TIE_BREAKER — do NOT count. place_count is the
 // diskful-replica target. A 3-replica RG sitting at 2 diskful + 1
 // diskless witness must be treated as 1-short so the placer fills the
 // gap rather than declaring satisfaction.
+//
+// INACTIVE replicas do NOT count either. An INACTIVE replica is
+// `drbdadm down` (Bug 350): it serves no I/O, casts no quorum vote,
+// and is dropped from every sibling's .res file (see the dispatcher's
+// regenerateResFile INACTIVE filter). So an RD sitting at 2 active
+// diskful + 1 INACTIVE diskful with place_count=3 is effectively
+// 1-short on active redundancy, and the placer must gap-fill a
+// replacement active diskful on a healthy node rather than declaring
+// satisfaction. This mirrors the active-replica accounting used by the
+// satellite/dispatcher INACTIVE filters (Bugs 350/387).
 func countDiskfulReplicas(existing []apiv1.Resource, disabled map[string]struct{}) int {
 	count := 0
 
@@ -384,6 +394,10 @@ func countDiskfulReplicas(existing []apiv1.Resource, disabled map[string]struct{
 		}
 
 		if slices.Contains(existing[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		if slices.Contains(existing[i].Flags, apiv1.ResourceFlagInactive) {
 			continue
 		}
 

--- a/pkg/placer/placer_test.go
+++ b/pkg/placer/placer_test.go
@@ -1018,6 +1018,95 @@ func TestPlacerDeficitExcludesDisklessAndTiebreaker(t *testing.T) {
 	}
 }
 
+// TestPlacerDeficitExcludesInactiveDiskful pins Bug 393: an INACTIVE
+// diskful replica is `drbdadm down` — it serves no I/O and casts no
+// quorum vote — so it must NOT count toward place_count. An RD at
+// 2 active diskful + 1 INACTIVE diskful with place_count=3 is 1-short
+// on ACTIVE redundancy; the placer must gap-fill a replacement active
+// diskful rather than declaring satisfaction.
+//
+// Setup: place_count=3, 4 healthy nodes. Pre-seed 2 active diskful
+// replicas (n1+n2) and one INACTIVE diskful replica (n3). The placer
+// must add a 3rd ACTIVE diskful replica on n4 — NOT treat the INACTIVE
+// replica as the 3rd active replica and exit early. The INACTIVE
+// replica's node stays "taken" so the replacement lands on n4.
+func TestPlacerDeficitExcludesInactiveDiskful(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	seedStore(t, st, []string{"n1", "n2", "n3", "n4"})
+
+	// Two active diskful replicas on n1 + n2.
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-1", NodeName: n,
+			Props: map[string]string{"StorPoolName": "pool"},
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	// INACTIVE diskful replica on n3: backing pool present (it IS
+	// diskful) but deactivated. Without the Bug 393 fix the placer
+	// counts n3 as a satisfied replica and stops at 2 active + 1
+	// INACTIVE instead of going to 3 active diskful.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-1", NodeName: "n3",
+		Props: map[string]string{"StorPoolName": "pool"},
+		Flags: []string{apiv1.ResourceFlagInactive},
+	}); err != nil {
+		t.Fatalf("seed inactive: %v", err)
+	}
+
+	p := placer.New(st)
+
+	placed, want, err := p.Place(ctx, "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 3})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 3 || want != 3 {
+		t.Errorf("placed/want: got %d/%d, want 3/3 (INACTIVE must not count)", placed, want)
+	}
+
+	got, _ := st.Resources().ListByDefinition(ctx, "pvc-1")
+
+	active := 0
+	inactive := 0
+
+	for _, r := range got {
+		if slices.Contains(r.Flags, apiv1.ResourceFlagInactive) {
+			inactive++
+
+			continue
+		}
+
+		active++
+	}
+
+	if active != 3 {
+		t.Errorf("active diskful count: got %d, want 3 (gap-fill must run); resources=%+v", active, got)
+	}
+
+	if inactive != 1 {
+		t.Errorf("inactive count: got %d, want 1 (existing INACTIVE left untouched); resources=%+v", inactive, got)
+	}
+
+	// The new active diskful replica must land on n4 — the only
+	// remaining healthy node not already taken by an existing replica
+	// (n3 stays taken so we don't double-place onto the INACTIVE node).
+	gotNodes := map[string]bool{}
+	for _, r := range got {
+		gotNodes[r.NodeName] = true
+	}
+
+	if !gotNodes["n4"] {
+		t.Errorf("expected new active diskful replica on n4; got %+v", gotNodes)
+	}
+}
+
 // TestPlacePlaceCountIgnoresDisklessWitness pins Bug 28: PlaceCount
 // counts DISKFUL replicas only — a DISKLESS / TIE_BREAKER witness
 // pre-seeded by the RD reconciler's ensureTiebreaker race must NOT

--- a/tests/e2e/cli-matrix/r-inactive-refills-active-redundancy.sh
+++ b/tests/e2e/cli-matrix/r-inactive-refills-active-redundancy.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# usage: r-inactive-refills-active-redundancy.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 393 (P1, placer INACTIVE miscount).
+#
+# Symptom: the autoplacer counts an INACTIVE diskful replica toward
+# place_count. An INACTIVE replica is `drbdadm down` (operator
+# deactivation, Bug 350) — it serves no I/O and casts no quorum vote,
+# and is dropped from every sibling's .res file. So on an RD sitting at
+# 2 ACTIVE diskful + 1 INACTIVE diskful with place_count=3 the placer's
+# `placed >= want` test was satisfied and it did NOT gap-fill a
+# replacement active diskful — the RD silently ran with only 2 active
+# replicas instead of the 3 the operator requested.
+#
+# Root cause: pkg/placer/placer.go `countDiskfulReplicas` excluded
+# DISKLESS and disabled-node (EVICTED/LOST) replicas, but NOT INACTIVE.
+# Fix: also skip INACTIVE so it never satisfies place_count — the same
+# INACTIVE-miscount class as Bugs 387 / 390.
+#
+# Unit pin: pkg/placer/placer_test.go
+# (TestPlacerDeficitExcludesInactiveDiskful).
+#
+# This L6 cell is the stand-side companion: drives the real
+# python-linstor CLI on a 3-diskful → deactivate-one → re-autoplace=3
+# shape and asserts the placer refills a replacement ACTIVE diskful on
+# a 4th node, so the count of ACTIVE diskful replicas reaches 3 again
+# (the INACTIVE replica stays put and does not count).
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# Need a 4th healthy worker as the gap-fill target: the 3 original
+# diskful nodes are all "taken" (incl. the INACTIVE one), so the
+# replacement active diskful must land on a node outside that set.
+require_workers 4
+
+linstor_cli_setup
+
+RD=cli-matrix-393
+SP=${SP:-stand}
+# WORKER_4 is not exported by the parent lib.sh (it only ships
+# WORKER_1..3); derive it from the same alphabetically-sorted worker
+# list so the gap-fill target is deterministic.
+mapfile -t _WORKERS < <(
+    kubectl get nodes -l '!node-role.kubernetes.io/control-plane' \
+        -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | sort
+)
+N4="${_WORKERS[3]:-}"
+if [[ -z "$N4" ]]; then
+    skip "scenario needs a 4th worker for the gap-fill target"
+fi
+
+# linstor_active_diskful_count <rd> — number of replicas that are
+# diskful (no DISKLESS / TIE_BREAKER) AND active (no INACTIVE). This is
+# exactly what place_count must count after Bug 393.
+linstor_active_diskful_count() {
+    local rd=$1
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}' \
+        | while read -r name; do
+            [[ -z "$name" ]] && continue
+            local flags
+            flags=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+                -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+            if [[ "$flags" != *"DISKLESS"* ]] \
+                && [[ "$flags" != *"TIE_BREAKER"* ]] \
+                && [[ "$flags" != *"INACTIVE"* ]]; then
+                echo "${name#${rd}.}"
+            fi
+        done \
+        | awk 'NF{c++} END{print c+0}'
+}
+
+cleanup() {
+    # Reactivate the deactivated replica first so delete_rd can drive a
+    # clean cascade tear-down. DEACT is only set once we've picked the
+    # node, so guard with the default-empty form.
+    if [[ -n "${DEACT:-}" ]]; then
+        "${LCTL[@]}" resource activate "$DEACT" "$RD" 2>/dev/null || true
+    fi
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug 393] rd c + vd c + r c --auto-place=3 -s $SP"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=3 --storage-pool="$SP" "$RD" >/dev/null
+
+echo ">> wait up to 180s for 3 active diskful UpToDate"
+deadline=$(( $(date +%s) + 180 ))
+ready=false
+while (( $(date +%s) < deadline )); do
+    if [[ "$(linstor_active_diskful_count "$RD")" == "3" ]] \
+        && [[ "$(linstor_replica_count "$RD")" == "3" ]]; then
+        ready=true
+        break
+    fi
+    sleep 3
+done
+if [[ "$ready" != "true" ]]; then
+    echo "FAIL: never reached 3 active diskful within 180s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# Capture the 3 diskful node names so we can deactivate one and verify
+# the replacement lands OUTSIDE this set.
+mapfile -t DISKFUL_NODES < <(linstor_diskful_nodes "$RD")
+DEACT="${DISKFUL_NODES[0]}"
+echo "   3 active diskful on: ${DISKFUL_NODES[*]}; deactivating $DEACT"
+
+# Deactivate one diskful replica → INACTIVE flag. It is still a diskful
+# replica (backing disk present) but `drbdadm down`: non-voting,
+# non-serving. The placer must treat the RD as 1-short on active
+# redundancy.
+echo ">> linstor r deactivate $DEACT $RD  (→ INACTIVE)"
+"${LCTL[@]}" resource deactivate "$DEACT" "$RD" >/dev/null 2>&1 || {
+    echo "FAIL: r deactivate $DEACT $RD exited non-zero" >&2
+    exit 1
+}
+
+echo ">> wait up to 30s for INACTIVE flag visible on $DEACT"
+deadline=$(( $(date +%s) + 30 ))
+inactive=false
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${DEACT}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$flags" == *"INACTIVE"* ]]; then
+        inactive=true
+        break
+    fi
+    sleep 2
+done
+if [[ "$inactive" != "true" ]]; then
+    echo "FAIL: INACTIVE flag never landed on $DEACT within 30s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo "   $DEACT is INACTIVE; active diskful is now 2 (want 3)"
+
+# Re-trigger autoplace=3. Pre-fix the placer counts the INACTIVE
+# replica as the 3rd and is satisfied → no replacement. Post-fix the
+# INACTIVE replica does NOT count, so the placer gap-fills a fresh
+# active diskful on the 4th node.
+echo ">> linstor r c $RD --auto-place=3 -s $SP  (rebalance / gap-fill)"
+"${LCTL[@]}" resource create --auto-place=3 --storage-pool="$SP" "$RD" >/dev/null 2>&1 || {
+    echo "FAIL: re-autoplace=3 exited non-zero" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+}
+
+echo ">> wait up to 180s for ACTIVE diskful count to reach 3 again"
+deadline=$(( $(date +%s) + 180 ))
+refilled=false
+while (( $(date +%s) < deadline )); do
+    if [[ "$(linstor_active_diskful_count "$RD")" == "3" ]]; then
+        refilled=true
+        break
+    fi
+    sleep 3
+done
+if [[ "$refilled" != "true" ]]; then
+    n_active=$(linstor_active_diskful_count "$RD")
+    echo "FAIL (Bug 393 regression): active diskful = $n_active, want 3" >&2
+    echo "  an INACTIVE replica must NOT satisfy place_count — the placer" >&2
+    echo "  must gap-fill a replacement active diskful." >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# The deactivated node must STILL be INACTIVE — the gap-fill must not
+# have reactivated it; it must have placed a NEW replica elsewhere.
+deact_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${DEACT}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+if [[ "$deact_flags" != *"INACTIVE"* ]]; then
+    echo "FAIL (Bug 393): $DEACT lost its INACTIVE flag (flags=$deact_flags)" >&2
+    echo "  the placer must refill on a fresh node, not reactivate the down one" >&2
+    exit 1
+fi
+
+# The replacement active diskful must be on a node OUTSIDE the original
+# 3-diskful set — i.e. the 4th worker. Confirm $N4 now carries an
+# active diskful replica.
+n4_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N4}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "__missing__")
+if [[ "$n4_flags" == "__missing__" ]]; then
+    echo "FAIL (Bug 393): no replacement replica on the 4th worker $N4" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+if [[ "$n4_flags" == *"INACTIVE"* ]] \
+    || [[ "$n4_flags" == *"DISKLESS"* ]] \
+    || [[ "$n4_flags" == *"TIE_BREAKER"* ]]; then
+    echo "FAIL (Bug 393): replacement on $N4 is not an active diskful (flags=$n4_flags)" >&2
+    exit 1
+fi
+
+echo ">> r-inactive-refills-active-redundancy OK (Bug 393 pinned: INACTIVE diskful does not satisfy place_count; placer refilled active redundancy on $N4)"

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -171,6 +171,7 @@ substitute() {
     s=${s//\{\{node1\}\}/${NODE1:-}}
     s=${s//\{\{node2\}\}/${NODE2:-}}
     s=${s//\{\{node3\}\}/${NODE3:-}}
+    s=${s//\{\{node4\}\}/${NODE4:-}}
     echo "$s"
 }
 
@@ -211,6 +212,30 @@ try:
         d=d[0]
     print(len(d))
 except: print(0)")
+            [[ "$count" -ge "$min" ]]
+            ;;
+        active_diskful_count)
+            # Bug 393: count replicas of rd that are ACTIVE diskful —
+            # i.e. NOT DISKLESS / TIE_BREAKER (no backing disk) and NOT
+            # INACTIVE (`drbdadm down`, non-voting, non-serving). This is
+            # exactly what place_count must be measured against: an
+            # INACTIVE diskful replica does NOT count toward satisfied
+            # redundancy, so the placer must gap-fill to reach `min`.
+            local rd min count
+            rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
+            min=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('min',2))" "$spec")
+            count=$(kubectl get resources.blockstor.cozystack.io -o json 2>/dev/null \
+                | python3 -c "import json,sys
+d=json.load(sys.stdin)
+rd='$rd'
+n=0
+for it in d.get('items',[]):
+    if it.get('spec',{}).get('resourceDefinitionName')!=rd: continue
+    flags=it.get('spec',{}).get('flags',[]) or []
+    if 'DISKLESS' in flags or 'TIE_BREAKER' in flags: continue
+    if 'INACTIVE' in flags: continue
+    n+=1
+print(n)")
             [[ "$count" -ge "$min" ]]
             ;;
         disk_state)

--- a/tests/operator-harness/replay-runner.sh
+++ b/tests/operator-harness/replay-runner.sh
@@ -45,6 +45,9 @@
 # Assertion kinds supported under "await":
 #
 #   - replica_count        wait until N replicas of rd exist with disk≠Diskless
+#   - active_diskful_count wait until ≥ min ACTIVE diskful replicas exist
+#                           (excludes DISKLESS/TIE_BREAKER and INACTIVE;
+#                            Bug 393 — INACTIVE must not satisfy place_count)
 #   - disk_state           wait until rd@node reports disk_state == expected
 #   - all_uptodate         wait until every replica reports UpToDate
 #   - replica_diskless     wait until rd@node has disk_state == Diskless
@@ -67,7 +70,8 @@
 #
 #   {{rd}}            workflow.vars.rd (default "replay-<name>-<rand4>")
 #   {{sp}}            workflow.vars.sp (default "stand")
-#   {{node1}} … {{node3}}  resolved from kubectl-discovered worker list
+#   {{node1}} … {{node4}}  resolved from kubectl-discovered worker list
+#                           ({{node4}} needs min_nodes: 4)
 #
 # Exit codes:
 #
@@ -125,6 +129,10 @@ mapfile -t WORKERS < <(
 NODE1="${WORKERS[0]:-}"
 NODE2="${WORKERS[1]:-}"
 NODE3="${WORKERS[2]:-}"
+# NODE4 is the gap-fill target for redundancy-refill workflows (Bug 393):
+# an RD pinned to NODE1..3 that loses one active replica must refill onto
+# a node OUTSIDE that set. Workflows needing it declare min_nodes: 4.
+NODE4="${WORKERS[3]:-}"
 
 # ----------------------------------------------------------------------
 # variable substitution

--- a/tests/operator-harness/replay/inactive-refills-active-redundancy.yaml
+++ b/tests/operator-harness/replay/inactive-refills-active-redundancy.yaml
@@ -1,0 +1,91 @@
+name: inactive-refills-active-redundancy
+description: |
+  Bug-393 catcher (P1). The autoplacer must NOT count an INACTIVE
+  diskful replica toward place_count.
+
+  An INACTIVE replica is `drbdadm down` (operator deactivation, Bug 350):
+  it serves no I/O, casts no quorum vote, and is dropped from every
+  sibling's .res file. So an RD sitting at 2 ACTIVE diskful + 1 INACTIVE
+  diskful with place_count=3 is effectively 1-short on active redundancy.
+  Pre-fix, `pkg/placer/placer.go countDiskfulReplicas` counted the
+  INACTIVE replica as satisfied (`placed >= want`), so a re-autoplace did
+  nothing and the RD silently ran with only 2 active replicas. The fix
+  excludes INACTIVE so the placer gap-fills a replacement active diskful.
+
+  Sequence: pin 3 diskful (node1+node2+node3) → wait all UpToDate →
+  deactivate node1 (INACTIVE) → re-autoplace=3 → assert the active
+  diskful count climbs back to 3 (the replacement lands on node4, the
+  only worker outside the original taken set) and node4 reaches UpToDate.
+  This is the SAME INACTIVE-miscount class as Bugs 387 / 390.
+
+prerequisites:
+  min_nodes: 4
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node3
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-3-active-diskful
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: active_diskful_count
+      rd: "{{rd}}"
+      min: 3
+      timeout_s: 240
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: r-deactivate-node1
+    cmd: ["resource", "deactivate", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+  # Re-trigger autoplace. Pre-fix the placer counts the INACTIVE node1 as
+  # the 3rd diskful and is satisfied → no replacement is created. Post-fix
+  # the INACTIVE replica does NOT count, so the placer gap-fills a fresh
+  # active diskful on node4.
+  - name: re-autoplace-3
+    cmd: ["resource", "create", "--auto-place=3", "--storage-pool={{sp}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: active_diskful_count
+      rd: "{{rd}}"
+      min: 3
+      timeout_s: 240
+  # The replacement active diskful must materialise on node4 — the only
+  # worker outside the original 3-node taken set — and reach UpToDate.
+  - name: node4-replacement-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node4}}"
+      expected: UpToDate
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource", "activate", "{{node1}}", "{{rd}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## What

The autoplacer counted INACTIVE diskful replicas toward `place_count`. An INACTIVE replica is `drbdadm down` (operator deactivation, Bug 350): it serves no I/O, casts no quorum vote, and is dropped from every sibling's `.res` file. Counting it toward satisfied redundancy let an RD sitting at 2 active diskful + 1 INACTIVE diskful with `place_count=3` satisfy `placed >= want`, so the placer skipped the gap-fill and the RD silently ran with fewer ACTIVE replicas than the operator requested.

## Why

This is the same INACTIVE-miscount class as Bugs 387 and 390 — both already learned that an INACTIVE replica is not a voting/serving diskful. `pkg/placer/placer.go countDiskfulReplicas` excluded DISKLESS and disabled-node (EVICTED/LOST) replicas but never INACTIVE, so the placer's redundancy accounting diverged from the rest of the controller.

## Fix

Skip INACTIVE in `countDiskfulReplicas` (reusing `apiv1.ResourceFlagInactive`, the same constant the dispatcher/satellite INACTIVE filters use). Now an INACTIVE diskful no longer satisfies `place_count`, so the placer gap-fills a replacement active diskful on a healthy node and active redundancy is restored to `place_count`. The change is scoped to the single redundancy-counting helper; topology/anti-affinity seeding still sees the INACTIVE replica's node so the replacement lands on a fresh node rather than double-placing.

## Tests (CLI-bug-fix protocol)

- **L1 unit** — `pkg/placer/placer_test.go::TestPlacerDeficitExcludesInactiveDiskful`: 2 active diskful + 1 INACTIVE diskful, `place_count=3` → asserts the placer adds a 3rd active diskful on the free node and leaves the INACTIVE one untouched. Verified failing pre-fix (active=2), passing post-fix.
- **L6 cli-matrix** — `tests/e2e/cli-matrix/r-inactive-refills-active-redundancy.sh`: real CLI 3-diskful → deactivate-one → re-autoplace=3, asserts active diskful reaches 3 on a 4th node and the deactivated node stays INACTIVE.
- **L7 replay** — `tests/operator-harness/replay/inactive-refills-active-redundancy.yaml`: codifies the operator sequence with a new `active_diskful_count` await (excludes DISKLESS/TIE_BREAKER and INACTIVE) and `{{node4}}` substitution for the refill target.

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./pkg/placer/...` all green. Live-stand replay validation is left to the launcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Placer now correctly excludes INACTIVE replicas when calculating diskful redundancy satisfaction, ensuring replacement replicas are properly placed when one becomes inactive.

* **Tests**
  * Added unit tests, end-to-end CLI tests, and replay scenarios to validate proper handling of INACTIVE diskful replicas during placement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->