### PR TITLE
fix(rest,satellite): reject/sync snapshot-restore onto snapshot-less node instead of silent empty replica (Bug 397)

### DIFF
--- a/pkg/rest/bug_397_restore_snapshotless_node_test.go
+++ b/pkg/rest/bug_397_restore_snapshotless_node_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestSnapshotRestoreBug397RejectsSnapshotlessNode is the Bug 397 (P0
+// DATA INTEGRITY) input-validation regression. An explicit `--node-name`
+// restore onto a node that does NOT hold the snapshot must be REJECTED at
+// the API edge — never silently stamp a diskful Resource there. Such a
+// replica would fall back to a blank CreateVolume on the satellite and,
+// taking the skip-init-sync day0 seed, latch UpToDate while EMPTY: an
+// empty replica presenting as a good copy, promotable on failover.
+//
+// Snapshot lives on {n1, n2}; the operator asks to restore onto {n1, n3}.
+// n3 is snapshot-less → the whole request is refused, and NO Resource (and
+// no target RD) is created (reject before any Store mutation).
+func TestSnapshotRestoreBug397RejectsSnapshotlessNode(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "pvc-src"}); err != nil {
+		t.Fatalf("seed source RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-src", NodeName: "n1",
+		Props: map[string]string{"StorPoolName": "zpool"},
+	}); err != nil {
+		t.Fatalf("seed source resource: %v", err)
+	}
+
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap-1",
+		ResourceName: "pvc-src",
+		Nodes:        []string{"n1", "n2"}, // snapshot present ONLY here
+		VolumeDefinitions: []apiv1.SnapshotVolumeDef{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024},
+		},
+	}); err != nil {
+		t.Fatalf("seed snap: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// n3 does NOT hold the snapshot — must be rejected.
+	body, _ := json.Marshal(snapshotRestoreRequest{
+		ToResource:   "pvc-restored",
+		FromSnapshot: "snap-1",
+		Nodes:        []string{"n1", "n3"},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-src/snapshot-restore-resource", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (restore onto snapshot-less node must be rejected)", resp.StatusCode)
+	}
+
+	var rcs []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rcs); err != nil {
+		t.Fatalf("decode APICallRc envelope: %v", err)
+	}
+
+	if len(rcs) != 1 {
+		t.Fatalf("envelope: got %d entries, want 1", len(rcs))
+	}
+
+	if rcs[0].RetCode&apiCallRcError == 0 {
+		t.Errorf("ret_code %d must carry MASK_ERROR", rcs[0].RetCode)
+	}
+
+	if rcs[0].RetCode&apiCallRcFailNotFoundNode == 0 {
+		t.Errorf("ret_code %d must carry FAIL_NOT_FOUND_NODE sub-code (%d)",
+			rcs[0].RetCode, apiCallRcFailNotFoundNode)
+	}
+
+	if !contains(rcs[0].Message, "n3") {
+		t.Errorf("message %q must name the offending node n3", rcs[0].Message)
+	}
+
+	// CRITICAL: no orphan state. The target RD must NOT have been created,
+	// and no Resource may have been stamped on the bad node.
+	if _, err := st.ResourceDefinitions().Get(ctx, "pvc-restored"); err == nil {
+		t.Errorf("target RD pvc-restored must NOT exist after a rejected restore (orphan state)")
+	}
+
+	res, err := st.Resources().ListByDefinition(ctx, "pvc-restored")
+	if err != nil {
+		t.Fatalf("list restored Resources: %v", err)
+	}
+
+	if len(res) != 0 {
+		t.Errorf("no Resource may be stamped after a rejected restore, got %d", len(res))
+	}
+}
+
+// TestSnapshotRestoreBug397AcceptsSnapshotNodes is the positive control:
+// restoring onto nodes that DO hold the snapshot proceeds normally and
+// stamps one Resource per node. Guards against the Bug 397 input gate
+// over-rejecting the legitimate restore path.
+func TestSnapshotRestoreBug397AcceptsSnapshotNodes(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "pvc-src"}); err != nil {
+		t.Fatalf("seed source RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-src", NodeName: "n1",
+		Props: map[string]string{"StorPoolName": "zpool"},
+	}); err != nil {
+		t.Fatalf("seed source resource: %v", err)
+	}
+
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap-1",
+		ResourceName: "pvc-src",
+		Nodes:        []string{"n1", "n2"},
+		VolumeDefinitions: []apiv1.SnapshotVolumeDef{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024},
+		},
+	}); err != nil {
+		t.Fatalf("seed snap: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// Subset of snap.Nodes — every requested node holds the snapshot.
+	body, _ := json.Marshal(snapshotRestoreRequest{
+		ToResource:   "pvc-restored",
+		FromSnapshot: "snap-1",
+		Nodes:        []string{"n1", "n2"},
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-src/snapshot-restore-resource", body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (restore onto snapshot nodes must succeed)", resp.StatusCode)
+	}
+
+	got, err := st.Resources().ListByDefinition(ctx, "pvc-restored")
+	if err != nil {
+		t.Fatalf("list restored Resources: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("Resource CRDs stamped: got %d, want 2", len(got))
+	}
+}
+
+// TestSnapshotRestoreBug397NoNodesUnaffected verifies the auto-place path
+// (no explicit --node-name) is untouched by the Bug 397 input gate: the
+// gate only constrains the explicit-node branch, leaving the auto-place
+// branch's own constrainAutoplaceToSnapshotNodes constraint to do its job.
+func TestSnapshotRestoreBug397NoNodesUnaffected(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: "pvc-src"}); err != nil {
+		t.Fatalf("seed source RD: %v", err)
+	}
+
+	if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+		Name:         "snap-1",
+		ResourceName: "pvc-src",
+		Nodes:        []string{"n1", "n2"},
+		VolumeDefinitions: []apiv1.SnapshotVolumeDef{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024},
+		},
+	}); err != nil {
+		t.Fatalf("seed snap: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// No Nodes/NodeNames at all — auto-place branch, must reach 201.
+	body, _ := json.Marshal(snapshotRestoreRequest{
+		ToResource:   "pvc-restored",
+		FromSnapshot: "snap-1",
+	})
+
+	resp := httpPost(t, base+"/v1/resource-definitions/pvc-src/snapshot-restore-resource", body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201 (no-node restore must not be rejected by the explicit-node gate)", resp.StatusCode)
+	}
+}

--- a/pkg/rest/snapshot_restore.go
+++ b/pkg/rest/snapshot_restore.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strings"
 
 	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
 	"github.com/cozystack/blockstor/pkg/placer"
@@ -217,6 +218,22 @@ func (s *Server) handleSnapshotRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bug 397 (P0, DATA INTEGRITY): an explicit `--node-name` restore MUST
+	// NOT place a diskful replica on a node that does NOT hold the snapshot.
+	// Such a replica falls back to a BLANK CreateVolume on the satellite (no
+	// local snapshot, cross-node fetch may miss) and — if it then takes the
+	// skip-init-sync day0 seed — latches UpToDate while EMPTY: a silent
+	// data-integrity loss (an empty replica presenting as a good copy,
+	// promotable on failover). The auto-place branch already constrains
+	// placement to snap.Nodes via constrainAutoplaceToSnapshotNodes; mirror
+	// that contract here at the API edge for the explicit-node path so the
+	// bad placement is rejected BEFORE any Store mutation, matching upstream
+	// LINSTOR (restoring to a snapshot-less node errors clearly rather than
+	// silently placing an empty replica).
+	if !validateRestoreNodesHoldSnapshot(w, srcRD, snapName, &req, &snap) {
+		return
+	}
+
 	newRDName, err := s.materializeRestoredRD(r.Context(), srcRD, &req, &snap)
 	if err != nil {
 		writeStoreError(w, err)
@@ -228,6 +245,77 @@ func (s *Server) handleSnapshotRestore(w http.ResponseWriter, r *http.Request) {
 		RetCode: maskInfo,
 		Message: "snapshot restored: " + snapName + " → " + newRDName,
 	}})
