### PR TITLE
fix(satellite): resync grown region on thick-LVM resize instead of --assume-clean (Bug 395)

### DIFF
--- a/pkg/drbd/drbdadm.go
+++ b/pkg/drbd/drbdadm.go
@@ -274,11 +274,33 @@ func (a *Adm) Attach(ctx context.Context, resource string) error {
 // Resize rescans the lower disk's size and tells DRBD to grow the
 // replicated volume to match. The lower disk (LV / zvol / dm-crypt
 // target) must already be the target size — this is a notify-only
-// command. `--assume-clean` skips the resync of the new bytes since
-// they were just allocated, which would otherwise serialise growing
-// every replica.
-func (a *Adm) Resize(ctx context.Context, resource string) error {
-	return a.run(ctx, "resize", "--assume-clean", resource)
+// command.
+//
+// assumeClean selects the post-grow reconciliation strategy for the new
+// region [old_size, new_size):
+//
+//   - assumeClean=true: pass `--assume-clean` so DRBD marks the grown
+//     region UpToDate on every replica WITHOUT a resync. Sound ONLY
+//     for zero-on-allocate providers (ZFS/thin/file), where the grown
+//     bytes are deterministically zero on every replica — skipping the
+//     resync there is a correct fast path that avoids serialising the
+//     grow on every replica.
+//   - assumeClean=false: omit the flag so DRBD marks the grown region
+//     out-of-sync on the non-source peers and resyncs it from the
+//     UpToDate source. Required for classic thick `LVM` (Bug 395, P1
+//     data integrity): `lvextend` exposes recycled VG extents whose
+//     prior content differs per node, so `--assume-clean` would
+//     silently leave replicas disagreeing on the grown region with no
+//     out-of-sync flag.
+//
+// The caller derives assumeClean from the provider's
+// storage.ResizeZeroFiller capability.
+func (a *Adm) Resize(ctx context.Context, resource string, assumeClean bool) error {
+	if assumeClean {
+		return a.run(ctx, "resize", "--assume-clean", resource)
+	}
+
+	return a.run(ctx, "resize", resource)
 }
 
 // SetGI pre-seeds the per-peer GI slot in this replica's DRBD

--- a/pkg/drbd/drbdadm_test.go
+++ b/pkg/drbd/drbdadm_test.go
@@ -296,15 +296,15 @@ func TestAdmForgetPeerInvokesDrbdmeta(t *testing.T) {
 	}
 }
 
-// TestAdmResizeInvokesDrbdadm: Resize → `drbdadm resize --assume-clean <res>`.
-// --assume-clean skips re-syncing the new bytes (they're freshly
-// allocated zeros) — without it growing 3 replicas serialises on
-// every resync.
+// TestAdmResizeInvokesDrbdadm: Resize(assumeClean=true) →
+// `drbdadm resize --assume-clean <res>`. --assume-clean skips
+// re-syncing the new bytes (zero-fill providers expose freshly-zeroed
+// extents) — without it growing 3 replicas serialises on every resync.
 func TestAdmResizeInvokesDrbdadm(t *testing.T) {
 	fx := storage.NewFakeExec()
 	adm := drbd.NewAdm(fx)
 
-	err := adm.Resize(t.Context(), "pvc-1")
+	err := adm.Resize(t.Context(), "pvc-1", true)
 	if err != nil {
 		t.Fatalf("Resize: %v", err)
 	}
@@ -312,6 +312,34 @@ func TestAdmResizeInvokesDrbdadm(t *testing.T) {
 	want := "drbdadm resize --assume-clean pvc-1"
 	if !slices.Contains(fx.CommandLines(), want) {
 		t.Errorf("expected %q in calls; got %v", want, fx.CommandLines())
+	}
+}
+
+// TestAdmResizeWithoutAssumeClean: Resize(assumeClean=false) →
+// `drbdadm resize <res>` (no --assume-clean). Bug 395 (P1, data
+// integrity): non-zero-fill providers (thick LVM) MUST omit
+// --assume-clean so DRBD marks the grown region out-of-sync and
+// resyncs it from the UpToDate source — otherwise replicas silently
+// disagree on the grown region (0xA1/0xB2 divergence confirmed on the
+// stand).
+func TestAdmResizeWithoutAssumeClean(t *testing.T) {
+	fx := storage.NewFakeExec()
+	adm := drbd.NewAdm(fx)
+
+	err := adm.Resize(t.Context(), "pvc-1", false)
+	if err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	want := "drbdadm resize pvc-1"
+	if !slices.Contains(fx.CommandLines(), want) {
+		t.Errorf("expected %q in calls; got %v", want, fx.CommandLines())
+	}
+
+	for _, cl := range fx.CommandLines() {
+		if strings.Contains(cl, "--assume-clean") {
+			t.Errorf("did not expect --assume-clean in calls; got %v", fx.CommandLines())
+		}
 	}
 }
 

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -2230,7 +2230,18 @@ func (r *Reconciler) finishDRBDApply(ctx context.Context, dr *intent.DesiredReso
 	// disk to resize but they still need their internal state to
 	// catch up; drbdadm resize handles that case too.
 	if resized {
-		err := r.cfg.Adm.Resize(ctx, dr.GetName())
+		// Bug 395 (P1, data integrity): gate `--assume-clean` on whether
+		// the backing provider zero-fills the grown region. For thick
+		// `LVM` (non-zero-fill) we MUST omit `--assume-clean` so DRBD
+		// marks the grown region out-of-sync and resyncs it from the
+		// UpToDate source — otherwise replicas silently disagree on
+		// [old_size, new_size) (recycled VG extents differ per node).
+		// Diskless replicas have no backing disk and no provider, so the
+		// helper returns true (the notify-only resize there has no data
+		// region to mark; the diskful peers drive the resync).
+		assumeClean := r.resizeAssumeClean(dr)
+
+		err := r.cfg.Adm.Resize(ctx, dr.GetName(), assumeClean)
 		if err != nil {
 			return errors.Wrapf(err, "resize %s", dr.GetName())
 		}
@@ -2335,6 +2346,48 @@ func (r *Reconciler) finishDRBDApply(ctx context.Context, dr *intent.DesiredReso
 	}
 
 	return nil
+}
+
+// resizeAssumeClean decides whether the pickup-time `drbdadm resize`
+// may pass `--assume-clean` (skip resync of the grown region) for this
+// resource (Bug 395, P1 data integrity).
+//
+// `--assume-clean` is sound ONLY when every diskful volume's backing
+// provider zero-fills the grown region [old_size, new_size) — i.e. the
+// grown bytes are deterministically zero on every replica. Classic
+// thick `LVM` does NOT (recycled VG extents differ per node), so for it
+// we return false and let DRBD mark the grown region out-of-sync and
+// resync it from the UpToDate source.
+//
+// A provider that does not implement storage.ResizeZeroFiller is
+// treated as non-zero-fill (the safe default → return false). A volume
+// whose pool is unknown to this satellite (e.g. a diskless replica with
+// no StoragePool, or a historical pool after a rename) is skipped: it
+// has no local backing disk to mark dirty, and the diskful peers'
+// reconcilers drive the cluster-wide resync decision. With no diskful
+// volume on this node the helper returns true (the notify-only resize
+// has nothing local to resync).
+func (r *Reconciler) resizeAssumeClean(dr *intent.DesiredResource) bool {
+	for _, vol := range dr.GetVolumes() {
+		pool := vol.GetStoragePool()
+		if pool == "" {
+			continue
+		}
+
+		provider, ok := r.cfg.Providers[pool]
+		if !ok {
+			continue
+		}
+
+		zf, ok := provider.(storage.ResizeZeroFiller)
+		if !ok || !zf.ResizeZeroFills() {
+			// Non-zero-fill (or capability not declared): the grown
+			// region must be resynced — omit `--assume-clean`.
+			return false
+		}
+	}
+
+	return true
 }
 
 // maybeRecoveryPromote re-arms the auto-primary seed on a steady-state

--- a/pkg/satellite/reconciler_drbd_test.go
+++ b/pkg/satellite/reconciler_drbd_test.go
@@ -407,6 +407,13 @@ func TestApplyDisklessNoCreateMD(t *testing.T) {
 // already exists at 1 GiB, the desired size is 2 GiB → reconciler
 // must call lvextend then drbdadm resize. Pins the upstream-style
 // growth-path semantics CSI ControllerExpandVolume relies on.
+//
+// Bug 395 (P1, data integrity): this case uses an LVM_THIN pool — a
+// zero-fill provider — so the fast path is preserved: the drbdadm
+// resize KEEPS `--assume-clean` (the grown thin chunks read back as
+// zeros on every replica, so no resync is needed). The non-zero-fill
+// (thick LVM) counterpart is TestApplyThickResizeOmitsAssumeClean
+// below, which asserts `--assume-clean` is dropped so DRBD resyncs.
 func TestApplyTriggersResizeOnGrow(t *testing.T) {
 	dir := t.TempDir()
 	fx := storage.NewFakeExec()
@@ -454,6 +461,77 @@ func TestApplyTriggersResizeOnGrow(t *testing.T) {
 	for _, w := range want {
 		if !slices.Contains(fx.CommandLines(), w) {
 			t.Errorf("expected %q in calls; got %v", w, fx.CommandLines())
+		}
+	}
+}
+
+// TestApplyThickResizeOmitsAssumeClean is the Bug 395 (P1, data
+// integrity) regression: growing a thick-LVM-backed volume MUST issue
+// `drbdadm resize` WITHOUT `--assume-clean`. Thick `LVM` is NOT
+// zero-on-allocate — `lvextend` exposes recycled VG extents whose prior
+// content differs per node — so the only way the grown region
+// [old_size, new_size) ends up byte-identical across replicas is for
+// DRBD to mark it out-of-sync and resync it from the UpToDate source.
+// `--assume-clean` would skip that resync and silently diverge the
+// replicas (0xA1 on w1 vs 0xB2 on w2, confirmed on the stand) with no
+// out-of-sync flag.
+//
+// Mirror of TestApplyTriggersResizeOnGrow but with lvm.NewThick instead
+// of lvm.NewThin — the lvextend/lvs command shapes are identical; only
+// the drbdadm resize argv differs (no --assume-clean).
+func TestApplyThickResizeOmitsAssumeClean(t *testing.T) {
+	dir := t.TempDir()
+	fx := storage.NewFakeExec()
+	// Volume already exists (thick CreateVolume idempotent-skip probe).
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings -o lv_name vg/pvc-grow_00000",
+		storage.FakeResponse{Stdout: []byte("pvc-grow_00000\n")})
+	// VolumeStatus: 1 GiB on disk (1024*1024 KiB).
+	fx.Expect("lvs --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } --noheadings --separator | -o lv_path,lv_size --units k --nosuffix vg/pvc-grow_00000",
+		storage.FakeResponse{Stdout: []byte("/dev/vg/pvc-grow_00000|1048576\n")})
+
+	thick := lvm.NewThick(lvm.ThickConfig{VolumeGroup: "vg"}, fx)
+	rec := satellite.NewReconciler(satellite.ReconcilerConfig{
+		Providers: map[string]storage.Provider{"thick1": thick},
+		Adm:       drbd.NewAdm(fx),
+		StateDir:  dir,
+		NodeName:  "n1",
+	})
+
+	// Desired: 2 GiB.
+	_, err := rec.Apply(t.Context(), []*intent.DesiredResource{
+		{
+			Name:     "pvc-grow",
+			NodeName: "n1",
+			Volumes: []*intent.DesiredVolume{
+				{VolumeNumber: 0, SizeKib: 2 * 1024 * 1024, StoragePool: "thick1"},
+			},
+			SkipInitialSync: skipInitTrue(),
+			DrbdOptions: map[string]string{
+				"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// lvextend must run (the grow happened) and drbdadm resize must
+	// follow WITHOUT --assume-clean.
+	wantLvextend := "lvextend --config devices { filter=['r|^/dev/drbd|','r|^/dev/zd|'] } activation { udev_sync=0 udev_rules=0 } --size 2048MiB vg/pvc-grow_00000"
+	if !slices.Contains(fx.CommandLines(), wantLvextend) {
+		t.Errorf("expected %q in calls; got %v", wantLvextend, fx.CommandLines())
+	}
+
+	wantResize := "drbdadm resize pvc-grow"
+	if !slices.Contains(fx.CommandLines(), wantResize) {
+		t.Errorf("expected %q in calls; got %v", wantResize, fx.CommandLines())
+	}
+
+	// Bug 395: the grown region MUST NOT be marked clean — assert no
+	// drbdadm resize carries --assume-clean for the thick provider.
+	for _, cl := range fx.CommandLines() {
+		if strings.HasPrefix(cl, "drbdadm resize") && strings.Contains(cl, "--assume-clean") {
+			t.Errorf("thick-LVM resize must omit --assume-clean (Bug 395); got %q", cl)
 		}
 	}
 }

--- a/pkg/storage/file/file.go
+++ b/pkg/storage/file/file.go
@@ -76,6 +76,14 @@ func (p *Provider) Kind() string {
 	return "FILE"
 }
 
+// ResizeZeroFills reports true for both FILE and FILE_THIN: growing the
+// backing file (truncate/fallocate) extends it into a hole that reads
+// back as zeros on every replica, so the grown region
+// [old_size, new_size) is byte-identical across replicas. The
+// `drbdadm resize --assume-clean` fast path is sound — no resync of the
+// grown region is needed (Bug 395). See storage.ResizeZeroFiller.
+func (*Provider) ResizeZeroFills() bool { return true }
+
 // CreateVolume idempotently:
 //   - creates the backing file at full size (fallocate, thick) or
 //     as a sparse file (truncate, thin)

--- a/pkg/storage/lvm/lvm_thick.go
+++ b/pkg/storage/lvm/lvm_thick.go
@@ -52,6 +52,15 @@ func NewThick(cfg ThickConfig, ex storage.Exec) *Thick {
 // Kind returns the upstream LINSTOR provider kind string.
 func (*Thick) Kind() string { return "LVM" }
 
+// ResizeZeroFills reports false: classic thick LVM does NOT zero on
+// allocate. `lvextend` exposes recycled VG extents whose prior content
+// differs per node, so a grown region [old_size, new_size) is NOT
+// guaranteed identical across replicas. The satellite therefore omits
+// `drbdadm resize --assume-clean` for this provider and lets DRBD
+// resync the grown region from the UpToDate source (Bug 395, P1 data
+// integrity). See storage.ResizeZeroFiller.
+func (*Thick) ResizeZeroFills() bool { return false }
+
 // CreateVolume allocates a thick LV. Idempotent: existing LV is a no-op.
 func (t *Thick) CreateVolume(ctx context.Context, vol storage.Volume) error {
 	if t.lvExists(ctx, volumeLVName(vol)) {

--- a/pkg/storage/lvm/lvm_thin.go
+++ b/pkg/storage/lvm/lvm_thin.go
@@ -57,6 +57,13 @@ func NewThin(cfg ThinConfig, ex storage.Exec) *Thin {
 // Kind returns the upstream LINSTOR provider kind string.
 func (*Thin) Kind() string { return "LVM_THIN" }
 
+// ResizeZeroFills reports true: LVM thin pools zero newly-provisioned
+// chunks, so a grown region [old_size, new_size) reads back as zeros on
+// every replica. The `drbdadm resize --assume-clean` fast path is
+// therefore sound — no resync of the grown region is needed (Bug 395).
+// See storage.ResizeZeroFiller.
+func (*Thin) ResizeZeroFills() bool { return true }
+
 // volumeLVName mirrors upstream LINSTOR's naming: `<resource>_<vol5digits>`.
 // We zero-pad the volume number to keep lexical sort meaningful.
 func volumeLVName(vol storage.Volume) string {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -221,3 +221,34 @@ type SnapshotShipper interface {
 	// metadata for the local node-id.
 	RecvSnapshot(ctx context.Context, target Volume, src io.Reader) error
 }
+
+// ResizeZeroFiller is the optional "grown region reads back as zeros"
+// capability (Bug 395, P1 data integrity). A provider implements it to
+// declare whether the bytes exposed by a grow (the region
+// [old_size, new_size)) are deterministically zero on every replica.
+//
+// This gates the `--assume-clean` fast path on `drbdadm resize`: that
+// flag tells DRBD to mark the grown region UpToDate on every replica
+// WITHOUT a resync. That is sound ONLY when the grown bytes are
+// guaranteed identical across replicas. Zero-on-allocate backends
+// (ZFS/ZFS_THIN refreservation reads zeros for never-written blocks,
+// LVM_THIN zeroes new thin chunks, FILE/FILE_THIN grow into a hole that
+// reads as zeros) satisfy this. Classic thick `LVM` does NOT:
+// `lvextend` exposes recycled VG extents whose prior content differs
+// per node, so `--assume-clean` would silently leave the replicas
+// disagreeing on [old_size, new_size) with no out-of-sync flag — a
+// failover then changes the bytes an application reads.
+//
+// A provider that does NOT implement this interface is treated as
+// NOT zero-fill (the safe default): the satellite omits `--assume-clean`
+// so DRBD marks the grown region out-of-sync and resyncs it from the
+// UpToDate source, guaranteeing every replica agrees on the grown
+// bytes. Implemented as an optional capability so the base Provider
+// interface stays under the interfacebloat budget.
+type ResizeZeroFiller interface {
+	// ResizeZeroFills reports whether a grow on this provider yields a
+	// region that reads back as zeros on every replica. true → the
+	// `drbdadm resize --assume-clean` fast path is sound; false →
+	// DRBD must resync the grown region.
+	ResizeZeroFills() bool
+}

--- a/pkg/storage/zfs/zfs.go
+++ b/pkg/storage/zfs/zfs.go
@@ -63,6 +63,14 @@ func (p *Provider) Kind() string {
 	return "ZFS"
 }
 
+// ResizeZeroFills reports true for both ZFS and ZFS_THIN: ZFS reads
+// zeros for never-written blocks (thick uses a refreservation but the
+// blocks are still zero-on-read until written), so a grown region
+// [old_size, new_size) is byte-identical (all zeros) across replicas.
+// The `drbdadm resize --assume-clean` fast path is sound — no resync of
+// the grown region is needed (Bug 395). See storage.ResizeZeroFiller.
+func (*Provider) ResizeZeroFills() bool { return true }
+
 // Pool returns the underlying ZFS pool name (`zpool list` identifier).
 // The satellite Reconciler's FlushBackingDevices uses this to issue
 // `zpool sync <pool>` between drbdadm suspend-io and `zfs snapshot`

--- a/tests/e2e/cli-matrix/vd-resize-thick-lvm-grown-region-consistent.sh
+++ b/tests/e2e/cli-matrix/vd-resize-thick-lvm-grown-region-consistent.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# usage: vd-resize-thick-lvm-grown-region-consistent.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 395 (P1, DATA INTEGRITY) regression catcher.
+#
+# Reproduces the confirmed-on-stand divergence: resizing a thick-LVM
+# ("LVM" kind, NOT thin) backed DRBD volume used to run
+# `drbdadm resize --assume-clean` unconditionally. `--assume-clean`
+# marks the grown region [old_size, new_size) UpToDate on EVERY replica
+# WITHOUT a resync — sound only for zero-on-allocate providers. Classic
+# thick LVM's `lvextend` exposes recycled VG extents whose prior content
+# differs per node, so the replicas silently disagreed on the grown
+# region (w1 read 0xA1, w2 read 0xB2 at the same grown offset through
+# the replicated /dev/drbd device) with out-of-sync:0 and no split-brain
+# flag — a failover changed the bytes an application read.
+#
+# The fix (provider-aware gate): thick LVM is non-zero-fill, so the
+# satellite now omits `--assume-clean`, DRBD marks the grown region
+# out-of-sync and resyncs it from the UpToDate source → both replicas
+# agree. Zero-fill providers (zfs/thin/file) keep the fast path
+# (--assume-clean) and are covered by vd-resize-full-lifecycle.sh.
+#
+# Mechanism of this cell:
+#   1. Register a thick LINSTOR `LVM` pool on the existing
+#      `blockstor-lvm` VG on >=2 workers (the stand has no spare disk;
+#      the VG had free extents past the thin pool). SKIP if a thick
+#      `LVM` pool is not available on >=2 nodes.
+#   2. rd c + vd c 1G + r c --auto-place=2 -s <thick-pool>; wait UpToDate.
+#   3. Pre-dirty the to-be-grown region on the BACKING LV of each
+#      replica with node-distinct bytes (0xA1 on N1, 0xB2 on N2) so the
+#      recycled-extent divergence is deterministic. The backing LV is
+#      reached via /dev/mapper/blockstor--lvm-<lv> (the satellites have
+#      NO udev, so /dev/<vg>/<lv> symlinks are stale regular files).
+#   4. linstor vd s <rd> 0 2G — grow.
+#   5. Wait converge (vd size + all UpToDate + sync clean).
+#   6. Read the grown region [1G, 2G) through the REPLICATED /dev/drbdN
+#      on BOTH replicas. Assert byte-identical. Pre-fix this FAILS
+#      (0xA1 vs 0xB2); post-fix the resync makes them equal.
+#   7. Cleanup pod/pvc/RD; assert_no_orphans.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+# The thick-LVM pool name registered on the stand. Override with
+# THICK_POOL=<name> if the launcher provisioned it under a different
+# name. The VG behind it is blockstor-lvm (mapper prefix below).
+THICK_POOL="${THICK_POOL:-lvm-thick}"
+THICK_VG="${THICK_VG:-blockstor-lvm}"
+# dm escapes a single '-' in a VG/LV name as '--'. blockstor-lvm → blockstor--lvm
+THICK_VG_DM="${THICK_VG//-/--}"
+
+RD="cli-matrix-thick-grow"
+SIZE_2G_KIB=2097152
+PVC_NS=default
+PVC_NAME="bs-thick-grow-pvc"
+POD_NAME="bs-thick-grow-pod"
+
+# Offsets/length for the grown-region read (in bytes). We read the
+# first 64 MiB of the grown region [1G, 2G) — enough to catch the
+# recycled-extent divergence without dd'ing the whole gigabyte.
+GROW_OFFSET_BYTES=$(( 1024 * 1024 * 1024 ))   # 1 GiB == old size
+GROW_READ_BYTES=$(( 64 * 1024 * 1024 ))       # 64 MiB sample of grown region
+
+cleanup_thick() {
+    local _ns=${PVC_NS:-default}
+    [[ -n "${POD_NAME:-}" ]] && kubectl -n "$_ns" delete pod "$POD_NAME" --wait=true --timeout=60s 2>/dev/null || true
+    [[ -n "${PVC_NAME:-}" ]] && kubectl -n "$_ns" delete pvc "$PVC_NAME" --wait=true --timeout=60s 2>/dev/null || true
+    [[ -n "${RD:-}" ]] && delete_rd "$RD"
+    [[ -n "${RD:-}" ]] && assert_no_orphans "$RD"
+}
+trap 'cleanup_thick; linstor_cli_teardown' EXIT
+
+echo "============================================================"
+echo ">> vd-resize-thick-lvm-grown-region-consistent (Bug 395)"
+echo "   THICK_POOL=$THICK_POOL VG=$THICK_VG (dm=$THICK_VG_DM)"
+echo "============================================================"
+
+echo ">> pre-flight: thick LVM '$THICK_POOL' pool on >=2 nodes"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$THICK_POOL" 2>/dev/null || echo "[]")
+ok_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+# Confirm it's actually the thick LVM kind (not LVM_THIN) — the whole
+# point of the cell. If the pool resolves to LVM_THIN the repro is
+# invalid (thin zero-fills) so skip rather than false-PASS.
+kind=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .provider_kind] | first // ""' <<<"$sp_json" 2>/dev/null || echo "")
+if (( ok_nodes < 2 )) || [[ "$kind" != "LVM" ]]; then
+    echo "SKIP: thick LVM pool '$THICK_POOL' not present as kind=LVM on >=2 nodes (got nodes=$ok_nodes kind='$kind')"
+    exit 0
+fi
+
+echo ">> rd c + vd c 1G + r c --auto-place=2 -s $THICK_POOL"
+_out=$("${LCTL[@]}" resource-definition create "$RD" 2>&1) \
+    || { echo "FAIL: rd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" volume-definition create "$RD" 1G 2>&1) \
+    || { echo "FAIL: vd c $RD 1G: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create --auto-place=2 --storage-pool="$THICK_POOL" "$RD" 2>&1) \
+    || { echo "FAIL: r c --auto-place=2 -s $THICK_POOL $RD: $_out" >&2; exit 1; }
+
+# Resolve the two diskful replicas (exclude DISKLESS / TIE_BREAKER).
+deadline=$(( $(date +%s) + 90 ))
+placed_nodes=()
+while (( $(date +%s) < deadline )); do
+    mapfile -t placed_nodes < <(
+        kubectl get resources.blockstor.cozystack.io -o json 2>/dev/null \
+            | jq -r --arg rd "$RD" '
+                .items[]?
+                | select(.spec.resourceDefinitionName==$rd)
+                | select(((.spec.flags // [])
+                    | map(select(.=="DISKLESS" or .=="TIE_BREAKER"))
+                    | length) == 0)
+                | .spec.nodeName'
+    )
+    if (( ${#placed_nodes[@]} >= 2 )); then break; fi
+    sleep 2
+done
+if (( ${#placed_nodes[@]} < 2 )); then
+    echo "FAIL: autoplace did not stage 2 diskful replicas for $RD (got ${#placed_nodes[@]})" >&2
+    exit 1
+fi
+N1="${placed_nodes[0]}"
+N2="${placed_nodes[1]}"
+echo ">> diskful replicas: N1=$N1 N2=$N2"
+wait_uptodate "$RD" "$N1" "$N2"
+
+# Backing LV name for volume 0 follows blockstor's <rd>_<vol5digits>
+# convention; on the stand it is reached via the dm mapper path
+# /dev/mapper/${THICK_VG_DM}-${RD}_00000 (no udev → /dev/<vg>/<lv>
+# symlinks are stale regular files). The launcher's VG-prefill (below)
+# uses that path; this cell reads the grown region through the
+# REPLICATED /dev/drbdN, not the backing LV.
+
+# Divergence seeding: the grown region [1G, 2G) only comes into
+# existence at the satellite's `lvextend`, recycling whatever the VG's
+# free extents held. To make the divergence deterministic the LAUNCHER
+# pre-fills each node's free VG extents with a node-distinct byte
+# (0xA1 on N1, 0xB2 on N2) BEFORE this cell runs (e.g. dd a node-distinct
+# pattern across the free PE range on /dev/mapper/${THICK_VG_DM}-*),
+# so the extents lvextend recycles carry node-distinct bytes. Pre-fix
+# (--assume-clean) those bytes are never resynced and the read below
+# diverges; post-fix the resync makes both replicas agree. The cell
+# itself only asserts the post-grow invariant — it does not depend on
+# the specific fill bytes, only on cross-replica equality.
+
+echo ">> linstor vd s $RD 0 2G (grow; thick LVM must resync grown region)"
+"${LCTL[@]}" volume-definition set-size "$RD" 0 2G >/dev/null
+wait_vd_size "$RD" 0 "$SIZE_2G_KIB" 60
+wait_uptodate "$RD" "$N1" "$N2"
+# Give the resync of the grown region time to complete, then assert the
+# (node<->peer) link is back to clean UpToDate/Established.
+wait_sync_done "$RD" "$N1" "$N2" 180 || true
+wait_sync_done "$RD" "$N2" "$N1" 180 || true
+
+DEV1=$(device_for_rd "$RD" "$N1")
+DEV2=$(device_for_rd "$RD" "$N2")
+if [[ -z "$DEV1" || -z "$DEV2" ]]; then
+    echo "FAIL: could not resolve /dev/drbdN for $RD on $N1/$N2 (dev1='$DEV1' dev2='$DEV2')" >&2
+    exit 1
+fi
+
+# Read the grown region through the REPLICATED device on each replica.
+# DRBD serves reads from the local backing disk, so if the grown region
+# was not resynced the two replicas return different bytes. Promote is
+# needed to open the device for reads on a Secondary (read_md5 promotes).
+echo ">> read grown region [1G, 1G+64M) through /dev/drbd on both replicas"
+read_grown() {
+    local node=$1 dev=$2
+    local off_blocks=$(( GROW_OFFSET_BYTES / 4096 ))
+    local cnt_blocks=$(( GROW_READ_BYTES / 4096 ))
+    on_node "$node" bash -c "
+        drbdadm primary ${RD} 2>/dev/null || true
+        test -b ${dev} || { echo \"ABORT: ${dev} not a block device — \$(stat -c '%F' ${dev} 2>/dev/null || echo missing)\" >&2; exit 2; }
+        dd if=${dev} bs=4096 skip=${off_blocks} count=${cnt_blocks} status=none iflag=direct | md5sum | awk '{print \$1}'
+    "
+}
+
+MD5_N1=$(read_grown "$N1" "$DEV1")
+MD5_N2=$(read_grown "$N2" "$DEV2")
+echo "   grown-region md5: N1=$MD5_N1  N2=$MD5_N2"
+
+if [[ -z "$MD5_N1" || -z "$MD5_N2" ]]; then
+    echo "FAIL: empty md5 read of grown region (N1='$MD5_N1' N2='$MD5_N2')" >&2
+    exit 1
+fi
+
+if [[ "$MD5_N1" != "$MD5_N2" ]]; then
+    echo "FAIL (Bug 395 REGRESSION): grown region [1G,1G+64M) diverges across replicas" >&2
+    echo "       N1($N1)=$MD5_N1  N2($N2)=$MD5_N2" >&2
+    echo "       thick-LVM resize ran --assume-clean and skipped the resync —" >&2
+    echo "       the replicas silently disagree on the grown bytes (failover hazard)." >&2
+    exit 1
+fi
+
+echo ">> grown region byte-identical across replicas — Bug 395 fix holds"
+echo ">> vd-resize-thick-lvm-grown-region-consistent OK"
+
+cleanup_thick
+trap 'linstor_cli_teardown' EXIT
+echo ">> vd-resize-thick-lvm-grown-region-consistent COMPLETE"

--- a/tests/operator-harness/replay/vd-resize-thick-lvm-grown-region-consistent.yaml
+++ b/tests/operator-harness/replay/vd-resize-thick-lvm-grown-region-consistent.yaml
@@ -1,0 +1,115 @@
+name: vd-resize-thick-lvm-grown-region-consistent
+description: |
+  Bug 395 (P1, DATA INTEGRITY) operator-replay catcher for thick-LVM
+  resize. Drives the operator CLI sequence:
+
+    rd c → vd c 1G → r c --auto-place=2 -s <thick-LVM pool> → grow 1G→2G
+
+  on a thick LINSTOR `LVM` pool (kind=LVM, NOT LVM_THIN). Pre-fix the
+  satellite ran `drbdadm resize --assume-clean` unconditionally, which
+  marks the grown region [1G, 2G) UpToDate on every replica WITHOUT a
+  resync. For thick LVM that is unsound — `lvextend` exposes recycled
+  VG extents whose prior content differs per node, so the replicas
+  silently disagreed on the grown region (w1 read 0xA1, w2 read 0xB2
+  through the replicated /dev/drbd device) with out-of-sync:0 and no
+  split-brain flag. A failover then changed the bytes an application
+  read.
+
+  The fix makes resize provider-aware: thick LVM is non-zero-fill, so
+  the satellite OMITS `--assume-clean`, DRBD marks the grown region
+  out-of-sync and resyncs it from the UpToDate source. The
+  operator-visible signal of the resync is that the replicas pass
+  THROUGH a non-zero out-of-sync count and converge back to a CLEAN
+  `sync_clean` (UpToDate with no "(NN%)" suffix) — that is what this
+  workflow asserts.
+
+  The deep grown-region byte-identity check (read [1G, 2G) through the
+  replicated device on both replicas and assert equal) lives in the L6
+  cli-matrix cell
+  tests/e2e/cli-matrix/vd-resize-thick-lvm-grown-region-consistent.sh
+  — the replay runner drives the operator CLI + convergence; the
+  cli-matrix cell drives the raw cross-replica read on the live stand.
+
+  Zero-fill providers (zfs/thin/file) are unaffected and keep the
+  --assume-clean fast path — covered by vd-resize-full-lifecycle.yaml.
+
+  Requires a thick LINSTOR `LVM` pool registered on >=2 nodes. Set
+  vars.sp to that pool's name (default "lvm-thick"). If the stand only
+  has thin/zfs pools this workflow cannot exercise the bug.
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: lvm-thick
+
+vars:
+  sp: lvm-thick
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd-1g
+    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    expect_exit: 0
+    await:
+      kind: vd_size_kib
+      rd: "{{rd}}"
+      vol: 0
+      expected_kib: 1048576
+      timeout_s: 30
+  - name: auto-place-2
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 2
+      timeout_s: 120
+  - name: wait-uptodate-1g
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+  # ---- Grow 1G → 2G (thick LVM: DRBD must resync the grown region) ----
+  - name: grow-2g
+    cmd: ["volume-definition", "set-size", "{{rd}}", "0", "2G"]
+    expect_exit: 0
+    await:
+      kind: vd_size_kib
+      rd: "{{rd}}"
+      vol: 0
+      expected_kib: 2097152
+      timeout_s: 60
+  - name: wait-uptodate-2g
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  # sync_clean is the load-bearing assertion: the grown region was
+  # resynced (out-of-sync briefly non-zero) and has now drained back to
+  # UpToDate WITHOUT a "(NN%)" suffix. Pre-fix the resync never ran, so
+  # this would pass trivially BUT the cli-matrix cell's cross-replica
+  # read catches the silent divergence; together they bracket the bug.
+  - name: sync-clean-2g
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: sync_clean
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: "{{rd}}"
+      timeout_s: 60
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

**P1 data-integrity fix.** Resizing a thick-LVM-backed (`LVM` kind, not `LVM_THIN`) DRBD volume silently diverged replicas on the grown region.

The satellite ran `drbdadm resize --assume-clean` **unconditionally** for every provider. `--assume-clean` marks the grown region `[old_size, new_size)` UpToDate on every replica **without** a resync. That is sound only for zero-on-allocate backends. Classic thick LVM is not one: `lvextend` exposes recycled VG extents whose prior content differs per node, so the replicas ended up holding different bytes in the grown region with `out-of-sync:0` and no split-brain flag. A failover then changed the bytes an application reads.

## Confirmed on the stand

Pre-dirty the to-be-grown extents node-distinct, grow, read the grown region through the replicated `/dev/drbd` device on both replicas:

- thick `LVM`: w1 read `0xA1`, w2 read `0xB2` at the same grown offset — silent divergence, no out-of-sync flag.
- control on zfs-thin: both read zeros (safe — zero-on-allocate).

## Fix (option A — provider-aware gate)

Matches upstream LINSTOR, which does not use `--assume-clean`, and avoids write-amplification on every thick resize.

- New optional capability `storage.ResizeZeroFiller` (`ResizeZeroFills() bool`). Providers declare whether a grow reads back as zeros on every replica.
  - `ZFS` / `ZFS_THIN`, `LVM_THIN`, `FILE` / `FILE_THIN` → `true` (zero-on-allocate).
  - thick `LVM` → `false`.
  - A provider that does not implement the interface is treated as **non-zero-fill** (the safe default).
- `drbd.Adm.Resize` now takes an `assumeClean bool` instead of always passing the flag.
- The satellite's `finishDRBDApply` derives `assumeClean` from the backing provider's capability (`resizeAssumeClean` helper). Thick LVM omits `--assume-clean` → DRBD marks the grown region out-of-sync and resyncs it from the UpToDate source, so both replicas agree.

**Zero-fill providers (zfs/thin/file) are unaffected and keep the `--assume-clean` fast path** — no unnecessary full resync on resize.

## Tests (CLI-bug-fix protocol)

- **L1/L2 regression**:
  - `pkg/drbd`: `Resize(assumeClean=false)` omits the flag; `Resize(assumeClean=true)` keeps it.
  - `pkg/satellite`: `TestApplyThickResizeOmitsAssumeClean` asserts a thick-LVM grow issues `drbdadm resize` **without** `--assume-clean`. Verified it FAILS pre-fix and PASSES post-fix. The existing `TestApplyTriggersResizeOnGrow` pin (LVM_THIN, zero-fill) is updated to document that thin **keeps** `--assume-clean` as the provider-aware behaviour.
- **L6 cli-matrix**: `tests/e2e/cli-matrix/vd-resize-thick-lvm-grown-region-consistent.sh` — grows a thick-LVM replicated volume and asserts the grown region is byte-identical across replicas (read through the replicated device). Skips cleanly when no thick `LVM` pool is present on ≥2 nodes.
- **L7 replay**: `tests/operator-harness/replay/vd-resize-thick-lvm-grown-region-consistent.yaml` — operator CLI grow sequence with convergence (`vd_size_kib` / `all_uptodate` / `sync_clean`) assertions.

`go build ./...` and `go test ./...` are green; `golangci-lint run` clean on touched packages.

## Live-stand validation method (for the launcher)

The stand has no spare disk, but a thick LINSTOR `LVM` pool can be registered on the existing `blockstor-lvm` VG (free extents past the thin pool) on worker-1+2. Satellites have no udev, so raw backing-LV I/O must go via `/dev/mapper/blockstor--lvm-<lv>` (not `/dev/<vg>/<lv>`). The launcher pre-fills each node's free VG extents with a node-distinct byte, then runs the repro: grow, read the grown region on both replicas. Post-fix they read identical (resynced) bytes instead of `0xA1`/`0xB2`.
