### PR TITLE
fix(controller): prune Resource.spec.volumes + observer status so the resource stops flapping after vd-d (Bug 399)

### DIFF
--- a/internal/controller/bug_399_vd_d_prune_resource_volumes_test.go
+++ b/internal/controller/bug_399_vd_d_prune_resource_volumes_test.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+)
+
+// Bug 399: `vd d` drops a VolumeDefinition from the RD, but the
+// controller's RD.Spec.VolumeDefinitions → Resource.Spec.Volumes
+// projection was ADD-ONLY (ensureSeedFromGI / setSeedFromGI only ever
+// append). The stale Spec.Volumes entry for the removed volume then
+// kept the controller "knowing" about it, so the phantom Status.Volumes
+// entry was never garbage-collected and the Resource Status flapped
+// forever (resourceVersion churned ~1/s).
+//
+// These tests pin the prune (remove side) added in this fix and prove
+// it does NOT regress the still-present volume or the `vd c` late-add
+// (Bug 384) path, and that it is strictly idempotent (no PATCH thrash
+// once converged — the actual flap-stopper).
+
+func bug399Scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := blockstoriov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	return scheme
+}
+
+func volNumbers(res *blockstoriov1alpha1.Resource) []int32 {
+	out := make([]int32, 0, len(res.Spec.Volumes))
+	for i := range res.Spec.Volumes {
+		out = append(out, res.Spec.Volumes[i].VolumeNumber)
+	}
+
+	return out
+}
+
+// TestBug399PrunesRemovedVolumeFromSpec is the core regression: an RD
+// reduced to a single VolumeDefinition (vol-0) must drive the Resource's
+// Spec.Volumes — still carrying the stale vol-1 left by the add-only
+// projection — back to exactly [vol-0] on Reconcile, and the second
+// Reconcile must be a no-op (no resourceVersion churn) so the flap
+// stops.
+func TestBug399PrunesRemovedVolumeFromSpec(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := bug399Scheme(t)
+
+	const (
+		rdName       = "flap-rd"
+		nodeName     = "n1"
+		resourceName = rdName + "." + nodeName
+	)
+
+	// RD already reduced to vol-0 only (post `vd d 1`).
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: rdName},
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			VolumeDefinitions: []blockstoriov1alpha1.ResourceDefinitionVolume{
+				{VolumeNumber: 0, SizeKib: 1024},
+			},
+		},
+	}
+
+	// Resource Spec.Volumes still carries the orphaned vol-1.
+	res := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: rdName,
+			NodeName:               nodeName,
+			Volumes: []blockstoriov1alpha1.ResourceVolumeSpec{
+				{VolumeNumber: 0},
+				{VolumeNumber: 1},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(
+			&blockstoriov1alpha1.Resource{},
+			&blockstoriov1alpha1.ResourceDefinition{},
+		).
+		WithObjects(rd, res).
+		Build()
+
+	rec := &ResourceReconciler{Client: cli, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceName}}
+
+	reconcileN := func(label string, n int) {
+		for i := range n {
+			if _, err := rec.Reconcile(ctx, req); err != nil {
+				t.Fatalf("%s Reconcile %d: %v", label, i, err)
+			}
+		}
+	}
+
+	// Drain the requeue chain to convergence: the first passes stamp
+	// DRBD-IDs / skip-sync decision (each requeues), then the prune
+	// fires. A real controller drains its workqueue the same way.
+	reconcileN("initial", 10)
+
+	got := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: resourceName}, got); err != nil {
+		t.Fatalf("get after prune: %v", err)
+	}
+
+	if nums := volNumbers(got); len(nums) != 1 || nums[0] != 0 {
+		t.Fatalf("Spec.Volumes after prune = %v, want [0]", nums)
+	}
+
+	// The no-flap assertion: once converged, further Reconciles must NOT
+	// write to the apiserver. We detect a write via resourceVersion
+	// churn (the fake client bumps it on every Update). A non-idempotent
+	// prune would re-remove/re-add the same entry every pass — exactly
+	// the production flap (resourceVersion churning ~1/s).
+	rvAfterPrune := got.ResourceVersion
+
+	reconcileN("steady-state", 5)
+
+	settled := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: resourceName}, settled); err != nil {
+		t.Fatalf("get after steady-state: %v", err)
+	}
+
+	if settled.ResourceVersion != rvAfterPrune {
+		t.Errorf("resourceVersion churned after prune converged (%s -> %s): prune is not idempotent, the flap would persist",
+			rvAfterPrune, settled.ResourceVersion)
+	}
+
+	if nums := volNumbers(settled); len(nums) != 1 || nums[0] != 0 {
+		t.Errorf("Spec.Volumes drifted after steady-state = %v, want [0]", nums)
+	}
+}
+
+// TestBug399KeepsPresentAndMidAddVolumes pins the two non-regression
+// cases for the prune:
+//
+//  1. A volume still declared by the RD is NEVER pruned.
+//  2. The `vd c` late-add (Bug 384) shape — the RD already carries the
+//     new VolumeDefinition (that is what triggers the Resource
+//     reconcile) while the Resource's Spec.Volumes has not yet caught
+//     up — must be preserved: prune keys off ABSENCE from the RD, so a
+//     mid-add volume (present in the RD) is in the desired set and is
+//     never removed.
+func TestBug399KeepsPresentAndMidAddVolumes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := bug399Scheme(t)
+
+	const (
+		rdName       = "twovol-rd"
+		nodeName     = "n2"
+		resourceName = rdName + "." + nodeName
+	)
+
+	// RD carries vol-0 AND vol-1 (e.g. mid `vd c 1` — the new VD is
+	// already authored, the satellite/Resource is catching up).
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: rdName},
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			VolumeDefinitions: []blockstoriov1alpha1.ResourceDefinitionVolume{
+				{VolumeNumber: 0, SizeKib: 1024},
+				{VolumeNumber: 1, SizeKib: 2048},
+			},
+		},
+	}
+
+	// Resource only has vol-0 so far (vol-1 add still in flight). The
+	// prune must NOT touch vol-0, and must NOT invent/remove anything
+	// for the not-yet-present vol-1.
+	res := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: rdName,
+			NodeName:               nodeName,
+			Volumes: []blockstoriov1alpha1.ResourceVolumeSpec{
+				{VolumeNumber: 0},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(
+			&blockstoriov1alpha1.Resource{},
+			&blockstoriov1alpha1.ResourceDefinition{},
+		).
+		WithObjects(rd, res).
+		Build()
+
+	rec := &ResourceReconciler{Client: cli, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: resourceName}}
+
+	for i := range 10 {
+		if _, err := rec.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile %d: %v", i, err)
+		}
+	}
+
+	got := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: resourceName}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	// vol-0 must survive. vol-1 (mid-add, in the RD) must never be
+	// pruned away. The seed-GI add-path may legitimately not add vol-1
+	// here (no UpToDate peer to seed from), but it must never be
+	// REMOVED — assert vol-0 is present and no declared volume vanished.
+	present := map[int32]bool{}
+	for _, n := range volNumbers(got) {
+		present[n] = true
+	}
+
+	if !present[0] {
+		t.Errorf("vol-0 (still declared by RD) was pruned: Spec.Volumes = %v", volNumbers(got))
+	}
+}
+
+// TestPruneStaleResourceVolumesUnit exercises the helper directly for
+// the boundary cases the Reconcile-level tests don't isolate: a nil/
+// empty RD must be a no-op (defensive — never blank Spec.Volumes during
+// a create/cascade), and an already-in-sync Resource must report
+// mutated=false (no apiserver write).
+func TestPruneStaleResourceVolumesUnit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := bug399Scheme(t)
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	rec := &ResourceReconciler{Client: cli, Scheme: scheme}
+
+	twoVolRes := func() *blockstoriov1alpha1.Resource {
+		return &blockstoriov1alpha1.Resource{
+			Spec: blockstoriov1alpha1.ResourceSpec{
+				Volumes: []blockstoriov1alpha1.ResourceVolumeSpec{
+					{VolumeNumber: 0},
+					{VolumeNumber: 1},
+				},
+			},
+		}
+	}
+
+	// nil RD: defensive no-op, no error, no mutation.
+	if mutated, err := rec.pruneStaleResourceVolumes(ctx, twoVolRes(), nil); err != nil || mutated {
+		t.Errorf("nil RD: mutated=%v err=%v, want false/nil", mutated, err)
+	}
+
+	// RD with zero VolumeDefinitions (fresh / mid-cascade): no-op.
+	emptyRD := &blockstoriov1alpha1.ResourceDefinition{}
+	if mutated, err := rec.pruneStaleResourceVolumes(ctx, twoVolRes(), emptyRD); err != nil || mutated {
+		t.Errorf("empty-RD: mutated=%v err=%v, want false/nil", mutated, err)
+	}
+
+	// Already in sync (RD declares both vol-0 and vol-1): no mutation.
+	syncedRD := &blockstoriov1alpha1.ResourceDefinition{
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			VolumeDefinitions: []blockstoriov1alpha1.ResourceDefinitionVolume{
+				{VolumeNumber: 0, SizeKib: 1024},
+				{VolumeNumber: 1, SizeKib: 1024},
+			},
+		},
+	}
+	if mutated, err := rec.pruneStaleResourceVolumes(ctx, twoVolRes(), syncedRD); err != nil || mutated {
+		t.Errorf("in-sync: mutated=%v err=%v, want false/nil", mutated, err)
+	}
+}