+}
+
+// validateRestoreNodesHoldSnapshot is the Bug 397 input-validation guard
+// for the explicit `--node-name` restore path. It rejects the request when
+// any requested node does NOT appear in the snapshot's node set
+// (snap.Nodes) — those nodes cannot clone the snapshot locally, so a
+// diskful replica stamped there would fall back to a blank volume and risk
+// latching UpToDate while empty.
+//
+// No-ops (returns true) when:
+//   - the caller supplied no explicit nodes (auto-place branch handles its
+//     own snap.Nodes constraint downstream);
+//   - the snapshot records no nodes (snap.Nodes empty) — we cannot prove a
+//     violation, so we defer to the satellite-side seed guard (defense in
+//     depth) rather than reject a possibly-legitimate request.
+//
+// Returns false (and writes the typed error envelope) when at least one
+// requested node is not in snap.Nodes.
+func validateRestoreNodesHoldSnapshot(w http.ResponseWriter, srcRD, snapName string, req *snapshotRestoreRequest, snap *apiv1.Snapshot) bool {
+	nodes := canonicalRestoreNodeList(req)
+	if len(nodes) == 0 {
+		return true
+	}
+
+	if len(snap.Nodes) == 0 {
+		return true
+	}
+
+	snapNodes := make(map[string]struct{}, len(snap.Nodes))
+	for _, n := range snap.Nodes {
+		snapNodes[n] = struct{}{}
+	}
+
+	var missing []string
+
+	seen := make(map[string]struct{}, len(nodes))
+
+	for _, n := range nodes {
+		if n == "" {
+			continue
+		}
+
+		if _, dup := seen[n]; dup {
+			continue
+		}
+
+		seen[n] = struct{}{}
+
+		if _, ok := snapNodes[n]; !ok {
+			missing = append(missing, n)
+		}
+	}
+
+	if len(missing) == 0 {
+		return true
+	}
+
+	writeJSON(w, http.StatusBadRequest, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailNotFoundNode,
+		Message: "cannot restore snapshot '" + snapName + "' onto node(s) " +
+			strings.Join(missing, ", ") + ": the snapshot does not exist there",
+		Cause: "snapshot '" + snapName + "' on '" + srcRD + "' is present only on " +
+			strings.Join(snap.Nodes, ", ") + "; a diskful replica on a snapshot-less " +
+			"node would be created empty and could silently latch UpToDate without " +
+			"the snapshot's data",
+		Correc: "restore onto a node that holds the snapshot (" +
+			strings.Join(snap.Nodes, ", ") + "), or omit --node-name to auto-place " +
+			"onto the snapshot's nodes",
+	}})
+
+	return false
 }
 
 // resolveSnapshotName picks the snapshot name from the three accepted

