### PR TITLE
test(e2e): kernel-read connection state + wait for device node to deflake state-standalone-partition (Bug 396)

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -220,16 +220,31 @@ kernel_all_uptodate() {
         2>/dev/null || true
 }
 
-# status_connection_state <rd> <node> <peer> — full kernel connection
-# state string as observed FROM `node` TOWARD `peer`: Connected /
-# Connecting / StandAlone / BrokenPipe / NetworkFailure / Timeout /
-# Established / Unconnected / Disconnecting / ProtocolError / TearDown /
-# WFConnection. Returns "" if the connection row hasn't been observed
-# yet (Resource missing or pre-events2). Prefer this over parsing
-# `drbdsetup status --verbose | grep -oE 'connection:[A-Za-z]+'`.
+# status_connection_state <rd> <node> <peer> — full connection state
+# string as observed FROM `node` TOWARD `peer`: Connected / Connecting /
+# StandAlone / BrokenPipe / NetworkFailure / Timeout / Established /
+# Unconnected / Disconnecting / ProtocolError / TearDown / WFConnection.
+# Returns "" if the connection row hasn't been observed yet.
+#
+# Reads KERNEL ground truth first (`drbdsetup status --json` on `node`),
+# falling back to the CRD .status.connections projection only when the
+# node/kernel read fails. The CRD projection is events2-driven and lags
+# (or is briefly empty) under heavy CI load — which made the partition /
+# heal waits in state-standalone-partition flake (the projection read
+# empty for the whole window while the kernel already showed Connecting).
+# The kernel token set is identical to the projection's, so callers that
+# match Established|Connected / BAD_STATES_RE are unaffected.
 status_connection_state() {
-    kubectl get resource "${1}.${2}" -o json 2>/dev/null \
-        | jq -r --arg p "${3}" \
+    local rd=$1 node=$2 peer=$3 st
+    st=$(on_node "$node" drbdsetup status "$rd" --json 2>/dev/null \
+        | jq -r --arg p "$peer" '.[0].connections[]? | select(.name==$p) | .connection // empty' 2>/dev/null \
+        | head -1)
+    if [[ -n "$st" ]]; then
+        printf '%s\n' "$st"
+        return 0
+    fi
+    kubectl get resource "${rd}.${node}" -o json 2>/dev/null \
+        | jq -r --arg p "$peer" \
             '.status.connections[]? | select(.peerNodeName==$p) | .message // ""'
 }
 
@@ -314,7 +329,8 @@ write_random() {
     local blocks=$(( (bytes + 4095) / 4096 ))
     on_node "$node" bash -c "
         drbdadm primary ${RD} 2>/dev/null || true
-        test -b ${dev} || { echo \"ABORT: ${dev} is not a block device — \$(stat -c '%F' ${dev} 2>/dev/null || echo missing)\" >&2; exit 2; }
+        _w=0; while [ \$_w -lt 30 ] && ! test -b ${dev}; do sleep 0.5; _w=\$((_w+1)); done
+        test -b ${dev} || { echo \"ABORT: ${dev} is not a block device after 15s — \$(stat -c '%F' ${dev} 2>/dev/null || echo missing)\" >&2; exit 2; }
         dd if=/dev/urandom of=${dev} bs=4096 count=${blocks} status=none oflag=direct
         dd if=${dev} bs=4096 count=${blocks} status=none iflag=direct | md5sum | awk '{print \$1}'
     "
@@ -331,7 +347,8 @@ read_md5() {
     local blocks=$(( (bytes + 4095) / 4096 ))
     on_node "$node" bash -c "
         drbdadm primary ${RD} 2>/dev/null || true
-        test -b ${dev} || { echo \"ABORT: ${dev} is not a block device — \$(stat -c '%F' ${dev} 2>/dev/null || echo missing)\" >&2; exit 2; }
+        _w=0; while [ \$_w -lt 30 ] && ! test -b ${dev}; do sleep 0.5; _w=\$((_w+1)); done
+        test -b ${dev} || { echo \"ABORT: ${dev} is not a block device after 15s — \$(stat -c '%F' ${dev} 2>/dev/null || echo missing)\" >&2; exit 2; }
         dd if=${dev} bs=4096 count=${blocks} status=none iflag=direct | md5sum | awk '{print \$1}'
     "
 }


### PR DESCRIPTION
## What

`state-standalone-partition` kept flaking under heavy CI load in two modes the earlier hardening (Bug 392) didn't cover — both confirmed benign at the DRBD/data layer by two live-stand investigations (replicated data intact, ZFS checksums 0, won't reproduce in isolation / at loadavg 17):

1. **Partition / heal waits read a lagging CRD projection.** `status_connection_state` queried the events2-driven CRD `.status.connections` projection, which lags or reads empty under load — so the 30s partition wait could expire with an empty token while the kernel already showed `Connecting`. Now reads **kernel ground truth** (`drbdsetup status --json` on the node) first, falling back to the CRD projection only if the kernel read fails. The token set is identical, so this also de-flakes the four other scenarios that share the helper (split-brain-recovery, recovery-stuck-synctarget, state-auto-resync).

2. **Device-node race aborted too eagerly.** `write_random`/`read_md5` aborted (exit 2) the instant `/dev/drbdX` wasn't yet a block device. On no-udev Talos under load the device node can lag the resource coming up. Now waits up to 15s for the node before aborting, so a transient `EnsureDeviceNode` lag no longer fails the test — a genuine missing-device regression still aborts loudly.

## Why

These are the recurring CI flakes that have required an admin-override on every recent PR despite being orthogonal to the change under test. Fixing the observation method (kernel ground truth + bounded device-node wait) removes the false negatives without weakening real-regression detection.

## Scope

Test-harness only (`tests/e2e/lib.sh`). No production code change. Validated by the CI e2e lanes themselves (state-standalone-partition + the four sibling scenarios run under load).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved connection state detection by querying kernel ground truth with fallback to CRD status for enhanced reliability.
  * Enhanced device initialization handling with adaptive polling (up to 15 seconds) instead of immediate failure, providing better resilience during device path availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->