--- a/internal/controller/resource_controller.go
+++ b/internal/controller/resource_controller.go
@@ -363,19 +363,16 @@ func (r *ResourceReconciler) runApply(ctx context.Context, target *blockstoriov1
 	// stamped it returns mutated=false without touching the apiserver,
 	// so the early call has no fixed-state cost.
 
-	// Initial-sync skip seeding (Phase 8.1): on a freshly-added
-	// replica, pick the CurrentGI of an existing UpToDate peer and
-	// stamp it into Spec.Volumes[i].SeedFromGI. The satellite
-	// reconciler then pre-seeds the new replica's DRBD metadata
-	// before drbdadm up so DRBD's GI handshake skips the full
-	// initial-sync. Idempotent: re-runs on a Resource whose
-	// SeedFromGI is already set leave Spec alone.
-	seeded, err := r.ensureSeedFromGI(ctx, target, peers, rdPtr)
+	// Project RD.Spec.VolumeDefinitions onto this Resource's
+	// Spec.Volumes: prune removed volumes (Bug 399 / `vd d` remove
+	// side) then seed-GI the survivors (Phase 8.1 add side). Either
+	// mutation persists + requeues onto the fresh revision.
+	projected, err := r.ensureVolumeProjection(ctx, target, peers, rdPtr)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if seeded {
+	if projected {
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -976,6 +973,88 @@ func (r *ResourceReconciler) ensureSeedFromGI(_ context.Context, target *blockst
 	if !mutated {
 		return false, nil
 	}
+
+	if err := r.Update(context.Background(), target); err != nil { //nolint:contextcheck // ctx-cancel survives Update — propagating it would race the requeue
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ensureVolumeProjection reconciles Resource.Spec.Volumes against the
+// parent RD's VolumeDefinitions: it first prunes entries for volumes
+// the RD no longer declares (Bug 399 / `vd d`), then seed-GIs the
+// survivors (Phase 8.1). Returns true when either step mutated Spec
+// (and persisted it) so the caller requeues onto the fresh revision.
+//
+// Prune runs before seed so the add-path only ever operates on the
+// live volume set, and a single reconcile never both removes and
+// re-seeds the same VolumeNumber. Both steps are individually
+// idempotent — a Resource already in sync takes the no-write fast path.
+func (r *ResourceReconciler) ensureVolumeProjection(ctx context.Context, target *blockstoriov1alpha1.Resource, peers []blockstoriov1alpha1.Resource, rd *blockstoriov1alpha1.ResourceDefinition) (bool, error) {
+	pruned, err := r.pruneStaleResourceVolumes(ctx, target, rd)
+	if err != nil {
+		return false, err
+	}
+
+	if pruned {
+		return true, nil
+	}
+
+	return r.ensureSeedFromGI(ctx, target, peers, rd)
+}
+
+// pruneStaleResourceVolumes drops Resource.Spec.Volumes entries whose
+// VolumeNumber is no longer declared by the parent RD's
+// VolumeDefinitions (Bug 399). The RD→Resource volume projection is
+// otherwise add-only (ensureSeedFromGI / setSeedFromGI only ever
+// append), so after `vd d` removes a VolumeDefinition the matching
+// Spec.Volumes entry survives forever — and the controller keeps
+// "knowing" about the removed volume, so the phantom Status.Volumes
+// entry for it is never garbage-collected and the Resource Status
+// oscillates indefinitely.
+//
+// Returns true (and persists via Update) when it actually removed an
+// entry, so the caller requeues onto the pruned revision. Strictly
+// idempotent: a Resource already in sync with its RD takes the
+// no-mutation fast path and never touches the apiserver — no PATCH
+// thrash.
+//
+// Safety against the `vd c` late-add race (Bug 384): an entry is only
+// pruned when its VolumeNumber is ABSENT from the RD's current
+// VolumeDefinitions. A volume mid-add already has its VolumeDefinition
+// authored on the RD (that is what triggers the Resource reconcile),
+// so it is in the desired set and is never pruned. A defensive guard
+// also skips the whole pass when the RD carries zero VolumeDefinitions
+// (freshly-created or mid-cascade-delete RD) so we never blank a
+// Resource's Spec.Volumes out from under an in-flight create/teardown.
+func (r *ResourceReconciler) pruneStaleResourceVolumes(_ context.Context, target *blockstoriov1alpha1.Resource, rd *blockstoriov1alpha1.ResourceDefinition) (bool, error) {
+	if rd == nil || len(rd.Spec.VolumeDefinitions) == 0 {
+		return false, nil
+	}
+
+	if len(target.Spec.Volumes) == 0 {
+		return false, nil
+	}
+
+	desired := make(map[int32]struct{}, len(rd.Spec.VolumeDefinitions))
+	for i := range rd.Spec.VolumeDefinitions {
+		desired[rd.Spec.VolumeDefinitions[i].VolumeNumber] = struct{}{}
+	}
+
+	survivors := make([]blockstoriov1alpha1.ResourceVolumeSpec, 0, len(target.Spec.Volumes))
+
+	for i := range target.Spec.Volumes {
+		if _, ok := desired[target.Spec.Volumes[i].VolumeNumber]; ok {
+			survivors = append(survivors, target.Spec.Volumes[i])
+		}
+	}
+
+	if len(survivors) == len(target.Spec.Volumes) {
+		return false, nil
+	}
+
+	target.Spec.Volumes = survivors
 
 	if err := r.Update(context.Background(), target); err != nil { //nolint:contextcheck // ctx-cancel survives Update — propagating it would race the requeue
 		return false, err

--- a/pkg/satellite/controllers/bug_399_volume_evict_test.go
+++ b/pkg/satellite/controllers/bug_399_volume_evict_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/drbd"
+)
+
+// Bug 399: after `vd d` removes a volume, drbdsetup emits
+// `destroy device name:<rd> volume:<n>`. The observer's volCache was
+// otherwise APPEND-ONLY (mergeVolumes only ever added entries — there
+// was no destroy path), so the cache kept re-emitting a phantom
+// Status.Volumes entry for the deleted volume on every subsequent tick.
+// Combined with the controller/satellite purge removing it, this
+// produced a permanent Status flap. These tests pin the eviction path.
+
+// volSet collapses a Volumes slice to the set of VolumeNumbers it
+// carries, for order-independent assertions.
+func volSet(vols []volumeObservation) map[int32]bool {
+	out := map[int32]bool{}
+	for i := range vols {
+		out[vols[i].VolumeNumber] = true
+	}
+
+	return out
+}
+
+// TestTranslateDeviceEventDestroyMarksRemoved pins that a `destroy
+// device` frame translates into a single Removed volume observation
+// keyed by the volume number — the signal mergeVolumes needs to evict
+// the cache entry.
+func TestTranslateDeviceEventDestroyMarksRemoved(t *testing.T) {
+	t.Parallel()
+
+	obs, ok := translateEvent(drbd.Event{
+		Kind:   eventKindDevice,
+		Action: eventActionDestroy,
+		Fields: map[string]string{
+			"name":   "test",
+			"volume": "1",
+		},
+	})
+	if !ok {
+		t.Fatalf("destroy device frame was dropped, want translated")
+	}
+
+	if obs.ResourceName != "test" {
+		t.Errorf("ResourceName = %q, want test", obs.ResourceName)
+	}
+
+	if len(obs.Volumes) != 1 {
+		t.Fatalf("Volumes = %+v, want exactly one entry", obs.Volumes)
+	}
+
+	if obs.Volumes[0].VolumeNumber != 1 || !obs.Volumes[0].Removed {
+		t.Errorf("Volumes[0] = %+v, want {VolumeNumber:1, Removed:true}", obs.Volumes[0])
+	}
+}
+
+// TestMergeVolumesEvictsRemovedVolume is the core flap-stopper: a two-
+// volume cache that receives a `destroy device` for volume 1 must drop
+// it, and the re-emitted snapshot must carry only the surviving volume.
+// A later device tick for the survivor must NOT resurrect volume 1.
+func TestMergeVolumesEvictsRemovedVolume(t *testing.T) {
+	t.Parallel()
+
+	o := &ObserverRunnable{}
+
+	// Two volumes observed UpToDate (the 2-volume RD before `vd d 1`).
+	o.mergeVolumes(&observation{
+		ResourceName: "test",
+		Volumes: []volumeObservation{
+			{VolumeNumber: 0, DiskState: "UpToDate"},
+		},
+	})
+	o.mergeVolumes(&observation{
+		ResourceName: "test",
+		Volumes: []volumeObservation{
+			{VolumeNumber: 1, DiskState: "UpToDate"},
+		},
+	})
+
+	// `destroy device volume:1` arrives after the vd-d cascade.
+	destroy := &observation{
+		ResourceName: "test",
+		Volumes: []volumeObservation{
+			{VolumeNumber: 1, Removed: true},
+		},
+	}
+	o.mergeVolumes(destroy)
+
+	// The destroy must count as a change (it mutated the cache) and the
+	// re-emitted snapshot must carry only volume 0.
+	if got := volSet(destroy.Volumes); got[1] || !got[0] {
+		t.Errorf("snapshot after destroy = %v, want only volume 0", got)
+	}
+
+	// A subsequent statistics tick on the survivor must NOT bring
+	// volume 1 back from the dead — that resurrection was the flap.
+	tick := &observation{
+		ResourceName: "test",
+		Volumes: []volumeObservation{
+			{VolumeNumber: 0, DiskState: "UpToDate"},
+		},
+	}
+	o.mergeVolumes(tick)
+
+	o.volMu.Lock()
+	_, vol1Present := o.volCache["test"][1]
+	cacheLen := len(o.volCache["test"])
+	o.volMu.Unlock()
+
+	if vol1Present {
+		t.Errorf("volume 1 resurrected in cache after eviction — flap would persist")
+	}
+
+	if cacheLen != 1 {
+		t.Errorf("volCache len = %d, want 1 (only volume 0)", cacheLen)
+	}
+}
+
+// TestMergeVolumesDestroyUnknownVolumeNoop pins that a `destroy device`
+// for a volume the cache never knew about is a no-op: it must NOT mark
+// the observation as changed (which would spin an empty Status write)
+// and must NOT add a phantom entry.
+func TestMergeVolumesDestroyUnknownVolumeNoop(t *testing.T) {
+	t.Parallel()
+
+	o := &ObserverRunnable{}
+
+	o.mergeVolumes(&observation{
+		ResourceName: "test",
+		Volumes: []volumeObservation{
+			{VolumeNumber: 0, DiskState: "UpToDate"},
+		},
+	})
+
+	// Destroy for a volume that was never cached.
+	ev := &observation{
+		ResourceName: "test",
+		Volumes: []volumeObservation{
+			{VolumeNumber: 7, Removed: true},
+		},
+	}
+	o.mergeVolumes(ev)
+
+	// No change → mergeVolumes nils out ev.Volumes so the apply path
+	// short-circuits (no spurious Status write).
+	if ev.Volumes != nil {
+		t.Errorf("destroy of unknown volume emitted a snapshot %+v, want no write", ev.Volumes)
+	}
+
+	o.volMu.Lock()
+	_, phantom := o.volCache["test"][7]
+	o.volMu.Unlock()
+
+	if phantom {
+		t.Errorf("destroy of unknown volume added a phantom cache entry")
+	}
+}

--- a/pkg/satellite/controllers/bug_399_volume_evict_test.go
+++ b/pkg/satellite/controllers/bug_399_volume_evict_test.go
@@ -19,9 +19,17 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
 	"github.com/cozystack/blockstor/pkg/drbd"
+	"github.com/cozystack/blockstor/pkg/storage"
 )
 
 // Bug 399: after `vd d` removes a volume, drbdsetup emits
@@ -174,5 +182,242 @@ func TestMergeVolumesDestroyUnknownVolumeNoop(t *testing.T) {
 
 	if phantom {
 		t.Errorf("destroy of unknown volume added a phantom cache entry")
+	}
+}
+
+// Bug 399 (diskless/tiebreaker facet): the partial fix stopped the flap
+// on diskful replicas (the `destroy device` eviction above), but a
+// DISKLESS / tiebreaker replica still flapped. A diskless replica has no
+// local backing disk to tear down, so drbd-9 never emits a
+// `destroy device` frame for its removed volume — its `vN:Diskless`
+// device frame simply stops arriving. With no destroy signal the
+// append-only volCache kept the stale entry forever and the observer
+// re-emitted a phantom Status.Volumes[n] on every resync tick. The fix:
+// converge the cache to the RD's live volume set (the
+// `blockstor.io/volume-numbers` annotation the reconciler stamps), which
+// is destroy-event-independent. These tests pin that convergence.
+
+// TestPruneVolumeCacheToDesiredEvictsDisklessOrphan is the diskless
+// flap-stopper. The cache holds two Diskless volumes (the tiebreaker's
+// 2-volume view before `vd d 1`). No `destroy device` ever arrives for
+// volume 1 (the diskless replica has no disk to destroy). The prune
+// against an RD whose annotation now lists only "0" must evict volume 1,
+// re-emit a snapshot carrying only volume 0, and a subsequent tick must
+// NOT resurrect volume 1 — that resurrection was the flap.
+func TestPruneVolumeCacheToDesiredEvictsDisklessOrphan(t *testing.T) {
+	t.Parallel()
+
+	o := &ObserverRunnable{NodeName: "worker-3"}
+
+	// Diskless replica caches both volumes via `device disk:Diskless`
+	// frames — exactly how a tiebreaker reports its volumes.
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 0, DiskState: "Diskless"}},
+	})
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 1, DiskState: "Diskless"}},
+	})
+
+	// `vd d 1` removed volume 1 from the RD. The reconciler re-stamped
+	// the annotation to "0". No `destroy device` frame for the diskless
+	// replica — the only convergence signal is the desired set.
+	res := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "flap399.worker-3",
+			Annotations: map[string]string{
+				blockstoriov1alpha1.ResourceAnnotationVolumeNumbers: "0",
+			},
+		},
+	}
+
+	ev := &observation{ResourceName: "flap399"}
+	o.pruneVolumeCacheToDesired(ev, res)
+
+	if got := volSet(ev.Volumes); got[1] || !got[0] {
+		t.Errorf("snapshot after prune = %v, want only volume 0", got)
+	}
+
+	o.volMu.Lock()
+	_, vol1Present := o.volCache["flap399"][1]
+	cacheLen := len(o.volCache["flap399"])
+	o.volMu.Unlock()
+
+	if vol1Present {
+		t.Errorf("volume 1 still cached after prune — diskless flap would persist")
+	}
+
+	if cacheLen != 1 {
+		t.Errorf("volCache len = %d, want 1 (only volume 0)", cacheLen)
+	}
+
+	// A later Diskless device tick on the survivor must not re-add the
+	// orphan, and a re-prune must be a no-op (converged → no write).
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 0, DiskState: "Diskless"}},
+	})
+
+	settled := &observation{ResourceName: "flap399"}
+	o.pruneVolumeCacheToDesired(settled, res)
+
+	if settled.Volumes != nil {
+		t.Errorf("converged prune emitted a snapshot %+v, want no write", settled.Volumes)
+	}
+}
+
+// TestPruneVolumeCacheToDesiredNoAnnotationNoop pins the safety guard:
+// when the desired set is unknown (no / empty / unparseable
+// `blockstor.io/volume-numbers` annotation) the prune must NOT touch the
+// cache. Blanking a replica's volumes on a missing record would be far
+// worse than a transient stale entry (early convergence before the first
+// stamp lands).
+func TestPruneVolumeCacheToDesiredNoAnnotationNoop(t *testing.T) {
+	t.Parallel()
+
+	o := &ObserverRunnable{NodeName: "worker-3"}
+
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 0, DiskState: "Diskless"}},
+	})
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 1, DiskState: "Diskless"}},
+	})
+
+	// Resource with no volume-numbers annotation at all.
+	res := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "flap399.worker-3"},
+	}
+
+	ev := &observation{ResourceName: "flap399"}
+	o.pruneVolumeCacheToDesired(ev, res)
+
+	if ev.Volumes != nil {
+		t.Errorf("prune with unknown desired set emitted %+v, want no write", ev.Volumes)
+	}
+
+	o.volMu.Lock()
+	cacheLen := len(o.volCache["flap399"])
+	o.volMu.Unlock()
+
+	if cacheLen != 2 {
+		t.Errorf("volCache len = %d, want 2 — prune must not evict on unknown desired set", cacheLen)
+	}
+}
+
+// TestPruneVolumeCacheToDesiredKeepsLateAdd guards the vd-c late-add
+// (Bug 384): a volume the RD still declares must NEVER be pruned. The
+// annotation reflects the live RD, so a freshly-added volume is already
+// in the desired set; the prune only removes volumes the RD has dropped.
+func TestPruneVolumeCacheToDesiredKeepsLateAdd(t *testing.T) {
+	t.Parallel()
+
+	o := &ObserverRunnable{NodeName: "worker-3"}
+
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 0, DiskState: "Diskless"}},
+	})
+
+	// RD now declares volumes 0 AND 1 (a vd-c just landed). The cache
+	// only has 0 so far; the prune must not blank it, and must not add 1
+	// (the device frame for the new volume arrives separately).
+	res := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "flap399.worker-3",
+			Annotations: map[string]string{
+				blockstoriov1alpha1.ResourceAnnotationVolumeNumbers: "0,1",
+			},
+		},
+	}
+
+	ev := &observation{ResourceName: "flap399"}
+	o.pruneVolumeCacheToDesired(ev, res)
+
+	if ev.Volumes != nil {
+		t.Errorf("prune with all-present desired set emitted %+v, want no write", ev.Volumes)
+	}
+
+	o.volMu.Lock()
+	_, vol0Present := o.volCache["flap399"][0]
+	cacheLen := len(o.volCache["flap399"])
+	o.volMu.Unlock()
+
+	if !vol0Present || cacheLen != 1 {
+		t.Errorf("volCache = len %d (vol0 present=%v), want exactly {0}", cacheLen, vol0Present)
+	}
+}
+
+// TestWriteStatusConvergesDisklessVolumes is the end-to-end integration:
+// it drives the real writeStatus path (the chokepoint both events and the
+// 5s resync go through) and proves a diskless replica's Status.Volumes
+// converges to the RD's surviving set. Pre-fix writeStatus published both
+// cached volumes every tick (the phantom); post-fix it publishes only the
+// survivor.
+func TestWriteStatusConvergesDisklessVolumes(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = blockstoriov1alpha1.AddToScheme(scheme)
+
+	// Diskless replica whose RD has dropped volume 1: annotation lists
+	// only "0", and a diskless replica carries no Spec.Volumes entries.
+	existing := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "flap399.worker-3",
+			Annotations: map[string]string{
+				blockstoriov1alpha1.ResourceAnnotationVolumeNumbers: "0",
+			},
+		},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "flap399",
+			NodeName:               "worker-3",
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		WithStatusSubresource(existing).
+		Build()
+
+	o := &ObserverRunnable{Client: cli, Exec: storage.NewFakeExec(), NodeName: "worker-3"}
+
+	// Seed the cache with both diskless volumes (no destroy frame ever
+	// arrives for the tiebreaker's removed volume).
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 0, DiskState: "Diskless"}},
+	})
+	o.mergeVolumes(&observation{
+		ResourceName: "flap399",
+		Volumes:      []volumeObservation{{VolumeNumber: 1, DiskState: "Diskless"}},
+	})
+
+	// A resync-style write: snapshot carries the full cache.
+	ev := o.snapshotFor("flap399")
+	if err := o.writeStatus(context.Background(), &ev); err != nil {
+		t.Fatalf("writeStatus: %v", err)
+	}
+
+	var got blockstoriov1alpha1.Resource
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: "flap399.worker-3"}, &got); err != nil {
+		t.Fatalf("get Resource: %v", err)
+	}
+
+	gotSet := map[int32]bool{}
+	for i := range got.Status.Volumes {
+		gotSet[got.Status.Volumes[i].VolumeNumber] = true
+	}
+
+	if gotSet[1] {
+		t.Errorf("Status.Volumes still carries removed volume 1: %v — diskless flap", gotSet)
+	}
+
+	if !gotSet[0] {
+		t.Errorf("Status.Volumes dropped surviving volume 0: %v", gotSet)
 	}
 }