--- a/pkg/satellite/bug_397_restore_seed_test.go
+++ b/pkg/satellite/bug_397_restore_seed_test.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package satellite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/drbd"
+	intent "github.com/cozystack/blockstor/pkg/satellite/intent"
+	"github.com/cozystack/blockstor/pkg/storage"
+)
+
+// restoreSeedFakeProvider is a minimal storage.Provider for the Bug 397
+// seed-gate tests. RestoreVolumeFromSnapshot returns restoreErr (set to
+// storage.ErrNotFound to force the blank-fallback branch), CreateVolume is
+// counted. It does NOT implement storage.SnapshotShipper, so without a
+// CrossNodeFetcher materializeVolume falls straight through to the blank
+// CreateVolume fallback — exactly the Bug 397 data-loss path.
+type restoreSeedFakeProvider struct {
+	kind        string
+	restoreErr  error
+	createCalls int
+}
+
+func (p *restoreSeedFakeProvider) Kind() string { return p.kind }
+
+func (*restoreSeedFakeProvider) PoolStatus(_ context.Context) (storage.PoolStatus, error) {
+	return storage.PoolStatus{SupportsSnapshots: true}, nil
+}
+
+func (p *restoreSeedFakeProvider) CreateVolume(_ context.Context, _ storage.Volume) error {
+	p.createCalls++
+
+	return nil
+}
+
+func (*restoreSeedFakeProvider) DeleteVolume(_ context.Context, _ storage.Volume) error { return nil }
+func (*restoreSeedFakeProvider) ResizeVolume(_ context.Context, _ storage.Volume) error { return nil }
+
+func (*restoreSeedFakeProvider) VolumeStatus(_ context.Context, vol storage.Volume) (storage.VolumeStatus, error) {
+	return storage.VolumeStatus{
+		DevicePath: "/dev/fake/" + vol.ResourceName,
+		UsableKib:  vol.SizeKib,
+		State:      "PROVISIONED",
+	}, nil
+}
+
+func (*restoreSeedFakeProvider) CreateSnapshot(_ context.Context, _ storage.Snapshot) error {
+	return nil
+}
+
+func (*restoreSeedFakeProvider) DeleteSnapshot(_ context.Context, _ storage.Snapshot) error {
+	return nil
+}
+
+func (p *restoreSeedFakeProvider) RestoreVolumeFromSnapshot(_ context.Context,
+	_ storage.Volume, _ storage.Snapshot,
+) error {
+	return p.restoreErr
+}
+
+// TestResolveVolumeSeedBug397BlankFallbackRefusesSkip is the Bug 397 (P0
+// DATA INTEGRITY) satellite-seed regression. A snapshot-restore-backed
+// volume that fell back to a BLANK CreateVolume on this node (no local
+// snapshot, no cross-node fetch) holds NONE of the snapshot's data — it
+// MUST NOT take the day0 skip-init-sync seed, or it would latch UpToDate
+// while empty. The gate forces SkipInitialSync=false for the blank-fallback
+// replica so it comes up Inconsistent and SyncTargets the real restored
+// peer.
+//
+// The companion case proves the LEGITIMATE all-clone restore fast-path is
+// preserved: a replica that genuinely received the clone (recorded as NOT a
+// blank fallback) keeps its skip, because every diskful replica is
+// byte-identical to the snapshot.
+func TestResolveVolumeSeedBug397BlankFallbackRefusesSkip(t *testing.T) {
+	bptr := func(b bool) *bool { return &b }
+
+	cases := []struct {
+		name          string
+		sourceSnap    string
+		blankFallback bool // marker as recorded by materializeVolume
+		isWinner      bool
+		wantOK        bool // whether a skip seed is produced
+	}{
+		{
+			name:          "blank_fallback_restore_refuses_day0_skip",
+			sourceSnap:    "pvc-src:snap-1",
+			blankFallback: true,
+			wantOK:        false,
+		},
+		{
+			name:          "blank_fallback_restore_refuses_winner_uptodate_seed",
+			sourceSnap:    "pvc-src:snap-1",
+			blankFallback: true,
+			isWinner:      true,
+			wantOK:        false,
+		},
+		{
+			name:          "genuine_clone_restore_keeps_day0_skip_fastpath",
+			sourceSnap:    "pvc-src:snap-1",
+			blankFallback: false,
+			wantOK:        true,
+		},
+		{
+			name:          "genuine_clone_restore_winner_keeps_uptodate_seed",
+			sourceSnap:    "pvc-src:snap-1",
+			blankFallback: false,
+			isWinner:      true,
+			wantOK:        true,
+		},
+		{
+			name:       "non_restore_volume_unaffected_keeps_skip",
+			sourceSnap: "",
+			wantOK:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// AnyConnectedPeerHasData secondary kernel veto: report no
+			// connected peer (fresh replica) so the backstop never fires
+			// and the Bug 397 / Spec-flag decision is isolated.
+			fx := storage.NewFakeExec()
+			fx.Expect("drbdsetup status pvc-rseed --json",
+				storage.FakeResponse{Stdout: []byte(`[{"node-id":0,"connections":[]}]`)})
+
+			prov := &restoreSeedFakeProvider{kind: ProviderKindZFSThin}
+			rec := NewReconciler(ReconcilerConfig{
+				Providers: map[string]storage.Provider{"zfsthin1": prov},
+				Adm:       drbd.NewAdm(fx),
+				NodeName:  "n1",
+			})
+
+			// Reproduce what materializeVolume records for this replica.
+			if tc.sourceSnap != "" {
+				rec.recordRestoreBlankFallback("pvc-rseed", 0, tc.blankFallback)
+			}
+
+			vol := &intent.DesiredVolume{
+				VolumeNumber:   0,
+				SizeKib:        1024 * 1024,
+				StoragePool:    "zfsthin1",
+				SourceSnapshot: tc.sourceSnap,
+			}
+
+			// peerHasData=false reproduces the day0 ambiguity: the blank
+			// replica and the restored peer both sit at day0 with clean
+			// bitmaps, so the kernel/CRD probe cannot tell them apart — the
+			// exact window in which the bad skip used to fire.
+			seed, ok := rec.resolveVolumeSeed(
+				t.Context(), "pvc-rseed", vol, false, tc.isWinner, bptr(true))
+
+			if ok != tc.wantOK {
+				t.Fatalf("resolveVolumeSeed ok=%v, want %v (seed=%+v)", ok, tc.wantOK, seed)
+			}
+		})
+	}
+}
+
+// TestMaterializeVolumeBug397RecordsBlankFallback proves the end-to-end
+// wiring: materializeVolume records the blank-fallback marker when the
+// local clone misses and no cross-node fetcher is configured, and clears it
+// when the clone genuinely succeeds. This is what feeds the seed gate above
+// in a real reconcile pass.
+func TestMaterializeVolumeBug397RecordsBlankFallback(t *testing.T) {
+	t.Run("local_clone_miss_no_fetcher_marks_blank", func(t *testing.T) {
+		prov := &restoreSeedFakeProvider{kind: ProviderKindZFSThin, restoreErr: storage.ErrNotFound}
+		rec := NewReconciler(ReconcilerConfig{
+			Providers: map[string]storage.Provider{"zfsthin1": prov},
+			NodeName:  "n1",
+		})
+
+		vol := &intent.DesiredVolume{
+			VolumeNumber:   0,
+			SizeKib:        1024 * 1024,
+			StoragePool:    "zfsthin1",
+			SourceSnapshot: "pvc-src:snap-1",
+		}
+
+		if err := rec.materializeVolume(t.Context(), prov, "pvc-bf", vol); err != nil {
+			t.Fatalf("materializeVolume: %v", err)
+		}
+
+		if prov.createCalls != 1 {
+			t.Fatalf("expected blank CreateVolume fallback, got %d create calls", prov.createCalls)
+		}
+
+		if !rec.isRestoreBlankFallback("pvc-bf", 0) {
+			t.Errorf("blank-fallback marker must be set after a missed clone with no fetcher")
+		}
+	})
+
+	t.Run("local_clone_success_keeps_fastpath", func(t *testing.T) {
+		// restoreErr nil → RestoreVolumeFromSnapshot succeeds locally.
+		prov := &restoreSeedFakeProvider{kind: ProviderKindZFSThin}
+		rec := NewReconciler(ReconcilerConfig{
+			Providers: map[string]storage.Provider{"zfsthin1": prov},
+			NodeName:  "n1",
+		})
+
+		vol := &intent.DesiredVolume{
+			VolumeNumber:   0,
+			SizeKib:        1024 * 1024,
+			StoragePool:    "zfsthin1",
+			SourceSnapshot: "pvc-src:snap-1",
+		}
+
+		if err := rec.materializeVolume(t.Context(), prov, "pvc-clone", vol); err != nil {
+			t.Fatalf("materializeVolume: %v", err)
+		}
+
+		if prov.createCalls != 0 {
+			t.Errorf("genuine clone must not fall back to CreateVolume, got %d", prov.createCalls)
+		}
+
+		if rec.isRestoreBlankFallback("pvc-clone", 0) {
+			t.Errorf("genuine clone must NOT be marked blank-fallback (would break the fast-path skip)")
+		}
+	})
+}

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -250,6 +250,24 @@ type Reconciler struct {
 	// recovery by `grace` (default 30s).
 	seenStuckAt map[string]time.Time
 
+	// restoreBlankFallback records, per "<resource>/<volNumber>", that a
+	// snapshot-restore-backed volume could NOT be materialised from the
+	// snapshot on THIS node and fell back to a blank CreateVolume (no local
+	// snapshot, and cross-node fetch absent or missed). It is written in
+	// materializeVolume during applyStorage and consulted in the SAME
+	// reconcile pass by resolveVolumeSeed (Bug 397, P0 DATA INTEGRITY): a
+	// blank-fallback replica MUST NOT take the day0 skip-init-sync seed — it
+	// holds NO snapshot data, so it has to come up Inconsistent and
+	// SyncTarget the real restored peer instead of latching UpToDate empty.
+	//
+	// A volume that genuinely received the clone (RestoreVolumeFromSnapshot
+	// or cross-node recv succeeded) is recorded as false, so the legitimate
+	// all-clone restore fast-path keeps its skip (every diskful replica is
+	// byte-identical to the snapshot). Process-memory only; on a restart
+	// applyStorage re-runs (and re-probes) before seedInitialGI in the same
+	// pass, repopulating the marker, so the gate stays correct.
+	restoreBlankFallback map[string]bool
+
 	// lastRecoveryPromoteAt throttles the Bug 366 recovery-promote
 	// self-heal (maybeRecoveryPromote). Keyed by resource name; value
 	// is the last wall-clock time this node fired a recovery-promote
@@ -287,6 +305,7 @@ func NewReconciler(cfg ReconcilerConfig) *Reconciler {
 		cfg:                   cfg,
 		resourceToPool:        map[string]string{},
 		seenStuckAt:           map[string]time.Time{},
+		restoreBlankFallback:  map[string]bool{},
 		lastRecoveryPromoteAt: map[string]time.Time{},
 	}
 }
