### PR TITLE
fix(rest): exclude INACTIVE replicas from snapshot target nodes (Bug 394)

### DIFF
--- a/pkg/rest/snapshots.go
+++ b/pkg/rest/snapshots.go
@@ -465,10 +465,17 @@ func successDenominator(snap *apiv1.Snapshot, diskful map[string]struct{}) map[s
 }
 
 // diskfulPeerSet enumerates the Resources of an RD and returns the
-// set of node names whose Flags slice contains neither DISKLESS nor
-// TIE_BREAKER. NotFound on the RD soft-fails to an empty set —
-// matches handleSnapshotList's "treat orphan snapshot rows as
+// set of node names whose Flags slice contains neither DISKLESS,
+// TIE_BREAKER, nor INACTIVE. NotFound on the RD soft-fails to an empty
+// set — matches handleSnapshotList's "treat orphan snapshot rows as
 // renderable" stance.
+//
+// Bug 394: INACTIVE replicas are excluded from the snapshot target set
+// (listDiskfulNodes), so they never receive a Snapshots[] entry. They
+// must therefore also be excluded from the success denominator here,
+// otherwise an RD with an INACTIVE replica would hang at Incomplete
+// forever (the INACTIVE node can never satisfy the success check).
+// Mirrors the DISKLESS/TIE_BREAKER skips.
 func (s *Server) diskfulPeerSet(ctx context.Context, rdName string) (map[string]struct{}, error) {
 	resList, err := s.Store.Resources().ListByDefinition(ctx, rdName)
 	if err != nil {
@@ -488,6 +495,10 @@ func (s *Server) diskfulPeerSet(ctx context.Context, rdName string) (map[string]
 		}
 
 		if slices.Contains(flags, apiv1.ResourceFlagTieBreaker) {
+			continue
+		}
+
+		if slices.Contains(flags, apiv1.ResourceFlagInactive) {
 			continue
 		}
 
@@ -985,10 +996,18 @@ func (s *Server) offlineTargetNodes(ctx context.Context, targets []string) []str
 	return offline
 }
 
-// listDiskfulNodes returns the node names that host a diskful
+// listDiskfulNodes returns the node names that host an ACTIVE diskful
 // (non-DISKLESS) replica of rd. Used to default snap.Nodes when the
 // caller didn't pin a per-node list — matches upstream's
 // "snapshot all diskful replicas" semantic.
+//
+// Bug 394: an INACTIVE diskful replica holds data but its DRBD device
+// is down (`drbdadm down`), so the satellite cannot ack the snapshot
+// suspend-io barrier for it — that node reports Failed and the whole
+// snapshot group aborts (resume-on-abort). Exclude INACTIVE replicas
+// from the target node set, mirroring the DISKLESS skip; the INACTIVE
+// replica catches up on reactivation. Same INACTIVE-miscount class as
+// Bugs 387/390/393.
 func listDiskfulNodes(ctx context.Context, s *Server, rd string) ([]string, error) {
 	resList, err := s.Store.Resources().ListByDefinition(ctx, rd)
 	if err != nil {
@@ -999,6 +1018,10 @@ func listDiskfulNodes(ctx context.Context, s *Server, rd string) ([]string, erro
 
 	for i := range resList {
 		if slices.Contains(resList[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		if slices.Contains(resList[i].Flags, apiv1.ResourceFlagInactive) {
 			continue
 		}
 

--- a/pkg/rest/snapshots_test.go
+++ b/pkg/rest/snapshots_test.go
@@ -1970,3 +1970,168 @@ func TestSnapshotBug352TwoNodeScopedDenominatorOnePeerInFlightStaysIncomplete(t 
 			"reported back: %v", got[0].Flags)
 	}
 }
+
+// TestSnapshotCreateExcludesInactiveReplica_Bug394 pins the Bug 394
+// fix: an RD with an INACTIVE diskful replica must NOT target that
+// node in the snapshot fan-out. An INACTIVE replica holds data but its
+// DRBD device is down (`drbdadm down`), so the satellite cannot ack
+// the snapshot suspend-io barrier for it — the node reports Failed and
+// the whole snapshot group aborts (resume-on-abort). Pre-fix,
+// listDiskfulNodes only skipped DISKLESS, so the INACTIVE node leaked
+// into Spec.Nodes and every `snapshot create` on the RD aborted.
+//
+// Post-fix the snapshot targets only the ACTIVE diskful set; the
+// INACTIVE replica catches up on reactivation. Same INACTIVE-miscount
+// class as Bugs 387/390/393.
+func TestSnapshotCreateExcludesInactiveReplica_Bug394(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "pvc-inactive"}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Three diskful replicas: n1 + n2 ACTIVE, n3 INACTIVE (DRBD device
+	// down). The fan-out must include n1 + n2 only.
+	for _, r := range []apiv1.Resource{
+		{Name: "pvc-inactive", NodeName: "n1"},
+		{Name: "pvc-inactive", NodeName: "n2"},
+		{Name: "pvc-inactive", NodeName: "n3", Flags: []string{apiv1.ResourceFlagInactive}},
+	} {
+		if err := st.Resources().Create(ctx, &r); err != nil {
+			t.Fatalf("seed resource %s: %v", r.NodeName, err)
+		}
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Payload omits `nodes` — lets the controller derive "every ACTIVE
+	// diskful peer" (the `linstor snapshot create <rd> <snap>` form).
+	body, err := json.Marshal(apiv1.Snapshot{Name: "snap-bug394"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-inactive/snapshots", body)
+	_ = resp.Body.Close()
+
+	// The create must SUCCEED across the active set rather than abort.
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (snapshot must succeed across active set)", resp.StatusCode)
+	}
+
+	got, err := st.Snapshots().Get(ctx, "pvc-inactive", "snap-bug394")
+	if err != nil {
+		t.Fatalf("get snapshot: %v", err)
+	}
+
+	// Spec.Nodes MUST resolve to the ACTIVE diskful set only.
+	if len(got.Nodes) != 2 {
+		t.Fatalf("Nodes: got %v (len=%d), want exactly [n1 n2] (INACTIVE n3 must be excluded)",
+			got.Nodes, len(got.Nodes))
+	}
+
+	if slices.Contains(got.Nodes, "n3") {
+		t.Errorf("Nodes: INACTIVE replica n3 leaked into snapshot target set: %v "+
+			"(suspend-io barrier would abort the group)", got.Nodes)
+	}
+
+	wantNodes := map[string]bool{"n1": true, "n2": true}
+	for _, n := range got.Nodes {
+		if !wantNodes[n] {
+			t.Errorf("Nodes: unexpected entry %q", n)
+		}
+
+		delete(wantNodes, n)
+	}
+
+	for n := range wantNodes {
+		t.Errorf("Nodes: missing active diskful peer %q", n)
+	}
+
+	// Per-node materialisation mirrors the active set — the INACTIVE
+	// node must not receive a Snapshots[] entry.
+	if len(got.Snapshots) != 2 {
+		t.Fatalf("Snapshots[]: got %d entries, want 2 (one per active diskful peer); got=%+v",
+			len(got.Snapshots), got.Snapshots)
+	}
+
+	for _, sn := range got.Snapshots {
+		if sn.NodeName == "n3" {
+			t.Errorf("Snapshots[]: INACTIVE n3 included in per-node materialisation: %+v", got.Snapshots)
+		}
+	}
+}
+
+// TestSnapshotStateIgnoresInactiveReplica_Bug394 pins the
+// success-denominator half of the Bug 394 fix: diskfulPeerSet must
+// exclude INACTIVE replicas, exactly as it excludes DISKLESS and
+// TIE_BREAKER. The INACTIVE replica is never a snapshot target (it
+// holds no Snapshots[] entry), so if it stayed in the denominator the
+// snapshot would hang at Incomplete forever — every active peer can
+// report success yet the INACTIVE node can never satisfy the check.
+//
+// The snapshot row is seeded with an EMPTY Nodes list so the success
+// derivation takes the broadcast path (successDenominator returns the
+// full diskful set verbatim). That is what makes diskfulPeerSet's
+// INACTIVE skip load-bearing: with a non-empty Nodes list the absent
+// INACTIVE node would be filtered out by the Nodes∩diskful intersection
+// regardless, masking the bug.
+//
+// Topology: n1 + n2 ACTIVE diskful (both reported CreateTimestamp),
+// n3 INACTIVE diskful. The snapshot MUST be stamped SUCCESSFUL.
+func TestSnapshotStateIgnoresInactiveReplica_Bug394(t *testing.T) {
+	ctx := t.Context()
+
+	st := store.NewInMemory()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name: "bug394test",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	resources := []apiv1.Resource{
+		{Name: "bug394test", NodeName: "worker-1"},
+		{Name: "bug394test", NodeName: "worker-2"},
+		{Name: "bug394test", NodeName: "worker-3", Flags: []string{apiv1.ResourceFlagInactive}},
+	}
+
+	for i := range resources {
+		if err := st.Resources().Create(ctx, &resources[i]); err != nil {
+			t.Fatalf("seed Resource %s: %v", resources[i].NodeName, err)
+		}
+	}
+
+	// Broadcast snapshot row: empty Nodes → successDenominator returns
+	// the diskfulPeerSet verbatim. Both ACTIVE peers reported
+	// CreateTimestamp; the INACTIVE worker-3 reported nothing (its DRBD
+	// device is down). Pre-fix, diskfulPeerSet counted worker-3, so the
+	// "every diskful peer reported" check never passed → no SUCCESSFUL.
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap1",
+		ResourceName: "bug394test",
+		Snapshots: []apiv1.SnapshotPerNode{
+			{SnapshotName: "snap1", NodeName: "worker-1", CreateTimestamp: 1714000000},
+			{SnapshotName: "snap1", NodeName: "worker-2", CreateTimestamp: 1714000050},
+		},
+	}); err != nil {
+		t.Fatalf("seed Snapshot: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	got := decodeSnapshotPage(t, base+"/v1/view/snapshots")
+	if len(got) != 1 {
+		t.Fatalf("view len: got %d, want 1", len(got))
+	}
+
+	if !slices.Contains(got[0].Flags, apiv1.SnapshotFlagSuccessful) {
+		t.Errorf("Flags: got %v, want SUCCESSFUL (every active diskful peer reported, "+
+			"INACTIVE worker-3 MUST be excluded from the denominator)", got[0].Flags)
+	}
+}

--- a/tests/e2e/cli-matrix/snap-create-inactive-replica-excluded.sh
+++ b/tests/e2e/cli-matrix/snap-create-inactive-replica-excluded.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# usage: snap-create-inactive-replica-excluded.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 394.
+#
+# Snapshot create on an RD that has an INACTIVE diskful replica must
+# SUCCEED across the ACTIVE diskful set and must NOT target the
+# INACTIVE node.
+#
+# Root cause (pre-fix): pkg/rest/snapshots.go listDiskfulNodes skipped
+# DISKLESS (and thus TIE_BREAKER) replicas but NOT INACTIVE ones, so
+# the defaulted snap.Nodes included a node whose DRBD resource is
+# `drbdadm down` (INACTIVE). The snapshot suspend-io barrier then waits
+# for that node to ack a `drbdsetup suspend-io`, which the satellite
+# cannot do on a down resource → that node reports Failed → the whole
+# snapshot group aborts (resume-on-abort). Net effect: a `snapshot
+# create` on ANY RD that has an INACTIVE replica reliably FAILED.
+#
+# This is the same INACTIVE-miscount class as Bugs 387/390/393.
+#
+# Expected (post-fix): the snapshot targets only the ACTIVE diskful
+# replicas. The INACTIVE replica holds data but its DRBD device is
+# down and cannot participate in the suspend-io barrier; it catches up
+# on reactivation. A snapshot of the active set is the correct
+# semantic.
+#
+# Test contract:
+#
+#   Setup: 3-replica diskful RD on worker-1 + worker-2 + worker-3,
+#          all UpToDate. (3 replicas so that deactivating one still
+#          leaves 2 ACTIVE diskful peers for the snapshot to land on.)
+#
+#   1. linstor r deactivate N3 RD
+#      - INACTIVE flag visible in Spec.Flags within 30s on N3.
+#
+#   2. linstor snapshot create RD SNAP   (default fan-out form — no
+#      explicit node list, so the controller derives the target set
+#      from the diskful replicas; this is the path Bug 394 broke).
+#      - Returns zero.
+#      - Snapshot CRD spec.nodes == {N1, N2} exactly. N3 (INACTIVE)
+#        MUST NOT appear — otherwise the suspend-io barrier aborts.
+#      - Every targeted node reaches Ready=true within 60s; the
+#        snapshot MUST NOT stamp FAILED.
+#
+#   3. linstor snapshot list shows SNAP.
+#
+#   Cleanup: snapshot delete + reactivate N3 + delete_rd +
+#            assert_no_orphans.
+#
+# Catches regressions in:
+#   - listDiskfulNodes INACTIVE exclusion (target node-set leak)
+#   - the suspend-io barrier aborting the whole group because a
+#     down DRBD device was asked to ack suspend-io
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-snap-inactive
+SNAP=snap-bug394
+SIZE_MIB=64
+
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    "${LCTL[@]}" snapshot delete "$RD" "$SNAP" 2>/dev/null || true
+    # Reactivate N3 so delete_rd drives a clean teardown.
+    "${LCTL[@]}" resource activate "$N3" "$RD" 2>/dev/null || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# =====================================================================
+# Setup: 3-replica diskful RD on $N1 + $N2 + $N3, all UpToDate
+# =====================================================================
+echo ">> Setup: 3-replica diskful RD on $N1 + $N2 + $N3 (size=${SIZE_MIB} MiB)"
+_out=$("${LCTL[@]}" resource-definition create "$RD" 2>&1) \
+    || { echo "FAIL: rd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" volume-definition create "$RD" "${SIZE_MIB}M" 2>&1) \
+    || { echo "FAIL: vd c $RD ${SIZE_MIB}M: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N1" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N1 $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N2" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N2 $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N3" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N3 $RD: $_out" >&2; exit 1; }
+
+wait_uptodate "$RD" "$N1" "$N2" "$N3"
+
+# =====================================================================
+# Step 1: deactivate $N3 → INACTIVE
+# =====================================================================
+echo ">> Step 1: linstor r deactivate $N3 $RD"
+_out=$("${LCTL[@]}" resource deactivate "$N3" "$RD" 2>&1) \
+    || { echo "FAIL: r deactivate $N3 $RD: $_out" >&2; exit 1; }
+
+echo ">>   wait up to 30s for INACTIVE flag on $N3"
+deadline=$(( $(date +%s) + 30 ))
+inactive_seen=false
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" \
+        -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$flags" == *"INACTIVE"* ]]; then
+        inactive_seen=true
+        break
+    fi
+    sleep 2
+done
+if ! $inactive_seen; then
+    echo "FAIL: $N3 never got INACTIVE flag within 30s" >&2
+    kubectl get "resources.blockstor.cozystack.io/${RD}.${N3}" -o yaml 2>&1 | tail -30 >&2
+    exit 1
+fi
+
+# Settle window: let the .res rewrite + drbdadm adjust land before the
+# snapshot create races the satellite's reconcile.
+sleep 5
+
+# =====================================================================
+# Step 2: snapshot create — default fan-out (the Bug 394 path)
+# =====================================================================
+echo ">> Step 2: linstor snapshot create $RD $SNAP (default fan-out — no node list)"
+# Upstream grammar with no positional node before the RD lets the
+# controller derive the target set. Pre-fix, listDiskfulNodes leaked
+# the INACTIVE $N3 into spec.nodes and the suspend-io barrier aborted
+# the whole group. The create itself returning non-zero IS the bug.
+_out=$("${LCTL[@]}" snapshot create "$RD" "$SNAP" 2>&1) \
+    || { echo "FAIL (Bug 394): snapshot create returned non-zero — group likely aborted on INACTIVE peer: $_out" >&2; exit 1; }
+
+snap_json() {
+    kubectl get snapshots.blockstor.cozystack.io -o json 2>/dev/null \
+        | jq -c --arg rd "$RD" --arg s "$SNAP" '
+            [.items[]?
+             | select(.spec.resourceDefinitionName==$rd)
+             | select(.spec.snapshotName==$s)] | first // {}'
+}
+
+# spec.nodes must be exactly {N1, N2}; N3 (INACTIVE) must NOT appear.
+echo ">>   assert spec.nodes == {$N1,$N2} and excludes INACTIVE $N3"
+j=$(snap_json)
+n3_in_spec=$(jq -r --arg n "$N3" '((.spec.nodes // []) | index($n)) != null' <<<"$j" 2>/dev/null)
+if [[ "$n3_in_spec" == "true" ]]; then
+    echo "FAIL (Bug 394): $SNAP spec.nodes contains INACTIVE peer $N3 — suspend-io barrier will abort the group" >&2
+    echo "$j" >&2
+    exit 1
+fi
+n1_in_spec=$(jq -r --arg n "$N1" '((.spec.nodes // []) | index($n)) != null' <<<"$j" 2>/dev/null)
+n2_in_spec=$(jq -r --arg n "$N2" '((.spec.nodes // []) | index($n)) != null' <<<"$j" 2>/dev/null)
+if [[ "$n1_in_spec" != "true" || "$n2_in_spec" != "true" ]]; then
+    echo "FAIL (Bug 394): $SNAP spec.nodes missing an active diskful peer (want both $N1 and $N2)" >&2
+    echo "$j" >&2
+    exit 1
+fi
+
+# Every targeted node must reach Ready=true; the snapshot must NOT
+# stamp FAILED (the abort symptom).
+echo ">>   wait up to 60s for Ready=true on every targeted node (must NOT abort/FAIL)"
+deadline=$(( $(date +%s) + 60 ))
+ready_ok=false
+last_json=""
+while (( $(date +%s) < deadline )); do
+    j=$(snap_json)
+    last_json="$j"
+    failed=$(jq -r '((.status.flags // []) | index("FAILED")) != null' <<<"$j" 2>/dev/null)
+    if [[ "$failed" == "true" ]]; then
+        echo "FAIL (Bug 394): Snapshot $SNAP stamped FAILED — group aborted (resume-on-abort)" >&2
+        echo "$j" >&2
+        exit 1
+    fi
+    ready_complete=$(jq -r '
+        ((.spec.nodes // []) as $want
+         | ([.status.nodeStatus[]? | select(.ready==true) | .nodeName]) as $have
+         | ($want | length) > 0 and (($want - $have) | length == 0))' <<<"$j" 2>/dev/null)
+    if [[ "$ready_complete" == "true" ]]; then
+        ready_ok=true
+        break
+    fi
+    sleep 2
+done
+if ! $ready_ok; then
+    echo "FAIL (Bug 394): not every active node reached Ready=true within 60s" >&2
+    echo "$last_json" >&2
+    exit 1
+fi
+
+# =====================================================================
+# Step 3: snapshot list shows the snapshot
+# =====================================================================
+echo ">> Step 3: linstor snapshot list shows $SNAP"
+sl_out=$("${LCTL[@]}" snapshot list 2>&1 || true)
+echo "$sl_out" | head -20
+if ! grep -q "$SNAP" <<<"$sl_out"; then
+    echo "FAIL: linstor snapshot list does not show $SNAP" >&2
+    echo "$sl_out" >&2
+    exit 1
+fi
+
+# =====================================================================
+# Cleanup handled by EXIT trap.
+# =====================================================================
+echo ">> PASS: snap-create-inactive-replica-excluded (Bug 394: INACTIVE peer excluded from snapshot target set; group did not abort)"

--- a/tests/operator-harness/replay/snap-create-inactive-replica-excluded.yaml
+++ b/tests/operator-harness/replay/snap-create-inactive-replica-excluded.yaml
@@ -1,0 +1,81 @@
+name: snap-create-inactive-replica-excluded
+description: |
+  Bug-394 catcher (P2, but reliably breaks snapshots). A `snapshot
+  create` on an RD that has an INACTIVE diskful replica must SUCCEED
+  across the ACTIVE diskful set and must NOT target the INACTIVE node.
+
+  Root cause (pre-fix): pkg/rest/snapshots.go listDiskfulNodes skipped
+  DISKLESS (and thus TIE_BREAKER) replicas but NOT INACTIVE ones, so
+  the defaulted snap.Nodes included a node whose DRBD resource is
+  `drbdadm down` (INACTIVE). The snapshot suspend-io barrier then waits
+  for that node to ack a `drbdsetup suspend-io`, which the satellite
+  cannot do on a down resource → that node reports Failed → the whole
+  snapshot group aborts (resume-on-abort). Net effect: a `snapshot
+  create` on ANY RD that has an INACTIVE replica reliably FAILED.
+
+  Same INACTIVE-miscount class as Bugs 387/390/393. An INACTIVE replica
+  holds data but its DRBD device is down; it cannot participate in the
+  suspend-io barrier and catches up on reactivation, so a snapshot of
+  the active set is the correct semantic.
+
+  Sequence: 3 diskful RD → deactivate node3 (INACTIVE) → snapshot
+  create (default fan-out) → assert the create returns 0 (group did
+  NOT abort) and the snapshot is visible in the list. Pre-fix the
+  create step aborts (non-zero) because the suspend-io barrier hangs
+  on the down node3 replica.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node3
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  # Deactivate node3 → INACTIVE (drbdadm down). No await kind exists
+  # for "replica is INACTIVE", and re-asserting all_uptodate here is
+  # unsafe (the down node3 replica no longer reports UpToDate), so we
+  # follow the proven r-d-inactive-no-tiebreaker.yaml pattern: let the
+  # deactivate settle and rely on the next step's expect_exit. The bug
+  # signal is the snapshot-create step below — pre-fix the suspend-io
+  # barrier hangs on the down node3 replica and the group aborts
+  # non-zero (resume-on-abort).
+  - name: r-deactivate-node3
+    cmd: ["resource", "deactivate", "{{node3}}", "{{rd}}"]
+    expect_exit: 0
+  - name: snapshot-create-succeeds-across-active-set
+    cmd: ["snapshot", "create", "{{rd}}", "snap-bug394"]
+    expect_exit: 0
+  - name: snapshot-visible-in-list
+    cmd: ["snapshot", "list"]
+    expect_exit: 0
+
+teardown:
+  - cmd: ["snapshot", "delete", "{{rd}}", "snap-bug394"]
+  - cmd: ["resource", "activate", "{{node3}}", "{{rd}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/snap-create-inactive-replica-excluded.yaml
+++ b/tests/operator-harness/replay/snap-create-inactive-replica-excluded.yaml
@@ -30,6 +30,10 @@ prerequisites:
 
 vars:
   sp: stand
+  # Explicit short rd: the default `replay-<name>-<rand4>` is 49 chars for
+  # this scenario name, exceeding LINSTOR's 48-char resource-name limit, so
+  # create-rd was rejected and the replay could never run.
+  rd: snap394-inactive
 
 steps:
   - name: create-rd


### PR DESCRIPTION
## Summary

A `snapshot create` on any RD that has an INACTIVE diskful replica reliably failed.

`listDiskfulNodes` in `pkg/rest/snapshots.go` skipped DISKLESS (and thus TIE_BREAKER) replicas when defaulting the snapshot target node set, but not INACTIVE ones. An INACTIVE replica's DRBD device is `drbdadm down`, so when it leaked into `snap.Nodes` the snapshot suspend-io barrier waited for that node to ack a `suspend-io` it cannot perform on a down resource. The node reported Failed and the whole snapshot group aborted (resume-on-abort).

This is the same INACTIVE-miscount class as Bugs 387/390/393.

## Fix

- Exclude INACTIVE replicas from the snapshot target node set (`listDiskfulNodes`), mirroring the existing DISKLESS skip. The snapshot now targets only the active diskful replicas; the INACTIVE replica catches up on reactivation, which is the correct semantic (its device is down and cannot participate in the suspend-io barrier).
- Apply the same INACTIVE skip to the success denominator (`diskfulPeerSet`). Since the INACTIVE node is no longer a snapshot target it never receives a per-node entry, so leaving it in the denominator would hang the snapshot at Incomplete forever. Now it stamps SUCCESSFUL across the active set.

## Tests (CLI-bug-fix protocol)

- **L1/L2 regression** (`pkg/rest/snapshots_test.go`): `TestSnapshotCreateExcludesInactiveReplica_Bug394` pins the target-node selection (create succeeds, INACTIVE node absent from `spec.nodes` and per-node materialisation). `TestSnapshotStateIgnoresInactiveReplica_Bug394` uses the broadcast success path to pin the denominator exclusion. Both fail pre-fix, pass post-fix.
- **L6 cli-matrix cell** (`tests/e2e/cli-matrix/snap-create-inactive-replica-excluded.sh`): 3-replica RD, deactivate one node, snapshot create with default fan-out; asserts the group does not abort, `spec.nodes` excludes the INACTIVE node, every targeted node reaches Ready (never FAILED).
- **L7 replay YAML** (`tests/operator-harness/replay/snap-create-inactive-replica-excluded.yaml`): codifies the operator sequence and asserts the create returns 0 (group did not abort).

## Validation

`go build ./...`, `go test ./pkg/rest/... ./...`, and `golangci-lint run ./pkg/rest/...` are green. The two new unit tests were verified to fail pre-fix and pass post-fix. Live-stand replay is run by the launcher.