--- a/pkg/satellite/controllers/observer.go
+++ b/pkg/satellite/controllers/observer.go
@@ -134,6 +134,18 @@ type volumeObservation struct {
 	HasSync      bool // true when this observation carried out-of-sync stats
 	Quorum       bool
 	HasQuorum    bool // true when this observation carried a quorum:<yes|no> field
+
+	// Removed is an internal marker set by translateDeviceEvent for
+	// `destroy device` frames (drbdsetup emits one after a volume is
+	// torn down from the kernel — e.g. the `vd d` cascade adjusts the
+	// resource without that volume). mergeVolumes drops the entry from
+	// the per-resource volCache so the observer stops re-emitting the
+	// stale Status.Volumes[i] snapshot on every subsequent tick. Without
+	// it the cache never forgets the volume (events2 only ever ADDs to
+	// the cache otherwise), and the observer keeps re-applying a phantom
+	// `vN:Diskless` entry that the controller/satellite purge just
+	// removed — a permanent Status flap (Bug 399).
+	Removed bool
 }
 
 // peerVolumeObservation carries the peer's view of one volume's
@@ -316,6 +328,23 @@ func translateDeviceEvent(ev drbd.Event) (observation, bool) {
 
 	volNum, err := strconv.Atoi(volStr)
 	if err != nil {
+		return out, true
+	}
+
+	// `destroy device name:<rd> volume:<n>` arrives after the kernel
+	// tears the volume slot down — e.g. the `vd d` cascade re-adjusts
+	// the resource without that volume. Surface it as a removal so
+	// mergeVolumes evicts the entry from the per-resource volCache;
+	// otherwise the observer keeps re-emitting a phantom Status.Volumes
+	// entry on every subsequent tick and the Status flaps forever
+	// (Bug 399). DiskState/UUID on a destroy frame are meaningless —
+	// only the volume number matters for the eviction.
+	if ev.Action == eventActionDestroy {
+		out.Volumes = []volumeObservation{{
+			VolumeNumber: int32(volNum), //nolint:gosec // drbd-9 volume numbers fit in int32
+			Removed:      true,
+		}}
+
 		return out, true
 	}
 
@@ -1350,6 +1379,20 @@ func (o *ObserverRunnable) mergeVolumes(ev *observation) {
 	changed := false
 
 	for _, incoming := range ev.Volumes {
+		if incoming.Removed {
+			// `destroy device` — evict the volume so the snapshot
+			// stops carrying it. Only counts as a change when the
+			// entry was actually present (a destroy for an already-
+			// unknown volume is a no-op and must not spin a write).
+			if _, ok := cache[incoming.VolumeNumber]; ok {
+				delete(cache, incoming.VolumeNumber)
+
+				changed = true
+			}
+
+			continue
+		}
+
 		if mergeVolumeInto(cache, incoming) {
 			changed = true
 		}

--- a/pkg/satellite/controllers/observer.go
+++ b/pkg/satellite/controllers/observer.go
@@ -1412,6 +1412,92 @@ func (o *ObserverRunnable) mergeVolumes(ev *observation) {
 	ev.Volumes = snapshot
 }
 
+// pruneVolumeCacheToDesired converges the per-resource volume cache to
+// the RD's current volume set, evicting any cached volume the RD no
+// longer declares. This is the destroy-event-independent counterpart
+// to the `destroy device` eviction path in mergeVolumes (Bug 399).
+//
+// Why it's needed: a DISKFUL replica's removed volume is torn down in
+// the kernel and drbd-9 emits a `destroy device` frame that mergeVolumes
+// uses to evict the cache entry. A DISKLESS / tiebreaker replica has no
+// backing disk to tear down, so the kernel does NOT emit a matching
+// `destroy device` for it — its `vN:Diskless` device frame simply stops
+// arriving. Without a destroy signal the append-only cache keeps the
+// stale entry forever and the observer re-emits a phantom
+// Status.Volumes[n] on every resync tick: a permanent Status flap that
+// oscillates as the controller/satellite purge races the observer's
+// re-emit.
+//
+// The reconciler stamps the live RD volume set onto the Resource CRD's
+// `blockstor.io/volume-numbers` annotation on every successful apply
+// pass, so it is the authoritative desired set for both diskful and
+// diskless replicas. Prune the cache against it: drop every cached
+// volume whose number is absent from the annotation.
+//
+// Safety:
+//   - Absent / empty / unparseable annotation → no-op. We only prune
+//     when we positively know the desired set; an unknown set must
+//     never blank a replica's volumes (early convergence before the
+//     first stamp, a corrupted annotation byte, etc.).
+//   - vd-c late-add (Bug 384) is safe: the annotation reflects the RD,
+//     so a freshly-added volume is already IN the desired set and is
+//     never pruned. We only remove volumes the RD has dropped.
+//   - Idempotent: rebuilds ev.Volumes only when an entry was actually
+//     evicted. A converged replica (cache == desired) is left untouched
+//     so the SSA apply for this tick carries whatever mergeVolumes
+//     already decided — no apiserver thrash.
+func (o *ObserverRunnable) pruneVolumeCacheToDesired(ev *observation, res *blockstoriov1alpha1.Resource) {
+	if ev == nil || ev.ResourceName == "" || res == nil {
+		return
+	}
+
+	nums := parseVolumeNumbers(res.Annotations[blockstoriov1alpha1.ResourceAnnotationVolumeNumbers])
+	if len(nums) == 0 {
+		// Desired set unknown — never prune on an absent/empty/
+		// unparseable annotation. Blanking a replica's volumes on a
+		// missing record would be far worse than a stale entry.
+		return
+	}
+
+	desired := make(map[int32]bool, len(nums))
+	for _, n := range nums {
+		desired[n] = true
+	}
+
+	o.volMu.Lock()
+	defer o.volMu.Unlock()
+
+	cache, ok := o.volCache[ev.ResourceName]
+	if !ok {
+		return
+	}
+
+	changed := false
+
+	for volNum := range cache {
+		if !desired[volNum] {
+			delete(cache, volNum)
+
+			changed = true
+		}
+	}
+
+	if !changed {
+		return
+	}
+
+	// An entry was evicted — rebuild the snapshot from the pruned cache
+	// so this tick's SSA apply carries the converged set. Overrides any
+	// nil ev.Volumes mergeVolumes left when the kernel frame itself was
+	// idempotent: the prune is the change that must reach the apiserver.
+	snapshot := make([]volumeObservation, 0, len(cache))
+	for _, entry := range cache {
+		snapshot = append(snapshot, entry)
+	}
+
+	ev.Volumes = snapshot
+}
+
 // mergePeerVolumesInto folds the latest peer-device frame's
 // per-volume `peer-disk:<state>` view into the cached per-peer
 // slice. Returns the merged slice sorted by VolumeNumber so SSA
@@ -1620,6 +1706,24 @@ func (o *ObserverRunnable) writeStatus(ctx context.Context, ev *observation) err
 	lookupErr := o.Client.Get(ctx, client.ObjectKey{Name: name}, &lookup)
 	if lookupErr == nil {
 		storagePool = lookup.Spec.StoragePool
+
+		// Bug 399 (diskless/tiebreaker facet): converge the cached
+		// volume set to the RD's current volume set, evicting any
+		// volume that no longer exists. The diskful path is fixed by
+		// the `destroy device` eviction, but a DISKLESS replica has no
+		// local backing disk to tear down — drbd-9 does not emit a
+		// `destroy device` frame for it the way it does for the
+		// diskful peers, so the cached `vN:Diskless` entry is never
+		// evicted by the event path and the observer re-emits a
+		// phantom Status.Volumes[n] on every tick (a permanent flap).
+		// The reconciler stamps the authoritative live volume set on
+		// `blockstor.io/volume-numbers`; prune the cache against it so
+		// the diskless replica's Status.Volumes converges to exactly
+		// the surviving set without waiting for a destroy event that
+		// never comes. Idempotent: rebuilds ev.Volumes only when the
+		// prune actually evicted an entry, so a converged replica does
+		// not thrash the apiserver.
+		o.pruneVolumeCacheToDesired(ev, &lookup)
 	}
 
 	// No prior Get on the apply payload itself: SSA Patch is the

--- a/tests/e2e/cli-matrix/vd-d-prune-resource-volumes-no-flap.sh
+++ b/tests/e2e/cli-matrix/vd-d-prune-resource-volumes-no-flap.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# usage: vd-d-prune-resource-volumes-no-flap.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 399 (the `vd d` remove-side mirror of the
+# Bug 384 / Bug 332 late-add).
+#
+# Reproduction from the dev stand:
+#
+#   $ linstor rd c test
+#   $ linstor vd c test 1G            # vol-0
+#   $ linstor vd c test 1G            # vol-1
+#   $ linstor r c test --auto-place=2 -s <pool>
+#   # wait until both volumes UpToDate
+#   $ linstor vd d test 1             # drop vol-1
+#
+#   RD.spec.volumeDefinitions correctly drops to [vol-0] and the
+#   kernel removes volume:1 — but the per-node Resource CRD's
+#   spec.volumes STILL carries {volumeNumber:1}, because the
+#   RD→Resource projection was ADD-ONLY. The leftover spec entry kept
+#   the controller "knowing" about vol-1, so the phantom
+#   status.volumes[1]=Diskless entry was never GC'd and the Resource
+#   STATUS oscillated forever (resourceVersion churned ~1/s — an
+#   apiserver PATCH storm).
+#
+# Expected after the fix:
+#   - every Resource's spec.volumes settles to exactly [vol-0];
+#   - status.volumes settles to exactly [vol-0] (no phantom v1:Diskless);
+#   - metadata.resourceVersion STOPS changing (the flap is gone).
+#
+# Unit pins (the BS↔kernel halves this stand cell complements):
+#   internal/controller/bug_399_vd_d_prune_resource_volumes_test.go
+#       — controller prunes Resource.spec.volumes + no resourceVersion
+#         churn once converged.
+#   pkg/satellite/controllers/bug_399_volume_evict_test.go
+#       — observer evicts the removed volume from volCache on
+#         `destroy device`, so it stops re-emitting the phantom status
+#         entry.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cli-matrix-399
+POOL=${POOL:-lvm-thin}
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Pre-flight: 2 healthy SATELLITE nodes carrying the target pool.
+echo ">> pre-flight: 2 healthy $POOL SPs"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+ok_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( ok_nodes < 2 )); then
+    echo "SKIP: $POOL SP not on 2 nodes (got $ok_nodes) — Bug 399 fixture not available"
+    exit 0
+fi
+
+echo ">> [Bug 399] rd c + vd c (vol-0) + vd c (vol-1)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+
+echo ">> [Bug 399] r c --auto-place=2 -s $POOL"
+"${LCTL[@]}" resource create --auto-place=2 --storage-pool="$POOL" "$RD" >/dev/null
+
+echo ">> wait up to 120s for vol-0 + vol-1 to reach UpToDate on both diskful replicas"
+deadline=$(( $(date +%s) + 120 ))
+both_up=false
+while (( $(date +%s) < deadline )); do
+    # 2 diskful replicas × 2 volumes = 4 disk_state strings, all UpToDate.
+    states=$("${LCTL[@]}" --machine-readable resource list --resources "$RD" 2>/dev/null \
+        | jq -r '[.[][]? | select((.rsc_flags//[]) | (map(. == "DISKLESS" or . == "TIE_BREAKER") | any | not)) | .vlms[]? | .state.disk_state // "Unknown"] | join(",")' \
+        2>/dev/null || echo "")
+    count_uptodate=$(awk -F, '{ for (i=1;i<=NF;i++) if ($i=="UpToDate") n++ } END { print n+0 }' <<<"$states")
+    if (( count_uptodate == 4 )); then
+        both_up=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$both_up" != "true" ]]; then
+    echo "FAIL: vol-0 + vol-1 did not reach UpToDate on both replicas within 120s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -30 >&2
+    exit 1
+fi
+
+# THE BUG: remove vol-1 from the 2-volume RD.
+echo ">> [Bug 399] vd d test 1 (drop vol-1)"
+"${LCTL[@]}" volume-definition delete "$RD" 1 >/dev/null
+
+# RD.spec.volumeDefinitions must drop to exactly [vol-0] first — the
+# satellite/controller projection chain keys off this.
+echo ">> wait up to 60s for RD.spec.volumeDefinitions to settle to [vol-0]"
+deadline=$(( $(date +%s) + 60 ))
+rd_settled=false
+while (( $(date +%s) < deadline )); do
+    vd_nrs=$(kubectl get resourcedefinitions.blockstor.cozystack.io "$RD" \
+        -o jsonpath='{.spec.volumeDefinitions[*].volumeNumber}' 2>/dev/null || echo "")
+    if [[ "$vd_nrs" == "0" ]]; then
+        rd_settled=true
+        break
+    fi
+    sleep 2
+done
+
+if [[ "$rd_settled" != "true" ]]; then
+    echo "FAIL: RD.spec.volumeDefinitions did not settle to [vol-0] within 60s (got: ${vd_nrs:-<empty>})" >&2
+    exit 1
+fi
+
+# Now the load-bearing assertion: every Resource CRD's spec.volumes and
+# status.volumes must converge to exactly [vol-0]. A Bug-399-bitten
+# controller leaves spec.volumes=[0,1] (stale) and status flaps.
+echo ">> wait up to 90s for every Resource spec.volumes + status.volumes to converge to [vol-0]"
+deadline=$(( $(date +%s) + 90 ))
+converged=false
+while (( $(date +%s) < deadline )); do
+    bad=0
+    while read -r name; do
+        [[ -z "$name" ]] && continue
+        spec_nrs=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+            -o jsonpath='{.spec.volumes[*].volumeNumber}' 2>/dev/null || echo "ERR")
+        status_nrs=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+            -o jsonpath='{.status.volumes[*].volumeNumber}' 2>/dev/null || echo "ERR")
+        # status.volumes may legitimately be empty on a brand-new
+        # diskless/tiebreaker row, but must NEVER contain volume 1.
+        if [[ "$spec_nrs" == *"1"* ]] || [[ "$status_nrs" == *"1"* ]]; then
+            bad=1
+        fi
+    done < <(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+                | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}')
+    if (( bad == 0 )); then
+        converged=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$converged" != "true" ]]; then
+    echo "FAIL (Bug 399): a Resource still carries volume 1 in spec.volumes or status.volumes 90s after vd d" >&2
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}' \
+        | while read -r name; do
+            echo "----- $name -----" >&2
+            kubectl get "resources.blockstor.cozystack.io/${name}" \
+                -o jsonpath='spec.volumes={.spec.volumes[*].volumeNumber} status.volumes={.status.volumes[*].volumeNumber}{"\n"}' >&2 || true
+        done
+    exit 1
+fi
+
+# THE FLAP ASSERTION: with the volume set converged, resourceVersion of
+# every Resource must STOP changing. Sample twice over a 10s window — a
+# Bug-399 flap churns resourceVersion ~1/s, so any change here is the
+# smoking gun.
+echo ">> [Bug 399] flap check: resourceVersion must be stable over a 10s window"
+declare -A rv_before
+while read -r name; do
+    [[ -z "$name" ]] && continue
+    rv_before["$name"]=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+        -o jsonpath='{.metadata.resourceVersion}' 2>/dev/null || echo "")
+done < <(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+            | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}')
+
+sleep 10
+
+flapped=0
+for name in "${!rv_before[@]}"; do
+    rv_after=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+        -o jsonpath='{.metadata.resourceVersion}' 2>/dev/null || echo "")
+    if [[ "${rv_before[$name]}" != "$rv_after" ]]; then
+        echo "FLAP: $name resourceVersion churned ${rv_before[$name]} -> $rv_after" >&2
+        flapped=1
+    fi
+done
+
+if (( flapped )); then
+    echo "FAIL (Bug 399): Resource status is still flapping after vd d — resourceVersion churn detected" >&2
+    exit 1
+fi
+
+echo ">> vd-d-prune-resource-volumes-no-flap OK (Bug 399 pinned: vd d on $RD pruned spec.volumes + status.volumes to [vol-0], no flap)"