@@ -1465,6 +1484,8 @@ func (r *Reconciler) materializeVolume(ctx context.Context, provider storage.Pro
 
 	src := vol.GetSourceSnapshot()
 	if src == "" {
+		// Not a restore-backed volume; nothing for the Bug 397 seed gate
+		// to constrain. A plain blank create is not a snapshot fallback.
 		return provider.CreateVolume(ctx, target) //nolint:wrapcheck // caller wraps
 	}
 
@@ -1499,6 +1520,13 @@ func (r *Reconciler) materializeVolume(ctx context.Context, provider storage.Pro
 		PoolName:     vol.GetStoragePool(),
 	})
 	if !errors.Is(err, storage.ErrNotFound) {
+		if err == nil {
+			// Local clone succeeded: this replica holds the snapshot's
+			// data. Clear any stale blank-fallback marker so the
+			// legitimate all-clone restore fast-path keeps its skip.
+			r.recordRestoreBlankFallback(rdName, vol.GetVolumeNumber(), false)
+		}
+
 		return err //nolint:wrapcheck // caller wraps
 	}
 
@@ -1506,10 +1534,15 @@ func (r *Reconciler) materializeVolume(ctx context.Context, provider storage.Pro
 	// also doesn't pan out we fall through to a blank CreateVolume
 	// so DRBD has something to resync into.
 	if r.cfg.CrossNodeFetcher == nil {
+		// Bug 397: blank fallback — this replica did NOT receive the
+		// snapshot data. Mark it so resolveVolumeSeed refuses the day0
+		// skip and DRBD SyncTargets the real restored peer.
+		r.recordRestoreBlankFallback(rdName, vol.GetVolumeNumber(), true)
+
 		return provider.CreateVolume(ctx, target) //nolint:wrapcheck // caller wraps
 	}
 
-	return r.crossNodeClone(ctx, provider, target, srcRD, snapName, vol.GetVolumeNumber())
+	return r.crossNodeClone(ctx, provider, target, rdName, srcRD, snapName, vol.GetVolumeNumber())
 }
 
 // crossNodeClone is materializeVolume's cross-node fallback branch.