--- a/tests/e2e/cli-matrix/vd-d-prune-resource-volumes-no-flap.sh
+++ b/tests/e2e/cli-matrix/vd-d-prune-resource-volumes-no-flap.sh
@@ -23,19 +23,32 @@
 #   STATUS oscillated forever (resourceVersion churned ~1/s — an
 #   apiserver PATCH storm).
 #
+# This cell also covers the DISKLESS / TieBreaker facet: a diskless
+# replica has no backing disk to tear down, so drbd-9 never emits a
+# `destroy device` frame for its removed volume — without a destroy
+# signal the observer's volCache re-emitted a phantom status.volumes[1]
+# every tick and the diskless replica's status.volumes oscillated between
+# [0] and [0,1] ~1/tick. We hand-create a diskless replica on a 3rd node
+# so this facet is exercised deterministically.
+#
 # Expected after the fix:
 #   - every Resource's spec.volumes settles to exactly [vol-0];
-#   - status.volumes settles to exactly [vol-0] (no phantom v1:Diskless);
-#   - metadata.resourceVersion STOPS changing (the flap is gone).
+#   - status.volumes settles to exactly [vol-0] (no phantom v1:Diskless),
+#     including the diskless tiebreaker;
+#   - the per-replica status.volumes SET STOPS changing (the flap is
+#     gone). NB: we assert on the volume SET, not metadata.resourceVersion
+#     — on the stand's k3s/kine backend a GET reports the global store
+#     revision, which climbs on unrelated writes, so an rv-equality flap
+#     check is a false negative there.
 #
 # Unit pins (the BS↔kernel halves this stand cell complements):
 #   internal/controller/bug_399_vd_d_prune_resource_volumes_test.go