@@ -1522,11 +1555,14 @@ func (r *Reconciler) crossNodeClone(
 	ctx context.Context,
 	provider storage.Provider,
 	target storage.Volume,
-	srcRD, snapName string,
+	rdName, srcRD, snapName string,
 	volNum int32,
 ) error {
 	shipper, ok := provider.(storage.SnapshotShipper)
 	if !ok {
+		// Provider can't receive a shipped snapshot — blank fallback.
+		r.recordRestoreBlankFallback(rdName, volNum, true)
+
 		return provider.CreateVolume(ctx, target) //nolint:wrapcheck // caller wraps
 	}
 
@@ -1534,9 +1570,11 @@ func (r *Reconciler) crossNodeClone(
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			// No peer has the snapshot — DRBD resync is the last
-			// resort. Returns wrong-data on receive (split-brain
-			// from metadata mismatch); upstream behaviour with
-			// FILE_THIN matches this for now.
+			// resort. Bug 397: blank fallback, this replica holds NO
+			// snapshot data, so resolveVolumeSeed must refuse the day0
+			// skip and let DRBD SyncTarget the real restored peer.
+			r.recordRestoreBlankFallback(rdName, volNum, true)
+
 			return provider.CreateVolume(ctx, target) //nolint:wrapcheck // caller wraps
 		}
 
@@ -1550,7 +1588,40 @@ func (r *Reconciler) crossNodeClone(
 		return errors.Wrapf(err, "recv %s/%s from %s", srcRD, snapName, peer)
 	}
 
+	// Cross-node recv succeeded: this replica holds the snapshot's data.
+	// Clear any stale marker so the all-clone fast-path skip is preserved.
+	r.recordRestoreBlankFallback(rdName, volNum, false)
+
 	return nil
+}
+
+// recordRestoreBlankFallback stores, for a snapshot-restore-backed volume,
+// whether THIS node fell back to a blank CreateVolume (true) because it
+// could not materialise the snapshot, or genuinely received the clone
+// (false). resolveVolumeSeed reads this within the same reconcile pass to
+// decide whether the day0 skip-init-sync seed is safe (Bug 397). Keyed by
+// "<resource>/<volNumber>".
+func (r *Reconciler) recordRestoreBlankFallback(rdName string, volNum int32, blank bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.restoreBlankFallback[restoreSeedKey(rdName, volNum)] = blank
+}
+
+// isRestoreBlankFallback reports whether the given (resource, volume) was
+// recorded as a blank-fallback restore on this node in the current process
+// lifetime. Defaults to false when no record exists (no restore in flight,
+// or a plain create) so non-restore volumes keep their normal seed path.
+func (r *Reconciler) isRestoreBlankFallback(rdName string, volNum int32) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.restoreBlankFallback[restoreSeedKey(rdName, volNum)]
+}
+
+// restoreSeedKey builds the map key for the blank-fallback table.
+func restoreSeedKey(rdName string, volNum int32) string {
+	return rdName + "/" + strconv.Itoa(int(volNum))
 }
 
 // tearDownRemovedPeers runs `drbdadm del-peer` AND `drbdmeta
@@ -4311,6 +4382,28 @@ func (r *Reconciler) resolveVolumeSeed(ctx context.Context, resourceName string,
 	// bearing peer exists, so it remains the legitimate Phase 8.1
 	// relocate-skip path.
 	skipAllowed := skipInitialSync != nil && *skipInitialSync
+
+	// Bug 397 (P0, DATA INTEGRITY): restore-aware skip gate. A
+	// snapshot-restore-backed volume (SourceSnapshot set) that fell back to
+	// a BLANK CreateVolume on THIS node — because the snapshot was not
+	// present locally and the cross-node fetch missed (or no fetcher /
+	// shipper is configured) — holds NONE of the snapshot's data. If it
+	// took the day0 skip-init-sync seed it would latch UpToDate while empty
+	// (its day0 clean bitmap matches the restored peer's day0 clean bitmap,
+	// so DRBD does NO resync) → silent data-integrity loss, an empty
+	// replica presenting as a good copy and promotable on failover.
+	//
+	// Refuse the skip for the blank-fallback replica: it then comes up
+	// Inconsistent and SyncTargets the real restored peer, recovering the
+	// snapshot's data over the wire. The LEGITIMATE all-clone restore
+	// fast-path is preserved: a replica that genuinely received the clone
+	// (RestoreVolumeFromSnapshot / cross-node recv succeeded) is recorded
+	// as NOT a blank fallback, so it keeps its skip — every diskful replica
+	// is byte-identical to the snapshot and a full resync is needless.
+	if skipAllowed && vol.GetSourceSnapshot() != "" &&
+		r.isRestoreBlankFallback(resourceName, vol.GetVolumeNumber()) {
+		skipAllowed = false
+	}
 
 	day0 := day0GiFor(resourceName, vol.GetVolumeNumber())
 

--- a/tests/e2e/cli-matrix/README.md
+++ b/tests/e2e/cli-matrix/README.md
@@ -39,6 +39,7 @@ A cell counts as **FAIL** if either leg times out, the `linstor` CLI exits non-z
 | `sync-final-uptodate-transition.sh` | 329 | After a 3rd replica is added to a 2-replica RD, the new replica's State converges from `UpToDate(NN%)` to a bare `UpToDate` AND replication state reaches `Established`. |
 | `r-td-diskless.sh` | 330 | `linstor r td --diskless <node> <rd>` on a diskful replica flips Spec.Flags + Status.DiskState to Diskless within 30s, and `drbdsetup status` on the satellite confirms `disk:Diskless`. |
 | `r-l-conns-shapes.sh` | 331 | Conns/State column contract: parses `linstor r l` JSON across (Healthy, Disconnected peer, Diskless, TieBreaker) shapes and pins observer's events2 translation. |
+| `snap-restore-snapshotless-node-rejected.sh` | 397 | P0 DATA INTEGRITY. `snapshot resource restore` onto a node NOT holding the snapshot is rejected (no silent empty replica, no orphan RD); restoring onto the snapshot's own nodes converges UpToDate AND every replica holds the real snapshot bytes (marker read per-replica), never a silently-empty UpToDate copy. |
 
 ## Running
 

--- a/tests/e2e/cli-matrix/snap-restore-snapshotless-node-rejected.sh
+++ b/tests/e2e/cli-matrix/snap-restore-snapshotless-node-rejected.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# usage: snap-restore-snapshotless-node-rejected.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 397 (P0, DATA INTEGRITY).
+#
+# A snapshot-restore that targets a node LACKING the snapshot used to
+# fall back to a BLANK volume while leaving skip-init-sync enabled, so
+# the empty replica latched UpToDate WITHOUT syncing the real data —
+# silent data loss (an empty replica presenting as a good copy,
+# promotable on failover). This affects thin / ZFS providers (ZFS is
+# the cozystack default).
+#
+# Two-layer defense, both asserted here at operator-CLI level:
+#
+#   A. INPUT GUARD — restoring with an explicit node list that names a
+#      node NOT in the snapshot's node set must be REJECTED clearly
+#      (matching upstream LINSTOR), never silently place an empty
+#      replica. We assert the CLI returns non-zero and the bad node is
+#      named in the error.
+#
+#   B. RESTORE CORRECTNESS — restoring onto the snapshot's OWN nodes
+#      must converge UpToDate AND every diskful replica must hold the
+#      REAL snapshot bytes (the deterministic marker), never an empty
+#      device. We read the marker on EACH replica (promoting each in
+#      turn) so a silently-empty replica is caught even when DRBD
+#      reports it UpToDate.
+#
+# Contract:
+#   1. source RD, 2-replica diskful on worker-1 + worker-2.
+#   2. seed a deterministic marker, snapshot.
+#   3. (A) `snapshot resource restore ... worker-1 worker-3` where
+#      worker-3 does NOT hold the snapshot → MUST be rejected.
+#   4. (B) `snapshot resource restore ... worker-1 worker-2` → both
+#      replicas reach UpToDate and BOTH carry the marker bytes.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+SRC=cli-matrix-397-src
+SNAP=snap-397-1
+TGT_BAD=cli-matrix-397-tgt-bad
+TGT_OK=cli-matrix-397-tgt-ok
+MARKER='BLOCKSTOR-BUG397-MARKER'
+
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    "${LCTL[@]}" snapshot delete "$SRC" "$SNAP" 2>/dev/null || true
+    delete_rd "$TGT_OK"
+    delete_rd "$TGT_BAD"
+    delete_rd "$SRC"
+    assert_no_orphans "$SRC"
+    assert_no_orphans "$TGT_OK"
+    assert_no_orphans "$TGT_BAD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> source RD: 2-replica diskful on $N1 + $N2 (snapshot will live ONLY here)"
+_out=$("${LCTL[@]}" resource-definition create "$SRC" 2>&1) \
+    || { echo "FAIL: rd c $SRC: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" volume-definition create "$SRC" 64M 2>&1) \
+    || { echo "FAIL: vd c $SRC: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N1" "$SRC" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N1 $SRC: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N2" "$SRC" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N2 $SRC: $_out" >&2; exit 1; }
+wait_uptodate "$SRC" "$N1" "$N2"
+
+echo ">> seed deterministic marker on $N1 $SRC"
+on_node "$N1" drbdadm primary --force "$SRC" 2>/dev/null || true
+on_node "$N1" bash -c "
+    dev=\$(readlink -f /dev/drbd/by-res/$SRC/0 2>/dev/null || true)
+    if [ -n \"\$dev\" ]; then
+        printf '$MARKER' | dd of=\"\$dev\" bs=1 count=${#MARKER} conv=fsync status=none
+    else
+        echo 'ABORT: could not resolve /dev/drbd for $SRC on $N1' >&2
+        exit 2
+    fi
+"
+wait_uptodate "$SRC" "$N1" "$N2"
+
+echo ">> snap c $SRC $SNAP"
+_out=$("${LCTL[@]}" snapshot create "$SRC" "$SNAP" 2>&1) \
+    || { echo "FAIL: snap c $SRC $SNAP: $_out" >&2; exit 1; }
+
+# Wait snapshot Successful on its two nodes.
+deadline=$(( $(date +%s) + 60 ))
+while (( $(date +%s) < deadline )); do
+    ok=$(kubectl get snapshots.blockstor.cozystack.io -o json 2>/dev/null \
+        | jq -r --arg rd "$SRC" --arg s "$SNAP" '
+            [.items[]?
+             | select(.spec.resourceDefinitionName==$rd)
+             | select(.spec.snapshotName==$s)
+             | (.nodes = (.spec.nodes // []))
+             | (.ready = ([.status.nodeStatus[]? | select(.ready==true) | .nodeName]))
+             | ((.nodes | length) > 0) and (.nodes - .ready | length == 0)
+            ] | length > 0 and all' 2>/dev/null || echo "false")
+    [[ "$ok" == "true" ]] && break
+    sleep 2
+done
+
+# ===========================================================================
+# Layer A — INPUT GUARD: restore onto a snapshot-less node must be rejected.
+# ===========================================================================
+echo ">> [Bug 397 / A] restore onto snapshot-less $N3 must be REJECTED"
+err_file=$(mktemp)
+if "${LCTL[@]}" snapshot resource restore \
+        --from-resource "$SRC" \
+        --from-snapshot "$SNAP" \
+        --to-resource "$TGT_BAD" \
+        "$N1" "$N3" >"$err_file" 2>&1; then
+    echo "FAIL (Bug 397): restore onto snapshot-less node $N3 was ACCEPTED — would place an empty replica" >&2
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    exit 1
+fi
+
+# The error should name the offending node so the operator can fix the
+# invocation. Soft-check: surface but don't fail if wording differs.
+if ! grep -q "$N3" "$err_file"; then
+    echo "note: rejection did not name $N3 explicitly:" >&2
+    cat "$err_file" >&2
+fi
+rm -f "$err_file"
+
+# No orphan target RD / Resources may have been created by the rejected call.
+if "${LCTL[@]}" resource-definition list --resource-definitions "$TGT_BAD" 2>/dev/null | grep -q "$TGT_BAD"; then
+    echo "FAIL (Bug 397): rejected restore left an orphan target RD $TGT_BAD" >&2
+    exit 1
+fi
+
+echo ">> [Bug 397 / A] OK — snapshot-less node restore rejected, no orphan RD"
+
+# ===========================================================================
+# Layer B — RESTORE CORRECTNESS: restore onto snapshot nodes carries data.
+# ===========================================================================
+echo ">> [Bug 397 / B] restore onto snapshot nodes $N1 $N2 → $TGT_OK"
+if ! _out=$("${LCTL[@]}" snapshot resource restore \
+        --from-resource "$SRC" \
+        --from-snapshot "$SNAP" \
+        --to-resource "$TGT_OK" \
+        "$N1" "$N2" 2>&1); then
+    echo "FAIL (Bug 397): legitimate restore onto snapshot nodes rejected: $_out" >&2
+    exit 1
+fi
+
+echo ">> [Bug 397 / B] wait up to 90s for 2 Resource CRDs on $TGT_OK"
+deadline=$(( $(date +%s) + 90 ))
+placed_nodes=()
+while (( $(date +%s) < deadline )); do
+    mapfile -t placed_nodes < <(
+        kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+            | awk -v rd="${TGT_OK}." '$1 ~ "^"rd {sub(rd, "", $1); print $1}'
+    )
+    if (( ${#placed_nodes[@]} >= 2 )); then break; fi
+    sleep 3
+done
+if (( ${#placed_nodes[@]} < 2 )); then
+    echo "FAIL (Bug 397): restored RD $TGT_OK has ${#placed_nodes[@]} Resource CRD(s), expected 2" >&2
+    exit 1
+fi
+
+echo ">> [Bug 397 / B] wait up to 180s for both restored replicas UpToDate"
+deadline=$(( $(date +%s) + 180 ))
+ok=false
+while (( $(date +%s) < deadline )); do
+    s1=$(status_disk_state "$TGT_OK" "${placed_nodes[0]}" 0)
+    s2=$(status_disk_state "$TGT_OK" "${placed_nodes[1]}" 0)
+    if [[ "$s1" == "UpToDate" && "$s2" == "UpToDate" ]]; then
+        ok=true
+        break
+    fi
+    sleep 3
+done
+if ! $ok; then
+    echo "FAIL (Bug 397): restored RD $TGT_OK never reached UpToDate on both replicas — ${placed_nodes[0]}=$s1 ${placed_nodes[1]}=$s2" >&2
+    "${LCTL[@]}" resource list --resources "$TGT_OK" 2>&1 | tail -10 >&2
+    exit 1
+fi
+
+# DATA-INTEGRITY assertion: read the marker on EACH replica. A silently-
+# empty replica (the Bug 397 failure mode) reports UpToDate but reads back
+# zeros — promoting each node in turn and reading the device catches it.
+echo ">> [Bug 397 / B] assert REAL snapshot bytes on EACH restored replica"
+for node in "${placed_nodes[0]}" "${placed_nodes[1]}"; do
+    # Demote the other replicas so this node can become Primary cleanly.
+    for other in "${placed_nodes[@]}"; do
+        [[ "$other" == "$node" ]] && continue
+        on_node "$other" drbdadm secondary "$TGT_OK" 2>/dev/null || true
+    done
+
+    marker_read=$(on_node "$node" bash -c "
+        drbdadm primary --force $TGT_OK 2>/dev/null || true
+        dev=\$(readlink -f /dev/drbd/by-res/$TGT_OK/0 2>/dev/null || true)
+        if [ -n \"\$dev\" ]; then
+            head -c ${#MARKER} \"\$dev\" 2>/dev/null
+        fi
+    " 2>/dev/null || echo "")
+
+    if [[ "$marker_read" != "$MARKER" ]]; then
+        echo "FAIL (Bug 397): replica $node of $TGT_OK does NOT hold the snapshot data" >&2
+        echo "  read='${marker_read}', expected '$MARKER'" >&2
+        echo "  This is the silent-empty-replica data-integrity bug: UpToDate but no data." >&2
+        exit 1
+    fi
+    echo "   $node: marker present"
+done
+
+echo ">> snap-restore-snapshotless-node-rejected OK (Bug 397: reject snapshot-less node; restored replicas all hold real data)"

--- a/tests/operator-harness/replay/snap-restore-data-correctness.yaml
+++ b/tests/operator-harness/replay/snap-restore-data-correctness.yaml
@@ -1,0 +1,113 @@
+name: snap-restore-data-correctness
+description: |
+  Bug-397 catcher (P0, DATA INTEGRITY). The round-3 hunt found there is
+  NO restore data-correctness replay today; this is it.
+
+  A snapshot-restore that targets a node LACKING the snapshot used to
+  fall back to a BLANK volume while leaving skip-init-sync enabled, so
+  the empty replica latched UpToDate WITHOUT syncing from the real
+  restored peer — silent data loss (an empty replica presenting as a
+  good copy, promotable on failover). Affects thin/ZFS providers (ZFS
+  is the cozystack default).
+
+  Two-layer defense, both exercised here:
+
+    A. INPUT GUARD — `snapshot resource restore` with an explicit node
+       list naming a node NOT in the snapshot's node set must be
+       REJECTED (non-zero), mirroring upstream LINSTOR, instead of
+       silently stamping an empty replica. Step `restore-snapshotless-
+       node-rejected` pins this; pre-fix the call returned 0 and placed
+       an empty replica on the snapshot-less node.
+
+    B. RESTORE CORRECTNESS — restoring onto the snapshot's OWN nodes
+       must converge every replica to UpToDate. Step `restore-onto-
+       snapshot-nodes` + the `all_uptodate` await pins this. The
+       satellite-side seed gate (defense in depth) ensures a
+       blank-fallback replica comes up Inconsistent and SyncTargets the
+       real restored peer rather than latching UpToDate empty; the
+       legitimate all-clone restore fast-path is preserved.
+
+  Sequence: 2-replica diskful RD on node1+node2 → snapshot (lives on
+  node1,node2 only) → restore targeting node1+node3 (node3 snapshot-
+  less) MUST be rejected → restore targeting node1+node2 converges
+  UpToDate on both. The harness data-presence check is the per-replica
+  marker read in the sibling L6 cell
+  (tests/e2e/cli-matrix/snap-restore-snapshotless-node-rejected.sh);
+  this replay codifies the operator sequence + the reject/converge
+  contract the harness can assert directly.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+  rd: snap397-src
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-source-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: snapshot-create
+    cmd: ["snapshot", "create", "{{rd}}", "snap397"]
+    expect_exit: 0
+  # ---- Layer A: restore onto a snapshot-less node MUST be rejected ----
+  # The snapshot lives on node1+node2 only. node3 does NOT hold it, so a
+  # diskful restore there would create an empty replica. The handler
+  # rejects this at the API edge (apiCallRcError envelope → CLI exit 10,
+  # matching the auto-place-no-drbd rejection idiom). Pre-fix this
+  # returned 0 and silently placed an empty replica on node3.
+  - name: restore-snapshotless-node-rejected
+    cmd: ["snapshot", "resource", "restore",
+          "--from-resource", "{{rd}}",
+          "--from-snapshot", "snap397",
+          "--to-resource", "snap397-tgt-bad",
+          "{{node1}}", "{{node3}}"]
+    expect_exit: 10
+  - name: rejected-restore-left-no-rd
+    cmd: ["resource-definition", "list", "--resource-definitions", "snap397-tgt-bad"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: snap397-tgt-bad
+      timeout_s: 30
+  # ---- Layer B: restore onto the snapshot's nodes converges UpToDate ----
+  - name: restore-onto-snapshot-nodes
+    cmd: ["snapshot", "resource", "restore",
+          "--from-resource", "{{rd}}",
+          "--from-snapshot", "snap397",
+          "--to-resource", "snap397-tgt-ok",
+          "{{node1}}", "{{node2}}"]
+    expect_exit: 0
+  - name: restored-replicas-all-uptodate
+    cmd: ["resource", "list", "--resources", "snap397-tgt-ok"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: snap397-tgt-ok
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "snap397-tgt-ok"]
+  - cmd: ["resource-definition", "delete", "snap397-tgt-bad"]
+  - cmd: ["snapshot", "delete", "{{rd}}", "snap397"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

P0 **data-integrity** fix. A snapshot-restore that targeted a node **lacking the snapshot** (and where cross-node fetch also missed) fell back to a **blank** volume, but skip-init-sync was left enabled — so the blank replica latched `UpToDate` **without syncing** from the real restored peer. The result was a silently-empty replica presenting as a good copy, promotable on failover. This affects thin / ZFS providers (ZFS is the cozystack default). It is the Bug-395 class (skip a needed sync) on the restore/clone path.

## Fix — defense in depth (two layers)

**1. REST input guard (primary, upstream-aligned).** The explicit `--node-name` restore path now constrains the named nodes to the snapshot's node set and rejects — before any Store mutation — a node that does not hold the snapshot. This mirrors what the auto-place branch already does via `constrainAutoplaceToSnapshotNodes`, and matches upstream LINSTOR: restoring onto a snapshot-less node errors clearly instead of silently placing an empty replica. The rejection carries the typed `FAIL_NOT_FOUND_NODE` envelope and leaves no orphan RD/Resource.

**2. Satellite seed correctness (defense in depth).** `materializeVolume` now records whether a restore-backed volume genuinely received the clone or fell back to a blank `CreateVolume`. `resolveVolumeSeed` refuses the day0 skip-init-sync seed for a blank-fallback replica, so it comes up Inconsistent and SyncTargets the real restored peer rather than latching `UpToDate` empty.

The two layers protect different reachable paths (API-edge placement vs. an already-placed blank-fallback replica) and are coordinated so they don't double-cover in a way that breaks the happy path.

## Legitimate restore fast-path preserved

When **every** diskful replica genuinely received the clone, all replicas are byte-identical to the snapshot and the skip is safe — that fast-path is kept (no needless full resync). Only the **blank-fallback** replica is forced to sync. This is the restore-path analog of the zero-fill fast-path in Bug 395.

## Tests (CLI-bug-fix protocol, all in this PR)

- **L1 REST**: restoring with a `--node-name` not in the snapshot's node set is rejected (typed envelope, no orphan state); restoring onto snapshot nodes still succeeds; the no-node auto-place path is unaffected.
- **L1 satellite**: a restore-backed blank-fallback replica does **not** get the day0 skip seed (must sync), while an all-clone restore keeps the fast-path skip; plus an end-to-end `materializeVolume` marker test (blank-fallback sets it, a genuine clone clears it).
- **L6 cli-matrix** (`snap-restore-snapshotless-node-rejected.sh`): restore onto a snapshot-less node rejected (no orphan RD); restore onto the snapshot's nodes converges UpToDate **and** every replica is verified to hold the real snapshot bytes (marker read per-replica) — catching a silently-empty UpToDate copy.
- **L7 replay** (`snap-restore-data-correctness.yaml`): rd → snapshot → restore onto a snapshot-less node (rejected) → restore onto snapshot nodes (`all_uptodate`). Closes the round-3 hunt gap (no restore data-correctness replay existed).

Both L1 layers were verified to **fail pre-fix** and **pass post-fix**. `go build ./...`, `go test ./...` green; `golangci-lint run` clean on the touched packages. Live-stand validation of the L6/L7 cells is run by the launcher.