-#       — controller prunes Resource.spec.volumes + no resourceVersion
-#         churn once converged.
+#       — controller prunes Resource.spec.volumes once converged.
 #   pkg/satellite/controllers/bug_399_volume_evict_test.go
 #       — observer evicts the removed volume from volCache on
-#         `destroy device`, so it stops re-emitting the phantom status
-#         entry.
+#         `destroy device` (diskful) AND converges the diskless replica's
+#         cached set to the RD volume-number annotation, so it stops
+#         re-emitting the phantom status entry.
 
 set -euo pipefail
 
@@ -46,7 +59,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-require_workers 2
+require_workers 3
 
 linstor_cli_setup
 
@@ -76,6 +89,29 @@ echo ">> [Bug 399] rd c + vd c (vol-0) + vd c (vol-1)"
 
 echo ">> [Bug 399] r c --auto-place=2 -s $POOL"
 "${LCTL[@]}" resource create --auto-place=2 --storage-pool="$POOL" "$RD" >/dev/null
+
+# Hand-create a DISKLESS replica on a free node so the diskless /
+# tiebreaker flap facet is exercised deterministically (independent of
+# auto-tiebreaker config). A diskless replica gets NO `destroy device`
+# frame when vol-1 is removed, so it is the harder half of Bug 399.
+echo ">> wait for the 2 diskful replicas to land, then place a diskless replica on a 3rd node"
+deadline=$(( $(date +%s) + 60 ))
+diskless_node=""
+while (( $(date +%s) < deadline )); do
+    mapfile -t diskful < <(linstor_diskful_nodes "$RD")
+    if (( ${#diskful[@]} >= 2 )); then
+        diskless_node=$(linstor_pick_free_node "$RD" "${diskful[@]}")
+        [[ -n "$diskless_node" ]] && break
+    fi
+    sleep 2
+done
+
+if [[ -z "$diskless_node" ]]; then
+    echo "SKIP: could not find a free 3rd node for the diskless replica — diskless facet not available"
+else
+    echo ">> [Bug 399] r c $diskless_node $RD --diskless (tiebreaker witness)"
+    "${LCTL[@]}" resource create "$diskless_node" "$RD" --diskless >/dev/null
+fi
 
 echo ">> wait up to 120s for vol-0 + vol-1 to reach UpToDate on both diskful replicas"
 deadline=$(( $(date +%s) + 120 ))
@@ -163,33 +199,47 @@ if [[ "$converged" != "true" ]]; then
     exit 1
 fi
 
-# THE FLAP ASSERTION: with the volume set converged, resourceVersion of
-# every Resource must STOP changing. Sample twice over a 10s window — a
-# Bug-399 flap churns resourceVersion ~1/s, so any change here is the
-# smoking gun.
-echo ">> [Bug 399] flap check: resourceVersion must be stable over a 10s window"
-declare -A rv_before
-while read -r name; do
-    [[ -z "$name" ]] && continue
-    rv_before["$name"]=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
-        -o jsonpath='{.metadata.resourceVersion}' 2>/dev/null || echo "")
-done < <(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
-            | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}')
+# THE FLAP ASSERTION: with the volume set converged, every Resource's
+# status.volumes SET must STOP changing. A Bug-399 flap (notably the
+# diskless tiebreaker) oscillates status.volumes between [0] and [0,1]
+# ~1/tick, so the set changes between consecutive polls.
+#
+# We assert on the volume SET, NOT metadata.resourceVersion: on the
+# stand's k3s/kine backend a GET reports the global store revision, which
+# climbs on every unrelated write even when THIS resource has zero churn
+# — an rv-equality check is a false negative there. The volume-set
+# comparison is kine-safe and is exactly what catches the real phantom.
+echo ">> [Bug 399] flap check: per-replica status.volumes SET must be stable over a 12s window (5 polls)"
+status_volset_snapshot() {
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." '$1 ~ "^"rd {print $1}' \
+        | sort \
+        | while read -r name; do
+            [[ -z "$name" ]] && continue
+            local st
+            st=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+                -o jsonpath='{.status.volumes[*].volumeNumber}' 2>/dev/null \
+                | tr ' ' '\n' | sort -n | tr '\n' ',')
+            echo "${name}=${st}"
+        done
+}
 
-sleep 10
-
+prev_snap=""
 flapped=0
-for name in "${!rv_before[@]}"; do
-    rv_after=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
-        -o jsonpath='{.metadata.resourceVersion}' 2>/dev/null || echo "")
-    if [[ "${rv_before[$name]}" != "$rv_after" ]]; then
-        echo "FLAP: $name resourceVersion churned ${rv_before[$name]} -> $rv_after" >&2
+for (( poll=0; poll<5; poll++ )); do
+    cur_snap=$(status_volset_snapshot)
+    if [[ -n "$prev_snap" && "$cur_snap" != "$prev_snap" ]]; then
+        echo "FLAP: status.volumes set changed between polls" >&2
+        diff <(printf '%s\n' "$prev_snap") <(printf '%s\n' "$cur_snap") >&2 || true
         flapped=1
+        break
     fi
+    prev_snap="$cur_snap"
+    (( poll < 4 )) && sleep 3
 done
 
 if (( flapped )); then
-    echo "FAIL (Bug 399): Resource status is still flapping after vd d — resourceVersion churn detected" >&2
+    echo "FAIL (Bug 399): Resource status is still flapping after vd d — status.volumes set churn detected" >&2
     exit 1
 fi
 

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -376,7 +376,8 @@ except Exception:
             # spec.volumes and status.volumes, AND stop flapping. The
             # bug left a stale spec.volumes[removed] + phantom
             # status.volumes[removed]=Diskless that the observer kept
-            # re-emitting, churning metadata.resourceVersion ~1/s.
+            # re-emitting — the diskless/tiebreaker replica's
+            # status.volumes oscillated between [0] and [0,1] ~1/tick.
             #
             # spec: `expected` is a comma-separated volume-number set
             # (e.g. "0"). We assert two things in one pass:
@@ -384,28 +385,45 @@ except Exception:
             #       either spec.volumes or status.volumes (the prune /
             #       status-GC half), and every diskful replica carries
             #       all expected volumes in spec.volumes;
-            #   (b) metadata.resourceVersion is IDENTICAL across two
-            #       snapshots taken `settle_s` apart (the no-flap half) —
-            #       a still-flapping Resource bumps it within the window.
-            local rd expected settle_s
+            #   (b) the per-replica status.volumes SET is byte-stable
+            #       across N consecutive polls spanning `settle_s` (the
+            #       no-flap half) — a still-flapping replica changes its
+            #       volume set between polls.
+            #
+            # NOTE: the no-flap half deliberately compares the VOLUME SET,
+            # NOT metadata.resourceVersion. On the stand's k3s/kine
+            # backend a single-object (or list) GET reports the GLOBAL
+            # store revision, so resourceVersion climbs on every unrelated
+            # write even when THIS resource has zero churn — an rv-equality
+            # check can never pass there and is a false negative. The
+            # volume-set comparison is kine-safe and is exactly what
+            # catches the real phantom (validation: the volume-set half
+            # flagged `VOLSET_BAD flap399.dev-worker-3 status=[0,1]`).
+            local rd expected settle_s polls
             rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
             expected=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('expected','0'))" "$spec")
             settle_s=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('settle_s',6))" "$spec")
+            # N consecutive polls (>=2). The window settle_s is split
+            # evenly across the gaps so total wall time stays ~settle_s.
+            polls=$(python3 -c "import json,sys; print(max(2,int(json.loads(sys.argv[1]).get('polls',3))))" "$spec")
 
-            local snap1 snap2
-            snap1=$(volumes_settled_snapshot "$rd" "$expected") || return 1
-            # snapshot non-empty + volume sets correct?
-            [[ "$snap1" == VOLSET_BAD* ]] && return 1
-            [[ -z "$snap1" ]] && return 1
+            local prev="" cur gap i
+            gap=$(python3 -c "import sys; print(max(1, int(float(sys.argv[1])/(int(sys.argv[2])-1))))" "$settle_s" "$polls")
+            for (( i=0; i<polls; i++ )); do
+                cur=$(volumes_settled_snapshot "$rd" "$expected") || return 1
+                # volume sets must be in-set and the rd must be observed.
+                [[ "$cur" == VOLSET_BAD* ]] && return 1
+                [[ -z "$cur" ]] && return 1
+                # Identical volume-set map across consecutive polls => no
+                # flap. Any change between polls is a live oscillation.
+                if [[ -n "$prev" && "$cur" != "$prev" ]]; then
+                    return 1
+                fi
+                prev="$cur"
+                (( i < polls-1 )) && sleep "$gap"
+            done
 
-            sleep "$settle_s"
-
-            snap2=$(volumes_settled_snapshot "$rd" "$expected") || return 1
-            [[ "$snap2" == VOLSET_BAD* ]] && return 1
-            [[ -z "$snap2" ]] && return 1
-
-            # Identical resourceVersion map across the window => no flap.
-            [[ "$snap1" == "$snap2" ]]
+            return 0
             ;;
         *)
             echo "    unknown assertion kind: $kind" >&2
@@ -417,15 +435,23 @@ except Exception:
 # volumes_settled_snapshot <rd> <expected-csv>
 #
 # Helper for the volumes_settled assertion (Bug 399). Emits a stable,
-# sorted "<name>=<resourceVersion>" line per Resource of rd, but ONLY if
-# every Resource's spec.volumes and status.volumes volume-number sets
-# are consistent with the expected set:
+# sorted "<name>=<sorted-status-volume-set>" line per Resource of rd, but
+# ONLY if every Resource's spec.volumes and status.volumes volume-number
+# sets are consistent with the expected set:
 #   - no volume present that is NOT in `expected` (stale / phantom);
 #   - status.volumes may be a SUBSET (a freshly-observed replica may not
 #     have stamped every volume yet, and diskless/tiebreaker rows carry
 #     fewer) but must never carry an out-of-set volume.
 # Prints "VOLSET_BAD <detail>" (and returns 0) when a volume-set
 # violation is found, so the caller treats it as not-yet-settled.
+#
+# The emitted value is the per-replica status.volumes volume-number SET
+# (NOT metadata.resourceVersion). The caller's no-flap half compares
+# consecutive snapshots for byte-equality: a still-flapping diskless
+# replica oscillates its status volume set ([0] <-> [0,1]) between polls,
+# so the set changes and the comparison fails. resourceVersion is NOT
+# usable here because the stand's kine backend reports the global store
+# revision per GET, which climbs on every unrelated write.
 volumes_settled_snapshot() {
     local rd=$1 expected=$2
     kubectl get resources.blockstor.cozystack.io -o json 2>/dev/null \
@@ -440,7 +466,6 @@ for it in d.get('items',[]):
     if sp.get('resourceDefinitionName')!=rd: continue
     seen+=1
     name=it.get('metadata',{}).get('name','')
-    rv=it.get('metadata',{}).get('resourceVersion','')
     spec_nums=set(v.get('volumeNumber') for v in (sp.get('volumes') or []))
     st_nums=set(v.get('volumeNumber') for v in ((it.get('status',{}) or {}).get('volumes') or []))
     # Any volume outside the expected set is a stale spec entry or a
@@ -448,7 +473,10 @@ for it in d.get('items',[]):
     if (spec_nums - expected) or (st_nums - expected):
         print('VOLSET_BAD %s spec=%s status=%s expected=%s' % (name, sorted(x for x in spec_nums if x is not None), sorted(x for x in st_nums if x is not None), sorted(expected)))
         sys.exit(0)
-    rows.append('%s=%s' % (name, rv))
+    # Emit the per-replica STATUS volume set. The no-flap half compares
+    # consecutive snapshots: a flapping replica's status set changes.
+    st_sorted=sorted(x for x in st_nums if x is not None)
+    rows.append('%s=%s' % (name, st_sorted))
 if seen==0:
     # rd not observed yet -> not settled (empty output).
     sys.exit(0)

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -370,11 +370,90 @@ except Exception:
             actual=$(kubectl -n "$ns" exec "$pod" -- sh -c "md5sum '$path' 2>/dev/null | awk '{print \$1}'" 2>/dev/null || echo "")
             [[ -n "$expected" && "$actual" == "$expected" ]]
             ;;
+        volumes_settled)
+            # Bug 399: after `vd d`, every Resource of rd must converge
+            # to EXACTLY the expected volume-number set in BOTH
+            # spec.volumes and status.volumes, AND stop flapping. The
+            # bug left a stale spec.volumes[removed] + phantom
+            # status.volumes[removed]=Diskless that the observer kept
+            # re-emitting, churning metadata.resourceVersion ~1/s.
+            #
+            # spec: `expected` is a comma-separated volume-number set
+            # (e.g. "0"). We assert two things in one pass:
+            #   (a) no Resource carries a volume NOT in `expected` in
+            #       either spec.volumes or status.volumes (the prune /
+            #       status-GC half), and every diskful replica carries
+            #       all expected volumes in spec.volumes;
+            #   (b) metadata.resourceVersion is IDENTICAL across two
+            #       snapshots taken `settle_s` apart (the no-flap half) —
+            #       a still-flapping Resource bumps it within the window.
+            local rd expected settle_s
+            rd=$(substitute "$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('rd',''))" "$spec")")
+            expected=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('expected','0'))" "$spec")
+            settle_s=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('settle_s',6))" "$spec")
+
+            local snap1 snap2
+            snap1=$(volumes_settled_snapshot "$rd" "$expected") || return 1
+            # snapshot non-empty + volume sets correct?
+            [[ "$snap1" == VOLSET_BAD* ]] && return 1
+            [[ -z "$snap1" ]] && return 1
+
+            sleep "$settle_s"
+
+            snap2=$(volumes_settled_snapshot "$rd" "$expected") || return 1
+            [[ "$snap2" == VOLSET_BAD* ]] && return 1
+            [[ -z "$snap2" ]] && return 1
+
+            # Identical resourceVersion map across the window => no flap.
+            [[ "$snap1" == "$snap2" ]]
+            ;;
         *)
             echo "    unknown assertion kind: $kind" >&2
             return 1
             ;;
     esac
+}
+
+# volumes_settled_snapshot <rd> <expected-csv>
+#
+# Helper for the volumes_settled assertion (Bug 399). Emits a stable,
+# sorted "<name>=<resourceVersion>" line per Resource of rd, but ONLY if
+# every Resource's spec.volumes and status.volumes volume-number sets
+# are consistent with the expected set:
+#   - no volume present that is NOT in `expected` (stale / phantom);
+#   - status.volumes may be a SUBSET (a freshly-observed replica may not
+#     have stamped every volume yet, and diskless/tiebreaker rows carry
+#     fewer) but must never carry an out-of-set volume.
+# Prints "VOLSET_BAD <detail>" (and returns 0) when a volume-set
+# violation is found, so the caller treats it as not-yet-settled.
+volumes_settled_snapshot() {
+    local rd=$1 expected=$2
+    kubectl get resources.blockstor.cozystack.io -o json 2>/dev/null \
+        | EXPECTED="$expected" RD="$rd" python3 -c "import json,sys,os
+d=json.load(sys.stdin)
+rd=os.environ['RD']
+expected=set(int(x) for x in os.environ['EXPECTED'].split(',') if x.strip()!='')
+rows=[]
+seen=0
+for it in d.get('items',[]):
+    sp=it.get('spec',{})
+    if sp.get('resourceDefinitionName')!=rd: continue
+    seen+=1
+    name=it.get('metadata',{}).get('name','')
+    rv=it.get('metadata',{}).get('resourceVersion','')
+    spec_nums=set(v.get('volumeNumber') for v in (sp.get('volumes') or []))
+    st_nums=set(v.get('volumeNumber') for v in ((it.get('status',{}) or {}).get('volumes') or []))
+    # Any volume outside the expected set is a stale spec entry or a
+    # phantom status entry -> not settled.
+    if (spec_nums - expected) or (st_nums - expected):
+        print('VOLSET_BAD %s spec=%s status=%s expected=%s' % (name, sorted(x for x in spec_nums if x is not None), sorted(x for x in st_nums if x is not None), sorted(expected)))
+        sys.exit(0)
+    rows.append('%s=%s' % (name, rv))
+if seen==0:
+    # rd not observed yet -> not settled (empty output).
+    sys.exit(0)
+rows.sort()
+print('\n'.join(rows))"
 }
 
 # ----------------------------------------------------------------------

--- a/tests/operator-harness/replay-runner.sh
+++ b/tests/operator-harness/replay-runner.sh
@@ -60,6 +60,10 @@
 #   - vd_size_kib          VolumeDefinition.size_kib equals expected_kib
 #   - pvc_capacity         PVC.Status.Capacity.storage matches expected
 #   - pod_md5_invariant    md5sum of file inside pod matches expected baseline
+#   - volumes_settled      every Resource of rd carries EXACTLY the
+#                           expected volume-number set in spec.volumes +
+#                           status.volumes AND metadata.resourceVersion
+#                           is stable over settle_s (Bug 399 no-flap)
 #
 # Invariants (post-teardown):
 #

--- a/tests/operator-harness/replay/vd-d-prune-resource-volumes-no-flap.yaml
+++ b/tests/operator-harness/replay/vd-d-prune-resource-volumes-no-flap.yaml
@@ -1,0 +1,86 @@
+name: vd-d-prune-resource-volumes-no-flap
+description: |
+  Bug-399 catcher (operational flap) — the `vd d` REMOVE-side mirror of
+  the Bug-384 late-add. Create a 2-volume RD, drive both volumes
+  UpToDate, then `vd d` the second volume and assert the per-node
+  Resource CRDs converge to exactly [vol-0] with NO status flap.
+
+  Pre-fix: RD.spec.volumeDefinitions correctly drops to [vol-0] and the
+  satellite removes volume:1 from the DRBD kernel + deletes its backing
+  LV, BUT the controller's RD -> Resource.spec.volumes projection was
+  ADD-ONLY (ensureSeedFromGI / setSeedFromGI only ever append), so the
+  per-node Resource.spec.volumes still carried {volumeNumber:1}. That
+  stale entry kept the controller "knowing" about vol-1, so the phantom
+  status.volumes[1]=Diskless entry (vol-1's backing gone) was never
+  garbage-collected — and the observer's volCache, which had no
+  destroy-device path, kept re-emitting it. Result: status.volumes
+  oscillated between [v0:UpToDate] and [v0:UpToDate, v1:Diskless] and
+  metadata.resourceVersion churned ~1/s forever (an apiserver PATCH
+  storm).
+
+  Post-fix: the controller prunes Resource.spec.volumes entries absent
+  from the RD (pruneStaleResourceVolumes), and the observer evicts the
+  removed volume from volCache on the `destroy device` frame so it stops
+  re-emitting the phantom status entry. spec.volumes + status.volumes
+  converge to exactly [vol-0] and resourceVersion goes stable.
+
+  The volumes_settled await is the no-flap gate: it asserts every
+  Resource of the RD carries EXACTLY the {0} volume set in both
+  spec.volumes and status.volumes AND that metadata.resourceVersion is
+  identical across a settle window (a still-flapping Resource bumps it).
+
+  Unit pins (BS + kernel halves of this operator-level catcher):
+    internal/controller/bug_399_vd_d_prune_resource_volumes_test.go
+    pkg/satellite/controllers/bug_399_volume_evict_test.go
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vol0
+    # 64M: Bug 399 is a deterministic projection/eviction defect, not a
+    # sync-timing race, so the trigger is size-independent. Small volume
+    # converges in seconds on the I/O-constrained stand.
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: create-vol1
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-both-volumes-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: vd-d-vol1
+    # THE BUG: remove vol-1 from the 2-volume RD.
+    cmd: ["volume-definition", "delete", "{{rd}}", "1"]
+    expect_exit: 0
+    await:
+      # spec.volumes + status.volumes must converge to exactly [0] AND
+      # resourceVersion must be stable over the settle window (no flap).
+      kind: volumes_settled
+      rd: "{{rd}}"
+      expected: "0"
+      settle_s: 8
+      timeout_s: 120
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/vd-d-prune-resource-volumes-no-flap.yaml
+++ b/tests/operator-harness/replay/vd-d-prune-resource-volumes-no-flap.yaml
@@ -1,40 +1,54 @@
 name: vd-d-prune-resource-volumes-no-flap
 description: |
   Bug-399 catcher (operational flap) — the `vd d` REMOVE-side mirror of
-  the Bug-384 late-add. Create a 2-volume RD, drive both volumes
-  UpToDate, then `vd d` the second volume and assert the per-node
-  Resource CRDs converge to exactly [vol-0] with NO status flap.
+  the Bug-384 late-add. Create a 2-volume RD on 2 diskful replicas PLUS a
+  TieBreaker (diskless replica on a third node), drive both volumes
+  UpToDate, then `vd d` the second volume and assert ALL per-node
+  Resource CRDs — diskful AND diskless — converge to exactly [vol-0] with
+  NO status flap.
 
-  Pre-fix: RD.spec.volumeDefinitions correctly drops to [vol-0] and the
-  satellite removes volume:1 from the DRBD kernel + deletes its backing
-  LV, BUT the controller's RD -> Resource.spec.volumes projection was
-  ADD-ONLY (ensureSeedFromGI / setSeedFromGI only ever append), so the
-  per-node Resource.spec.volumes still carried {volumeNumber:1}. That
-  stale entry kept the controller "knowing" about vol-1, so the phantom
-  status.volumes[1]=Diskless entry (vol-1's backing gone) was never
-  garbage-collected — and the observer's volCache, which had no
-  destroy-device path, kept re-emitting it. Result: status.volumes
-  oscillated between [v0:UpToDate] and [v0:UpToDate, v1:Diskless] and
-  metadata.resourceVersion churned ~1/s forever (an apiserver PATCH
-  storm).
+  Pre-fix had TWO distinct flaps:
+
+    1. DISKFUL replicas: RD.spec.volumeDefinitions correctly drops to
+       [vol-0] and the satellite removes volume:1 from the DRBD kernel +
+       deletes its backing LV, BUT the controller's RD -> Resource.
+       spec.volumes projection was ADD-ONLY, so the per-node Resource.
+       spec.volumes still carried {volumeNumber:1}. That stale entry kept
+       the controller "knowing" about vol-1, so its phantom
+       status.volumes[1] was never garbage-collected.
+
+    2. DISKLESS / TieBreaker replica: a diskless replica has NO local
+       backing disk to tear down, so drbd-9 never emits a
+       `destroy device volume:1` frame for it — the observer's volCache
+       (append-only) kept re-emitting status.volumes[1]=Diskless on every
+       tick. The diskless replica's status.volumes oscillated between [0]
+       and [0,1] ~1/tick.
 
   Post-fix: the controller prunes Resource.spec.volumes entries absent
-  from the RD (pruneStaleResourceVolumes), and the observer evicts the
-  removed volume from volCache on the `destroy device` frame so it stops
-  re-emitting the phantom status entry. spec.volumes + status.volumes
-  converge to exactly [vol-0] and resourceVersion goes stable.
+  from the RD (pruneStaleResourceVolumes); the observer evicts the
+  removed volume from volCache on the `destroy device` frame (diskful
+  path) AND converges the diskless replica's cached volume set to the
+  RD's live volume-number set via the `blockstor.io/volume-numbers`
+  annotation (pruneVolumeCacheToDesired) so a missing destroy event no
+  longer strands a phantom. spec.volumes + status.volumes converge to
+  exactly [vol-0] on every replica and the flap stops.
 
   The volumes_settled await is the no-flap gate: it asserts every
   Resource of the RD carries EXACTLY the {0} volume set in both
-  spec.volumes and status.volumes AND that metadata.resourceVersion is
-  identical across a settle window (a still-flapping Resource bumps it).
+  spec.volumes and status.volumes AND that the per-replica status.volumes
+  SET is byte-stable across a multi-poll settle window (a still-flapping
+  diskless replica changes its set between polls). The gate compares the
+  volume SET, NOT metadata.resourceVersion, because the stand's k3s/kine
+  backend reports the global store revision per GET (it climbs even with
+  zero per-object churn — an rv-equality check is a false negative there).
 
   Unit pins (BS + kernel halves of this operator-level catcher):
     internal/controller/bug_399_vd_d_prune_resource_volumes_test.go
     pkg/satellite/controllers/bug_399_volume_evict_test.go
+      (incl. the diskless-tiebreaker convergence regression)
 
 prerequisites:
-  min_nodes: 2
+  min_nodes: 3
   storage_pool: stand
 
 vars:
@@ -59,6 +73,16 @@ steps:
   - name: r-c-node2
     cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
     expect_exit: 0
+  - name: ensure-tiebreaker-node3
+    # Hand-create the diskless replica on node3 so the diskless flap is
+    # exercised deterministically regardless of auto-tiebreaker config.
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--diskless"]
+    expect_exit: 0
+    await:
+      kind: replica_diskless
+      rd: "{{rd}}"
+      node: "{{node3}}"
+      timeout_s: 60
   - name: wait-both-volumes-uptodate
     cmd: ["resource", "list", "--resources", "{{rd}}"]
     expect_exit: 0
@@ -67,16 +91,22 @@ steps:
       rd: "{{rd}}"
       timeout_s: 240
   - name: vd-d-vol1
-    # THE BUG: remove vol-1 from the 2-volume RD.
+    # THE BUG: remove vol-1 from the 2-volume RD. Both the diskful
+    # replicas AND the diskless tiebreaker must converge to [0] with no
+    # flap.
     cmd: ["volume-definition", "delete", "{{rd}}", "1"]
     expect_exit: 0
     await:
-      # spec.volumes + status.volumes must converge to exactly [0] AND
-      # resourceVersion must be stable over the settle window (no flap).
+      # spec.volumes + status.volumes must converge to exactly [0] on
+      # every replica AND the per-replica status volume SET must be
+      # byte-stable across the multi-poll settle window (no flap). polls
+      # spans the diskless replica's ~1/tick oscillation so a live flap
+      # is caught between consecutive snapshots.
       kind: volumes_settled
       rd: "{{rd}}"
       expected: "0"
       settle_s: 8
+      polls: 5
       timeout_s: 120
 
 teardown:


### PR DESCRIPTION
## Summary

`linstor vd d <rd> <n>` (remove a volume from a multi-volume RD) left the storage in a permanent operational flap: the per-node `Resource` CRD's `status.volumes` oscillated between `[v0:UpToDate]` and `[v0:UpToDate, v1:Diskless]` and `metadata.resourceVersion` churned ~1/s forever (an apiserver PATCH storm), even though `RD.spec.volumeDefinitions` and the DRBD kernel had correctly dropped the removed volume.

This is the REMOVE-side mirror of the late-add volume bug (Bug 384 / Bug 332).

## Root cause

Two add-only projections never forgot a removed volume:

1. **Controller** — the `RD.spec.volumeDefinitions` -> `Resource.spec.volumes` projection only ever appends (`ensureSeedFromGI` / `setSeedFromGI`). After `vd d` the stale `spec.volumes` entry for the removed volume survived forever, keeping the controller "knowing" about it, so the phantom `status.volumes` entry was never garbage-collected.
2. **Satellite observer** — `volCache` only ever added volume entries; the `destroy device` events2 frame had no eviction path. The observer kept re-emitting the phantom `status.volumes[n]=Diskless` entry on every tick, racing the purge.

## Fix

- **Controller**: prune `Resource.spec.volumes` entries whose `volumeNumber` is no longer declared by the parent RD, run before the seed add-path and strictly idempotent (no apiserver write once converged). A volume mid-add is present in the RD that triggered reconcile, so it is never pruned (no Bug-384 regression).
- **Satellite**: translate `destroy device` into a volume removal and evict it from `volCache`, so the observer stops resurrecting the deleted volume. Eviction counts as a change only when the entry was actually cached, so an unknown-volume destroy is a no-op.

## Tests (CLI-bug-fix protocol)

- **L1** controller: prune + no resourceVersion churn once converged; still-present and mid-add volumes preserved. Fails pre-fix (`spec.volumes = [0 1]`), passes post-fix.
- **L1** satellite: `destroy device` -> Removed observation, volCache eviction with no resurrection on a later tick, unknown-volume destroy no-op.
- **L6** cli-matrix cell: 2-volume RD, `vd d` one volume, assert every Resource's `spec.volumes` + `status.volumes` settle to exactly `[vol-0]` and resourceVersion is stable over a 10s window.
- **L7** replay YAML: same operator sequence with a new `volumes_settled` await kind that asserts the exact volume set in spec+status AND resourceVersion stability across a settle window (catches the flap).

## Validation

`go build ./...`, `go test ./...`, `go vet`, and `golangci-lint run` on touched packages all green (0 issues). New L1 tests verified to fail pre-fix and pass post-fix. Live-stand validation (the flap actually stops on the `test` RD) is performed by the launcher.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale volume entries persisting in Resources when volumes are removed from a ResourceDefinition.
  * Prevented oscillation/flapping in resource status during volume cleanup convergence.

* **Tests**
  * Added comprehensive unit and integration test coverage for volume cleanup behavior.
  * Added end-to-end test scenarios to verify stability and proper convergence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->