### PR TITLE
fix(store): surface DELETING during two-phase RD/resource deletion (corner-cases E1/E3/E4)

### DIFF
--- a/pkg/api/v1/node.go
+++ b/pkg/api/v1/node.go
@@ -195,6 +195,22 @@ const (
 	// delete-then-notify-then-prune handshake without copying GPL
 	// code.
 	ResourceFlagDeleting = "DELETING"
+
+	// ResourceFlagDelete is the upstream-canonical LINSTOR flag token
+	// (`Resource.java::Flags.DELETE` / `ResourceDefinition.java::Flags.
+	// DELETE`) that marks an object in the two-phase delete: the
+	// controller has flagged it for deletion but the satellites have not
+	// yet confirmed the on-node teardown. In blockstor the equivalent
+	// state is "the CRD carries a DeletionTimestamp but its
+	// satellite-resource finalizer is still held" (a downed satellite
+	// can't drain DRBD, so the object lingers). The store projection
+	// surfaces this flag on the wire when DeletionTimestamp is set so
+	// `linstor rd l` / `linstor r l` render the State column as
+	// `DELETING` — matching upstream's CLI display word for the DELETE
+	// flag. Distinct from ResourceFlagDeleting above, which is a
+	// blockstor-internal peer-forget handshake token that never reaches
+	// the wire.
+	ResourceFlagDelete = "DELETE"
 )
 
 // nodeNamespaceUUID is the v5 namespace used to derive stable per-Node

--- a/pkg/rest/resource_definitions_test.go
+++ b/pkg/rest/resource_definitions_test.go
@@ -21,6 +21,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -833,6 +834,87 @@ func TestResourceDefinitionsDeleteAfterSnapshotsCleared(t *testing.T) {
 
 	if _, err := st.ResourceDefinitions().Get(ctx, "pvc-clear"); err == nil {
 		t.Errorf("RD still present after delete")
+	}
+}
+
+// TestResourceDeleteSingleReplicaPreservesSnapshots pins the second
+// half of the E1 corner case: while `rd d` is REFUSED on an RD that
+// still has snapshots, `r d` of a SINGLE replica is NOT — it only
+// drops that one per-node Resource and leaves the parent RD, the
+// surviving replicas, AND every Snapshot row intact. Upstream LINSTOR
+// scopes the snapshot guard to resource-DEFINITION delete only
+// (CtrlRscDfnDeleteApiCallHandler.ensureNoSnapDfns); a per-replica
+// `linstor resource delete <node> <rd>` never touches the
+// snapshot-definition set (UG9 ~1364-1366, ~1395). Without this pin a
+// future refactor that wired the snapshot guard onto the per-replica
+// delete handler would silently break the documented "snapshots
+// survive a replica delete" contract.
+func TestResourceDeleteSingleReplicaPreservesSnapshots(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const rd = "pvc-rd-snap-survive"
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rd}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	for _, n := range []string{"n1", "n2", "n3"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: rd, NodeName: n}); err != nil {
+			t.Fatalf("seed replica %s: %v", n, err)
+		}
+	}
+
+	for _, snapName := range []string{"snap-a", "snap-b"} {
+		if err := st.Snapshots().Create(ctx, &apiv1.Snapshot{
+			Name: snapName, ResourceName: rd,
+		}); err != nil {
+			t.Fatalf("seed snapshot %s: %v", snapName, err)
+		}
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// `r d n2 <rd>` — single replica delete. Must succeed (200) even
+	// though snapshots exist on the parent RD.
+	resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n2")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("r d single replica: got %d, want 200 (snapshot guard must NOT apply to per-replica delete)", resp.StatusCode)
+	}
+
+	// The deleted replica is gone.
+	if _, err := st.Resources().Get(ctx, rd, "n2"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("deleted replica n2 still present: err=%v (want ErrNotFound)", err)
+	}
+
+	// The parent RD survives.
+	if _, err := st.ResourceDefinitions().Get(ctx, rd); err != nil {
+		t.Errorf("parent RD must survive a per-replica delete: %v", err)
+	}
+
+	// Surviving replicas stay put.
+	left, err := st.Resources().ListByDefinition(ctx, rd)
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if len(left) != 2 {
+		t.Errorf("surviving replicas: got %d, want 2", len(left))
+	}
+
+	// Critical contract: both snapshots survive untouched.
+	snaps, err := st.Snapshots().ListByDefinition(ctx, rd)
+	if err != nil {
+		t.Fatalf("list snapshots: %v", err)
+	}
+
+	if len(snaps) != 2 {
+		t.Errorf("snapshots after single-replica delete: got %d, want 2 (snapshots MUST survive `r d`)", len(snaps))
 	}
 }
 

--- a/pkg/store/k8s/deleting_flag_internal_test.go
+++ b/pkg/store/k8s/deleting_flag_internal_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crdv1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// TestWithDeletingFlag pins the E4 two-phase-delete surface helper:
+// when a CRD carries a DeletionTimestamp the wire Flags slice gains
+// the upstream-canonical DELETE token (rendered as DELETING by the
+// CLI's State column); when it doesn't, the slice is passed through
+// untouched.
+func TestWithDeletingFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       []string
+		deleting bool
+		want     []string
+	}{
+		{
+			name:     "not deleting passes through nil",
+			in:       nil,
+			deleting: false,
+			want:     nil,
+		},
+		{
+			name:     "not deleting passes through existing flags",
+			in:       []string{apiv1.ResourceFlagTieBreaker},
+			deleting: false,
+			want:     []string{apiv1.ResourceFlagTieBreaker},
+		},
+		{
+			name:     "deleting appends DELETE to empty",
+			in:       nil,
+			deleting: true,
+			want:     []string{apiv1.ResourceFlagDelete},
+		},
+		{
+			name:     "deleting appends DELETE keeping siblings",
+			in:       []string{apiv1.ResourceFlagDiskless},
+			deleting: true,
+			want:     []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagDelete},
+		},
+		{
+			name:     "deleting is idempotent when DELETE already present",
+			in:       []string{apiv1.ResourceFlagDelete},
+			deleting: true,
+			want:     []string{apiv1.ResourceFlagDelete},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := withDeletingFlag(tc.in, tc.deleting)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("withDeletingFlag(%v, %v) = %v, want %v", tc.in, tc.deleting, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWithDeletingFlagDoesNotMutateInput guards the no-aliasing
+// contract: a caller that re-reads the original Spec.Flags slice
+// after the projection must not see DELETE leak back into the CRD.
+func TestWithDeletingFlagDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	in := []string{apiv1.ResourceFlagDiskless}
+	_ = withDeletingFlag(in, true)
+
+	if slices.Contains(in, apiv1.ResourceFlagDelete) {
+		t.Fatalf("withDeletingFlag mutated its input slice: %v", in)
+	}
+}
+
+// TestCrdToWireRDSurfacesDeletingFlag pins E4 at the RD projection
+// boundary: an RD CRD with a DeletionTimestamp (finalizer-blocked,
+// e.g. a downed satellite) surfaces DELETE on the wire so `rd l`
+// renders the State column as DELETING in the interim.
+func TestCrdToWireRDSurfacesDeletingFlag(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.NewTime(time.Now())
+	crd := &crdv1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-rd",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"blockstor.cozystack.io/satellite-resource"},
+		},
+	}
+	SetOriginalName(&crd.ObjectMeta, "deleting-rd")
+
+	wire := crdToWireRD(crd)
+	if !slices.Contains(wire.Flags, apiv1.ResourceFlagDelete) {
+		t.Fatalf("crdToWireRD did not surface DELETE on a deleting RD: flags=%v", wire.Flags)
+	}
+
+	// A live RD (no DeletionTimestamp) must NOT carry the flag.
+	live := &crdv1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-rd"},
+	}
+	SetOriginalName(&live.ObjectMeta, "live-rd")
+
+	if slices.Contains(crdToWireRD(live).Flags, apiv1.ResourceFlagDelete) {
+		t.Fatalf("crdToWireRD surfaced DELETE on a live RD")
+	}
+}
+
+// TestCrdToWireResourceSurfacesDeletingFlag pins E4 at the per-replica
+// projection boundary: a Resource CRD with a DeletionTimestamp surfaces
+// DELETE so `r l` renders DELETING for the stuck replica while the
+// satellite-resource finalizer is still held.
+func TestCrdToWireResourceSurfacesDeletingFlag(t *testing.T) {
+	t.Parallel()
+
+	now := metav1.NewTime(time.Now())
+	crd := &crdv1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-rsc",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"blockstor.cozystack.io/satellite-resource"},
+		},
+		Spec: crdv1alpha1.ResourceSpec{
+			ResourceDefinitionName: "deleting-rd",
+			NodeName:               "worker-1",
+		},
+	}
+
+	wire := crdToWireResource(crd)
+	if !slices.Contains(wire.Flags, apiv1.ResourceFlagDelete) {
+		t.Fatalf("crdToWireResource did not surface DELETE on a deleting Resource: flags=%v", wire.Flags)
+	}
+
+	live := &crdv1alpha1.Resource{
+		Spec: crdv1alpha1.ResourceSpec{
+			ResourceDefinitionName: "live-rd",
+			NodeName:               "worker-1",
+		},
+	}
+	if slices.Contains(crdToWireResource(live).Flags, apiv1.ResourceFlagDelete) {
+		t.Fatalf("crdToWireResource surfaced DELETE on a live Resource")
+	}
+}

--- a/pkg/store/k8s/resource_definitions.go
+++ b/pkg/store/k8s/resource_definitions.go
@@ -302,7 +302,7 @@ func crdToWireRD(crd *crdv1alpha1.ResourceDefinition) apiv1.ResourceDefinition {
 		ResourceGroupName: crd.Spec.ResourceGroupName,
 		Props:             props,
 		Annotations:       userAnnotations(crd.Annotations),
-		Flags:             crd.Spec.Flags,
+		Flags:             withDeletingFlag(crd.Spec.Flags, crd.DeletionTimestamp != nil),
 		LayerStack:        crd.Spec.LayerStack,
 		UUID:              string(crd.UID),
 	}

--- a/pkg/store/k8s/resources.go
+++ b/pkg/store/k8s/resources.go
@@ -20,6 +20,7 @@ package k8s
 
 import (
 	"context"
+	"slices"
 	"sort"
 
 	"github.com/cockroachdb/errors"
@@ -460,6 +461,38 @@ func buildVolumeStatusForApply(observations []apiv1.VolumeObservation) []crdv1al
 	return out
 }
 
+// withDeletingFlag appends the upstream-canonical `DELETE` flag to a
+// CRD's spec Flags slice when the object carries a DeletionTimestamp
+// (E4 / two-phase RD deletion). controller-runtime keeps returning a
+// CRD with a non-nil DeletionTimestamp from List/Get for as long as a
+// finalizer is held — in blockstor that window is "the
+// satellite-resource finalizer hasn't drained DRBD yet", e.g. because
+// the owning satellite is down. Surfacing DELETE here makes
+// `linstor rd l` / `linstor r l` render the State column as DELETING
+// during that interim, matching upstream LINSTOR's two-phase delete
+// visibility (the satellites confirm the on-node teardown before the
+// object disappears from the DB).
+//
+// Idempotent: if the spec already carries DELETE (a future cascade
+// path might stamp it explicitly) the flag is not duplicated. The
+// input slice is never mutated — a fresh slice is returned only when a
+// flag must be added, otherwise the original is passed through.
+func withDeletingFlag(flags []string, deleting bool) []string {
+	if !deleting {
+		return flags
+	}
+
+	if slices.Contains(flags, apiv1.ResourceFlagDelete) {
+		return flags
+	}
+
+	out := make([]string, 0, len(flags)+1)
+	out = append(out, flags...)
+	out = append(out, apiv1.ResourceFlagDelete)
+
+	return out
+}
+
 func crdToWireResource(crd *crdv1alpha1.Resource) apiv1.Resource {
 	props := mergeProps(crd.Spec.Props, typedToProps(crd.Spec.DRBDOptions, crd.Spec.ExtraProps))
 
@@ -478,7 +511,7 @@ func crdToWireResource(crd *crdv1alpha1.Resource) apiv1.Resource {
 		Name:     crd.Spec.ResourceDefinitionName,
 		NodeName: crd.Spec.NodeName,
 		Props:    props,
-		Flags:    crd.Spec.Flags,
+		Flags:    withDeletingFlag(crd.Spec.Flags, crd.DeletionTimestamp != nil),
 		// Resource CRD has no LayerStack — that lives on the parent RD.
 		// Looking it up here turns every list/view into an N+1 query, so
 		// we approximate with the default stack. The Python CLI only

--- a/tests/e2e/cli-matrix/rd-d-blocked-by-snapshot.sh
+++ b/tests/e2e/cli-matrix/rd-d-blocked-by-snapshot.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# usage: rd-d-blocked-by-snapshot.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case E1 (deletion semantics).
+#
+# UG9 linstor-administration.adoc ~1364-1366, ~1395 documents two
+# asymmetric deletion rules that are easy to break in a reimplementation:
+#
+#   1. `rd d <rd>` is REFUSED while the RD still has snapshots. The
+#      operator must drop the snapshots first. Upstream raises
+#      FAIL_EXISTS_SNAPSHOT_DFN with the text "Cannot delete <rd>
+#      because it has snapshots." (blockstor: "Cannot delete resource
+#      definition '<rd>' because it has snapshots.", code 514|MASK_ERROR,
+#      HTTP 409 → CLI exit 10).
+#
+#   2. `r d <node> <rd>` of a SINGLE replica is NOT blocked by snapshots —
+#      it drops one per-node replica and the snapshots SURVIVE on the
+#      remaining replicas / snapshot-definition.
+#
+# This cell pins both on the live operator-CLI path:
+#   a) 2-replica diskful RD + 1 snapshot.
+#   b) `rd d` → non-zero, RD + replicas + snapshot all still present.
+#   c) `r d <n2> <rd>` → exit 0, snapshot still present, replica n2 gone.
+#   d) drop the snapshot, then `rd d` → exit 0, RD gone.
+#
+# Why a dedicated cell: the snapshot guard lives on the RD-delete
+# handler only (pkg/rest/resource_definitions.go::handleRDDelete). A
+# refactor that accidentally wired it onto the per-replica delete path
+# (pkg/rest/autoplace.go::handleResourceDelete) would silently break the
+# documented "snapshots survive a replica delete" contract — exactly the
+# kind of regression L1 mocks can miss because the inmemory store and
+# the real cascade diverge under finalizer pressure.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cce-rd-d-snap
+SNAP=cce-snap1
+SIZE_MIB=32
+
+N1=$WORKER_1
+N2=$WORKER_2
+
+cleanup() {
+    "${LCTL[@]}" snapshot delete "$RD" "$SNAP" 2>/dev/null || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> Phase 1: rd c + vd c + r c $N1 + r c $N2 (size=${SIZE_MIB} MiB)"
+_out=$("${LCTL[@]}" resource-definition create "$RD" 2>&1) \
+    || { echo "FAIL: rd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" volume-definition create "$RD" "${SIZE_MIB}M" 2>&1) \
+    || { echo "FAIL: vd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N1" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N1: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N2" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N2: $_out" >&2; exit 1; }
+wait_uptodate "$RD" "$N1" "$N2"
+
+echo ">> Phase 2: snapshot create $RD $SNAP"
+_out=$("${LCTL[@]}" snapshot create "$RD" "$SNAP" 2>&1) \
+    || { echo "FAIL: snapshot create $SNAP: $_out" >&2; exit 1; }
+
+# Wait for the snapshot to register on the controller (CRD present).
+deadline=$(( $(date +%s) + 60 ))
+snap_seen=false
+while (( $(date +%s) < deadline )); do
+    if "${LCTL[@]}" snapshot list 2>/dev/null | grep -q "$SNAP"; then
+        snap_seen=true
+        break
+    fi
+    sleep 2
+done
+if ! $snap_seen; then
+    echo "FAIL: snapshot $SNAP never appeared in 'snapshot list'" >&2
+    "${LCTL[@]}" snapshot list >&2 || true
+    exit 1
+fi
+
+# =====================================================================
+# Contract 1: rd d is REFUSED while a snapshot exists.
+# =====================================================================
+echo ">> Phase 3: rd d $RD must be REJECTED (snapshot present)"
+set +e
+rd_d_out=$("${LCTL[@]}" resource-definition delete "$RD" 2>&1)
+rd_d_rc=$?
+set -e
+echo "$rd_d_out"
+
+if [[ $rd_d_rc -eq 0 ]]; then
+    echo "FAIL (E1): rd d returned 0 despite an existing snapshot — guard missing" >&2
+    exit 1
+fi
+
+# Error envelope must name the snapshot-blocked reason.
+if ! grep -qiE 'because it has snapshots' <<<"$rd_d_out"; then
+    echo "FAIL (E1): rd d rejection text does not mention 'because it has snapshots': $rd_d_out" >&2
+    exit 1
+fi
+
+# RD + both replicas must survive the refused delete (cascade must NOT
+# have fired). Probe the CRD layer directly.
+if ! kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" >/dev/null 2>&1; then
+    echo "FAIL (E1): RD ${RD} vanished after a REFUSED rd d — cascade fired before the guard" >&2
+    exit 1
+fi
+repl_count=$(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+    | awk -v rd="${RD}." '$1 ~ "^"rd' | wc -l | tr -d ' ')
+if [[ "$repl_count" -lt 2 ]]; then
+    echo "FAIL (E1): expected >=2 replicas after refused rd d, got $repl_count" >&2
+    exit 1
+fi
+echo "   OK: rd d refused, RD + $repl_count replicas + snapshot intact"
+
+# =====================================================================
+# Contract 2: r d of a SINGLE replica is NOT blocked; snapshot survives.
+# =====================================================================
+echo ">> Phase 4: r d $N2 $RD must SUCCEED and leave the snapshot intact"
+set +e
+r_d_out=$("${LCTL[@]}" resource delete "$N2" "$RD" 2>&1)
+r_d_rc=$?
+set -e
+echo "$r_d_out"
+
+if [[ $r_d_rc -ne 0 ]]; then
+    echo "FAIL (E1): r d $N2 $RD returned non-zero ($r_d_rc) — the snapshot guard must NOT apply to per-replica delete" >&2
+    exit 1
+fi
+
+# The snapshot must STILL be present.
+if ! "${LCTL[@]}" snapshot list 2>/dev/null | grep -q "$SNAP"; then
+    echo "FAIL (E1): snapshot $SNAP disappeared after a single-replica r d — snapshots must survive" >&2
+    "${LCTL[@]}" snapshot list >&2 || true
+    exit 1
+fi
+echo "   OK: r d succeeded, snapshot $SNAP survived"
+
+# =====================================================================
+# Contract 3: drop the snapshot, then rd d succeeds (recovery flow).
+# =====================================================================
+echo ">> Phase 5: snapshot delete then rd d must SUCCEED"
+_out=$("${LCTL[@]}" snapshot delete "$RD" "$SNAP" 2>&1) \
+    || { echo "FAIL: snapshot delete $SNAP: $_out" >&2; exit 1; }
+
+# Give the controller a moment to drop the snapshot CRD.
+deadline=$(( $(date +%s) + 60 ))
+while (( $(date +%s) < deadline )); do
+    if ! "${LCTL[@]}" snapshot list 2>/dev/null | grep -q "$SNAP"; then
+        break
+    fi
+    sleep 2
+done
+
+set +e
+rd_d2_out=$("${LCTL[@]}" resource-definition delete "$RD" 2>&1)
+rd_d2_rc=$?
+set -e
+echo "$rd_d2_out"
+
+if [[ $rd_d2_rc -ne 0 ]]; then
+    echo "FAIL (E1): rd d still refused after the snapshot was dropped: $rd_d2_out" >&2
+    exit 1
+fi
+
+# Wait for the RD to clear so the EXIT-trap cleanup + no-orphans check
+# starts from a clean state.
+deadline=$(( $(date +%s) + 120 ))
+while (( $(date +%s) < deadline )); do
+    if ! kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 3
+done
+
+echo ">> PASS: rd-d-blocked-by-snapshot (E1: rd d guarded, r d not, recovery flow)"

--- a/tests/e2e/cli-matrix/rd-d-deleting-surface.sh
+++ b/tests/e2e/cli-matrix/rd-d-deleting-surface.sh
@@ -133,12 +133,15 @@ deadline=$(( $(date +%s) + 60 ))
 deleting_seen=false
 while (( $(date +%s) < deadline )); do
     # Wire-level assertion: the Resource view carries the DELETE flag for
-    # the blocked replica. `r l -o json` exposes the flags array directly.
+    # the blocked replica. golinstor's `r l -o json` is a doubly-nested
+    # array of per-replica rows; the resource-level flags live under
+    # `rsc_flags` (see multi-volume-late-vd-create.sh / n-rst-recreates-
+    # tiebreaker.sh for the same shape).
     rl_json=$("${LCTL[@]}" resource list --resources "$RD" -o json 2>/dev/null || echo '[]')
     has_delete=$(jq -r --arg n "$N2" '
-        [ .[]? | (.resources // .)[]?
-          | select(.node_name == $n or .node == $n)
-          | (.flags // []) | index("DELETE") ] | any' <<<"$rl_json" 2>/dev/null || echo false)
+        [ .[]?[]?
+          | select(.node_name == $n)
+          | (.rsc_flags // []) | index("DELETE") ] | any' <<<"$rl_json" 2>/dev/null || echo false)
     # Fallback: the human-readable State column rendered by the CLI.
     rl_txt=$("${LCTL[@]}" resource list --resources "$RD" 2>/dev/null || true)
     if [[ "$has_delete" == "true" ]] || grep -qiE 'DELETING' <<<"$rl_txt"; then

--- a/tests/e2e/cli-matrix/rd-d-deleting-surface.sh
+++ b/tests/e2e/cli-matrix/rd-d-deleting-surface.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# usage: rd-d-deleting-surface.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case E4 (two-phase RD deletion surface).
+#
+# UG9 linstor-administration.adoc ~1350-1362 documents that an RD marked
+# for deletion is NOT immediately removed from the DB: the controller
+# flags it, the satellites confirm the on-node teardown, and only then
+# does it disappear. During the interim `rd l` / `r l` show the object
+# in a DELETING state, and a downed satellite blocks the final removal.
+#
+# In blockstor the two-phase delete is realised with CRD finalizers: a
+# `rd d` stamps DeletionTimestamp + cascades to the per-replica
+# Resources, whose `satellite-resource` finalizer drains DRBD before the
+# object is finalised. If a satellite cannot drain (it is down), the
+# Resource lingers with a DeletionTimestamp — which the k8s store now
+# projects onto the wire as the upstream-canonical DELETE flag, so the
+# CLI renders the State column as DELETING (fix: pkg/store/k8s
+# withDeletingFlag).
+#
+# We must NOT stop a blockstor satellite (forbidden on the shared
+# stand). Instead we SAFELY simulate the "finalizer held" condition on
+# our OWN cce- resource by adding an extra finalizer to one Resource
+# CRD, issuing `rd d`, and asserting the DELETING surface appears while
+# the finalizer blocks finalisation. We then remove our finalizer and
+# let the normal teardown complete. This touches only cce- objects.
+#
+# Contract:
+#   a) 2-replica diskful RD, UpToDate.
+#   b) Add a test finalizer to the Resource CRD on $N2.
+#   c) `rd d $RD` (cascade stamps DeletionTimestamp on every replica).
+#   d) Within the wait window, `r l -r $RD` shows DELETING for the
+#      finalizer-blocked replica (wire `flags` carries DELETE), and the
+#      RD is NOT yet gone (final removal blocked).
+#   e) Remove the test finalizer → the delete completes, RD clears.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cce-rd-d-deleting
+SIZE_MIB=32
+TEST_FINALIZER="cce.test/hold-deleting-surface"
+
+N1=$WORKER_1
+N2=$WORKER_2
+
+# The Resource CRD name is "<rd>.<node>" by blockstor's composite-key
+# convention; discover it rather than assume the exact slug.
+rsc_crd_name() {
+    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${RD}." -v node="$1" '$1 ~ "^"rd && $0 ~ node {print $1; exit}'
+}
+
+remove_test_finalizer() {
+    local crd
+    crd=$(rsc_crd_name "$N2")
+    if [[ -n "$crd" ]]; then
+        # Drop ONLY our test finalizer; keep any other finalizer the
+        # satellite set so the real teardown still runs to completion.
+        local kept
+        kept=$(kubectl get "resources.blockstor.cozystack.io/${crd}" \
+            -o json 2>/dev/null \
+            | jq -c --arg f "$TEST_FINALIZER" \
+                '[(.metadata.finalizers // [])[] | select(. != $f)]' 2>/dev/null || echo 'null')
+        kubectl patch "resources.blockstor.cozystack.io/${crd}" --type=merge \
+            -p "{\"metadata\":{\"finalizers\":${kept}}}" >/dev/null 2>&1 || true
+    fi
+}
+
+cleanup() {
+    # Always strip our test finalizer so nothing leaks even on a mid-cell
+    # abort, then run the standard teardown.
+    remove_test_finalizer || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> Phase 1: rd c + vd c + r c $N1 + r c $N2 (size=${SIZE_MIB} MiB)"
+_out=$("${LCTL[@]}" resource-definition create "$RD" 2>&1) \
+    || { echo "FAIL: rd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" volume-definition create "$RD" "${SIZE_MIB}M" 2>&1) \
+    || { echo "FAIL: vd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N1" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N1: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N2" "$RD" --storage-pool=stand 2>&1) \
+    || { echo "FAIL: r c $N2: $_out" >&2; exit 1; }
+wait_uptodate "$RD" "$N1" "$N2"
+
+echo ">> Phase 2: add a test finalizer to the $N2 Resource CRD (simulate a stuck on-node teardown)"
+CRD_N2=$(rsc_crd_name "$N2")
+if [[ -z "$CRD_N2" ]]; then
+    echo "FAIL: could not resolve Resource CRD name for $RD on $N2" >&2
+    kubectl get resources.blockstor.cozystack.io --no-headers >&2 || true
+    exit 1
+fi
+echo "   $N2 Resource CRD = $CRD_N2"
+# Append our finalizer (merge with whatever the satellite already set).
+existing_fin=$(kubectl get "resources.blockstor.cozystack.io/${CRD_N2}" \
+    -o jsonpath='{.metadata.finalizers}' 2>/dev/null || echo '[]')
+echo "   existing finalizers: $existing_fin"
+kubectl patch "resources.blockstor.cozystack.io/${CRD_N2}" --type=json \
+    -p "[{\"op\":\"add\",\"path\":\"/metadata/finalizers/-\",\"value\":\"${TEST_FINALIZER}\"}]" \
+    >/dev/null 2>&1 \
+    || kubectl patch "resources.blockstor.cozystack.io/${CRD_N2}" --type=merge \
+        -p "{\"metadata\":{\"finalizers\":[\"${TEST_FINALIZER}\"]}}" >/dev/null 2>&1 \
+    || { echo "FAIL: could not add test finalizer to $CRD_N2" >&2; exit 1; }
+
+echo ">> Phase 3: rd d $RD (cascade stamps DeletionTimestamp; finalizer blocks finalisation)"
+# `rd d` waits for cache convergence then returns; the cascade has
+# stamped DeletionTimestamp on every replica. The $N2 replica cannot
+# finalise because our test finalizer is held.
+"${LCTL[@]}" resource-definition delete "$RD" >/dev/null 2>&1 || true
+
+# =====================================================================
+# Contract: the wire surfaces DELETING for the finalizer-blocked replica
+# while the RD is NOT yet gone.
+# =====================================================================
+echo ">> Phase 4: r l -r $RD must show DELETING for the blocked replica"
+deadline=$(( $(date +%s) + 60 ))
+deleting_seen=false
+while (( $(date +%s) < deadline )); do
+    # Wire-level assertion: the Resource view carries the DELETE flag for
+    # the blocked replica. `r l -o json` exposes the flags array directly.
+    rl_json=$("${LCTL[@]}" resource list --resources "$RD" -o json 2>/dev/null || echo '[]')
+    has_delete=$(jq -r --arg n "$N2" '
+        [ .[]? | (.resources // .)[]?
+          | select(.node_name == $n or .node == $n)
+          | (.flags // []) | index("DELETE") ] | any' <<<"$rl_json" 2>/dev/null || echo false)
+    # Fallback: the human-readable State column rendered by the CLI.
+    rl_txt=$("${LCTL[@]}" resource list --resources "$RD" 2>/dev/null || true)
+    if [[ "$has_delete" == "true" ]] || grep -qiE 'DELETING' <<<"$rl_txt"; then
+        deleting_seen=true
+        break
+    fi
+    sleep 2
+done
+
+if ! $deleting_seen; then
+    echo "FAIL (E4): r l never surfaced a DELETING/DELETE state for the finalizer-blocked replica within 60s" >&2
+    "${LCTL[@]}" resource list --resources "$RD" >&2 || true
+    "${LCTL[@]}" resource list --resources "$RD" -o json >&2 || true
+    exit 1
+fi
+echo "   OK: DELETING surface visible while the finalizer blocks finalisation"
+
+# The RD must NOT be fully gone yet — a downed/stuck satellite blocks the
+# final removal (the whole point of the two-phase delete).
+if ! kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" >/dev/null 2>&1; then
+    # Acceptable race: if the RD object itself finalised faster than the
+    # blocked child, the child Resource CRD must still be observable as
+    # DELETING. Re-check the child directly.
+    if [[ -z "$(rsc_crd_name "$N2")" ]]; then
+        echo "FAIL (E4): both RD and blocked replica vanished despite a held finalizer" >&2
+        exit 1
+    fi
+fi
+
+# =====================================================================
+# Release: remove the test finalizer; the real delete completes.
+# =====================================================================
+echo ">> Phase 5: remove the test finalizer; delete must complete"
+remove_test_finalizer
+
+deadline=$(( $(date +%s) + 120 ))
+cleared=false
+while (( $(date +%s) < deadline )); do
+    if ! kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" >/dev/null 2>&1 \
+        && [[ -z "$(rsc_crd_name "$N2")" ]]; then
+        cleared=true
+        break
+    fi
+    sleep 3
+done
+if ! $cleared; then
+    echo "FAIL (E4): RD/replica did not clear within 120s after releasing the finalizer" >&2
+    kubectl get resources.blockstor.cozystack.io --no-headers | grep "$RD" >&2 || true
+    exit 1
+fi
+
+echo ">> PASS: rd-d-deleting-surface (E4: DELETING visible during two-phase delete, finalizer blocks final removal)"

--- a/tests/e2e/cli-matrix/rg-delete-with-rds-rejected.sh
+++ b/tests/e2e/cli-matrix/rg-delete-with-rds-rejected.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# usage: rg-delete-with-rds-rejected.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case E3 (deletion semantics + escape).
+#
+# UG9 linstor-administration.adoc ~1403-1429 documents:
+#
+#   1. `rg delete <rg>` is REFUSED while any ResourceDefinition still
+#      references it. Upstream raises FAIL_EXISTS_RSC_DFN with the text
+#      "Cannot delete resource group '<rg>' because it has existing
+#      resource definitions." There is NO `--force`.
+#
+#   2. The escape is to REASSIGN the RD to a different group:
+#      `rd modify <rd> --resource-group <other>`. After the reassign the
+#      RD starts inheriting the NEW group's properties retroactively
+#      (inheritance is a live reference, not a create-time copy), and the
+#      now-empty original group can be deleted.
+#
+# This cell pins both on the live operator-CLI path:
+#   a) rg c src_rg (with a marker property), rg c dst_rg (different marker),
+#      rd c under src_rg.
+#   b) rg d src_rg → non-zero, error names "existing resource definitions",
+#      src_rg still present.
+#   c) rd modify <rd> --resource-group dst_rg → exit 0.
+#   d) rd lp <rd> now surfaces dst_rg's inherited marker (retroactive
+#      inheritance), NOT src_rg's.
+#   e) rg d src_rg → exit 0 (now empty).
+#
+# Why a dedicated cell: the rejection guard
+# (pkg/rest/resource_groups.go::refuseRGDeleteIfReferenced) and the
+# retroactive-inheritance read path
+# (pkg/rest/effective_props.go::effectivePropsForRD) are separate code
+# paths; a regression in either silently breaks the documented escape
+# hatch operators rely on to retire a resource group.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 1
+
+linstor_cli_setup
+
+SRC_RG=cce-rg-src
+DST_RG=cce-rg-dst
+RD=cce-rg-escape-rd
+
+# Distinct inheritable marker props so we can prove the RD switches which
+# group it inherits from after the reassign. Aux/* keys are arbitrary
+# operator metadata that inherit Controller→RG→RD without DRBD semantics.
+SRC_MARK_KEY="Aux/cce-origin"
+SRC_MARK_VAL="src-group"
+DST_MARK_KEY="Aux/cce-origin"
+DST_MARK_VAL="dst-group"
+
+cleanup() {
+    delete_rd "$RD"
+    "${LCTL[@]}" resource-group delete "$SRC_RG" 2>/dev/null || true
+    "${LCTL[@]}" resource-group delete "$DST_RG" 2>/dev/null || true
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> Phase 1: create src_rg + dst_rg with distinct marker props, rd c under src_rg"
+_out=$("${LCTL[@]}" resource-group create "$SRC_RG" 2>&1) \
+    || { echo "FAIL: rg c $SRC_RG: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource-group create "$DST_RG" 2>&1) \
+    || { echo "FAIL: rg c $DST_RG: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource-group set-property "$SRC_RG" "$SRC_MARK_KEY" "$SRC_MARK_VAL" 2>&1) \
+    || { echo "FAIL: rg sp $SRC_RG: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource-group set-property "$DST_RG" "$DST_MARK_KEY" "$DST_MARK_VAL" 2>&1) \
+    || { echo "FAIL: rg sp $DST_RG: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource-definition create "$RD" --resource-group "$SRC_RG" 2>&1) \
+    || { echo "FAIL: rd c $RD --resource-group $SRC_RG: $_out" >&2; exit 1; }
+
+# Sanity: the RD inherits src_rg's marker before the reassign.
+rd_lp() { "${LCTL[@]}" resource-definition list-properties "$RD" 2>/dev/null; }
+if ! rd_lp | grep -q "$SRC_MARK_VAL"; then
+    echo "FAIL (E3 pre): RD does not inherit src_rg's marker '$SRC_MARK_VAL' before reassign" >&2
+    rd_lp >&2 || true
+    exit 1
+fi
+echo "   OK: RD inherits src_rg marker '$SRC_MARK_VAL' before reassign"
+
+# =====================================================================
+# Contract 1: rg d src_rg is REFUSED while the RD references it.
+# =====================================================================
+echo ">> Phase 2: rg d $SRC_RG must be REJECTED (RD still references it)"
+set +e
+rg_d_out=$("${LCTL[@]}" resource-group delete "$SRC_RG" 2>&1)
+rg_d_rc=$?
+set -e
+echo "$rg_d_out"
+
+if [[ $rg_d_rc -eq 0 ]]; then
+    echo "FAIL (E3): rg d $SRC_RG returned 0 despite a referencing RD — guard missing" >&2
+    exit 1
+fi
+if ! grep -qiE 'existing resource definitions' <<<"$rg_d_out"; then
+    echo "FAIL (E3): rg d rejection text does not mention 'existing resource definitions': $rg_d_out" >&2
+    exit 1
+fi
+if ! "${LCTL[@]}" resource-group list 2>/dev/null | grep -q "$SRC_RG"; then
+    echo "FAIL (E3): src_rg disappeared after a REFUSED rg d" >&2
+    exit 1
+fi
+echo "   OK: rg d refused, src_rg intact"
+
+# =====================================================================
+# Contract 2: reassign the RD to dst_rg via rd modify --resource-group.
+# =====================================================================
+echo ">> Phase 3: rd modify $RD --resource-group $DST_RG (the escape)"
+set +e
+mv_out=$("${LCTL[@]}" resource-definition modify "$RD" --resource-group "$DST_RG" 2>&1)
+mv_rc=$?
+set -e
+echo "$mv_out"
+if [[ $mv_rc -ne 0 ]]; then
+    echo "FAIL (E3): rd modify --resource-group $DST_RG returned non-zero ($mv_rc): $mv_out" >&2
+    exit 1
+fi
+
+# =====================================================================
+# Contract 3: retroactive inheritance — RD now inherits dst_rg's marker,
+# NOT src_rg's. Inheritance is a live reference (UG9 ~1403-1429).
+# =====================================================================
+echo ">> Phase 4: rd lp $RD must now inherit dst_rg's marker, not src_rg's"
+deadline=$(( $(date +%s) + 30 ))
+flipped=false
+while (( $(date +%s) < deadline )); do
+    lp=$(rd_lp || true)
+    if grep -q "$DST_MARK_VAL" <<<"$lp" && ! grep -q "$SRC_MARK_VAL" <<<"$lp"; then
+        flipped=true
+        break
+    fi
+    sleep 2
+done
+if ! $flipped; then
+    echo "FAIL (E3): after reassign, rd lp did not flip to dst_rg's marker '$DST_MARK_VAL' (still '$SRC_MARK_VAL'?)" >&2
+    rd_lp >&2 || true
+    exit 1
+fi
+echo "   OK: RD retroactively inherits dst_rg marker '$DST_MARK_VAL'"
+
+# =====================================================================
+# Contract 4: src_rg is now empty and can be deleted.
+# =====================================================================
+echo ">> Phase 5: rg d $SRC_RG must now SUCCEED (empty)"
+set +e
+rg_d2_out=$("${LCTL[@]}" resource-group delete "$SRC_RG" 2>&1)
+rg_d2_rc=$?
+set -e
+echo "$rg_d2_out"
+if [[ $rg_d2_rc -ne 0 ]]; then
+    echo "FAIL (E3): rg d $SRC_RG still refused after the RD was reassigned away: $rg_d2_out" >&2
+    exit 1
+fi
+if "${LCTL[@]}" resource-group list 2>/dev/null | grep -q "$SRC_RG"; then
+    echo "FAIL (E3): src_rg still present after a successful rg d" >&2
+    exit 1
+fi
+
+echo ">> PASS: rg-delete-with-rds-rejected (E3: rejection + reassign escape + retroactive inheritance)"

--- a/tests/operator-harness/replay/rd-d-blocked-by-snapshot.yaml
+++ b/tests/operator-harness/replay/rd-d-blocked-by-snapshot.yaml
@@ -1,0 +1,101 @@
+name: rd-d-blocked-by-snapshot
+description: |
+  Corner-case E1 (deletion semantics), UG9 linstor-administration.adoc
+  ~1364-1366, ~1395. Two asymmetric deletion rules an operator relies on:
+
+    1. `rd d <rd>` is REFUSED while the RD still has snapshots — the
+       operator must drop the snapshots first. Upstream raises
+       FAIL_EXISTS_SNAPSHOT_DFN ("... because it has snapshots."),
+       surfaced by the linstor CLI as a non-zero exit (apiCallRcError
+       envelope → exit 10).
+
+    2. `r d <node> <rd>` of a SINGLE replica is NOT blocked by snapshots:
+       it drops one per-node replica and the snapshots SURVIVE.
+
+  Sequence: 2-replica diskful RD on node1+node2 → snapshot → `rd d` MUST
+  be rejected (snapshot present) → `r d node2` MUST succeed (snapshot
+  survives) → drop the snapshot → `rd d` MUST succeed.
+
+  The snapshot guard lives only on the RD-delete handler
+  (pkg/rest/resource_definitions.go::handleRDDelete); this replay codifies
+  the exact operator sequence so a refactor that wired the guard onto the
+  per-replica delete path would FAIL here, not just in the L1 mock.
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+  rd: cce-e1-rdsnap
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: snapshot-create
+    cmd: ["snapshot", "create", "{{rd}}", "cce-e1-snap"]
+    expect_exit: 0
+  # ---- Contract 1: rd d refused while a snapshot exists ----
+  - name: rd-d-rejected-by-snapshot
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 10
+  # The RD must survive the refused delete.
+  - name: rd-still-present-after-rejection
+    cmd: ["resource-definition", "list", "--resource-definitions", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 2
+      timeout_s: 30
+  # ---- Contract 2: single-replica r d is NOT blocked; snapshot survives ----
+  - name: r-d-single-replica-allowed
+    cmd: ["resource", "delete", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+  - name: r-d-took-effect
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 60
+  # Snapshot must STILL be present — `rd d` is still refused.
+  - name: rd-d-still-refused-snapshot-survived
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 10
+  # ---- Contract 3: drop the snapshot, then rd d succeeds ----
+  - name: snapshot-delete
+    cmd: ["snapshot", "delete", "{{rd}}", "cce-e1-snap"]
+    expect_exit: 0
+  - name: rd-d-now-succeeds
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: "{{rd}}"
+      timeout_s: 120
+
+teardown:
+  - cmd: ["snapshot", "delete", "{{rd}}", "cce-e1-snap"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/rg-delete-with-rds-rejected.yaml
+++ b/tests/operator-harness/replay/rg-delete-with-rds-rejected.yaml
@@ -1,0 +1,76 @@
+name: rg-delete-with-rds-rejected
+description: |
+  Corner-case E3 (deletion semantics + reassign escape), UG9
+  linstor-administration.adoc ~1403-1429.
+
+    1. `rg delete <rg>` is REFUSED while any ResourceDefinition still
+       references it (FAIL_EXISTS_RSC_DFN: "Cannot delete resource group
+       '<rg>' because it has existing resource definitions."). There is
+       no `--force`. The CLI surfaces this as a non-zero exit
+       (apiCallRcError envelope → exit 10).
+
+    2. The escape is to REASSIGN the RD to another group with
+       `rd modify <rd> --resource-group <other>`; the now-empty original
+       group can then be deleted.
+
+  This replay codifies the operator sequence purely via exit-code
+  contracts (the runner has no "property-inherited" await kind — the
+  retroactive-inheritance flip is asserted at the L6 layer in
+  tests/e2e/cli-matrix/rg-delete-with-rds-rejected.sh, which can grep
+  `rd lp`). Sequence: rg c src + rg c dst → rd c under src → `rg d src`
+  MUST be rejected (exit 10) → `rd modify --resource-group dst` → `rg d
+  src` MUST now succeed (empty) → `rg d dst` after the RD is dropped.
+
+prerequisites:
+  min_nodes: 1
+  storage_pool: stand
+
+vars:
+  sp: stand
+  rd: cce-e3-escape-rd
+
+steps:
+  - name: create-src-rg
+    cmd: ["resource-group", "create", "cce-e3-src"]
+    expect_exit: 0
+  - name: create-dst-rg
+    cmd: ["resource-group", "create", "cce-e3-dst"]
+    expect_exit: 0
+  - name: create-rd-under-src
+    cmd: ["resource-definition", "create", "{{rd}}", "--resource-group", "cce-e3-src"]
+    expect_exit: 0
+  # ---- Contract 1: rg d src refused while the RD references it ----
+  - name: rg-d-src-rejected
+    cmd: ["resource-group", "delete", "cce-e3-src"]
+    expect_exit: 10
+  # src_rg must survive the refused delete.
+  - name: src-rg-still-present
+    cmd: ["resource-group", "list", "--resource-groups", "cce-e3-src"]
+    expect_exit: 0
+  # ---- Contract 2: reassign the RD to dst_rg (the escape) ----
+  - name: rd-modify-resource-group
+    cmd: ["resource-definition", "modify", "{{rd}}", "--resource-group", "cce-e3-dst"]
+    expect_exit: 0
+  # ---- Contract 3: src_rg is now empty → delete succeeds ----
+  - name: rg-d-src-now-succeeds
+    cmd: ["resource-group", "delete", "cce-e3-src"]
+    expect_exit: 0
+  # Drop the RD, then the destination group is empty too.
+  - name: delete-rd
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: "{{rd}}"
+      timeout_s: 120
+  - name: rg-d-dst-succeeds
+    cmd: ["resource-group", "delete", "cce-e3-dst"]
+    expect_exit: 0
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+  - cmd: ["resource-group", "delete", "cce-e3-src"]
+  - cmd: ["resource-group", "delete", "cce-e3-dst"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

Closes corner-case plan items **E1**, **E3**, **E4** (deletion semantics) from the LINSTOR corner-case campaign. Verifies the documented LINSTOR deletion rules against blockstor, pins them with L1 + L6 + L7 tests, and fixes the one divergence (E4).

| Item | Verdict | Evidence |
|---|---|---|
| **E1** — `rd d` blocked by snapshots; `r d` of a single replica is NOT (snapshots survive) | **MATCHES** (already correct, now pinned) | `rd d` guard already present in `handleRDDelete` with upstream code `514\|MASK_ERROR` (HTTP 409). `r d` only drops one Resource and never touches Snapshots. Stand: rejection text `Cannot delete resource definition '<rd>' because it has snapshots.`; single-replica `r d` succeeds, snapshot survives. |
| **E3** — `rg delete` with live RDs rejected; `rd modify --resource-group` escape; new group's props inherited retroactively | **MATCHES** (already correct, now pinned) | Rejection text `Cannot delete resource group '<rg>' because it has existing resource definitions.` (code `501\|MASK_ERROR`). Reassign works; **`rd lp` flips from the old group's marker to the new group's after the reassign** — inheritance is a live reference, not a create-time copy (answers the E3 ⚖️ question on the BS side). |
| **E4** — two-phase RD deletion: `rd l` shows DELETING in the interim; a downed satellite blocks final removal | **DIVERGED → fixed** | The k8s store projections dropped `metadata.DeletionTimestamp`, so a finalizer-blocked RD/Resource showed its normal flags with no CLI-visible signal that a delete was pending. Now `withDeletingFlag` surfaces the upstream-canonical `DELETE` flag when `DeletionTimestamp` is set, so `linstor rd l` / `r l` render the State column as `DELETING` while a held finalizer (e.g. a downed satellite) blocks finalisation. |

## Changes

- `pkg/api/v1`: add `ResourceFlagDelete = "DELETE"` (upstream-canonical token; distinct from the internal `DELETING` peer-forget constant).
- `pkg/store/k8s`: `crdToWireRD` / `crdToWireResource` now stamp `DELETE` onto the wire `Flags` when the CRD carries a `DeletionTimestamp` (E4).
- L1: `withDeletingFlag` + projection unit tests; a new REST test pinning that a single-replica `r d` leaves snapshots intact (E1 second half).
- L6 cli-matrix: `rd-d-blocked-by-snapshot.sh` (E1), `rg-delete-with-rds-rejected.sh` (E3), `rd-d-deleting-surface.sh` (E4).
- L7 replay: `rd-d-blocked-by-snapshot.yaml` (E1), `rg-delete-with-rds-rejected.yaml` (E3).

## Test evidence

`go test ./...` green; `golangci-lint run` 0 issues on touched packages.

Stand validation (dev, blockstor v0.1.9 + this branch's YAMLs/cells):

```
PASS: rd-d-blocked-by-snapshot            (L7 replay, 13 steps)
PASS: rg-delete-with-rds-rejected         (L7 replay, 9 steps)
PASS: rd-d-blocked-by-snapshot.sh         (L6 cell)   — rd d refused, r d allowed + snapshot survives
PASS: rg-delete-with-rds-rejected.sh      (L6 cell)   — rejection + reassign + rd lp flips src→dst
```

The E4 cli-matrix cell (`rd-d-deleting-surface.sh`) asserts the new `DELETE`-flag wire surface and therefore requires this branch's controller build deployed; it is pinned at L1 against the store projection. It safely simulates the "stuck on-node teardown" with a test finalizer on a `cce-` Resource only — it never stops a satellite.

## Notes / leftovers

- E1/E3 match upstream-documented behavior, so no `cli-parity-known-deltas.md` row is added; E4 moves toward parity (a fix), not a deliberate delta.
- Oracle (upstream LINSTOR) was not yet ready during this run; the exact upstream error wording was matched from LINSTOR source and confirmed against blockstor on the stand. The E3 retroactive-inheritance question was answered directly on BS (the `rd lp` flip).

## Oracle (upstream LINSTOR 1.33.2) cross-check

Ran the same E1/E3 sequences against the upstream Java controller on the shared stand (FILE_THIN `pool`):

- **E1 envelope — byte-identical.** Upstream `rd d` with a snapshot present: exit 10, `Cannot delete resource definition 'orc-e-snap-rd' because it has snapshots.` Snapshots ARE supported on FILE_THIN upstream; a single-replica `r d` succeeded and the snapshot survived (`Successful` in `snapshot list`) — matching blockstor exactly.
- **E3 envelope — byte-identical.** Upstream `rg d` with a live RD: exit 10, `Cannot delete resource group 'orc-e-src' because it has existing resource definitions.` Reassign via `rd modify --resource-group` succeeded and re-stamped the new group's `StorPoolName` onto the RD (retroactive inheritance confirmed at the effective level).
- **E3 display nuance (pre-existing, not introduced here).** Upstream `rd lp` shows `No property map found for this entry.` — it does NOT inline inherited RG `Aux/*` markers at the RD scope. blockstor DOES inline them (Bug 105, deliberate python-CLI parity), which is what lets the L6 cell observe the `src→dst` marker flip directly. The inheritance itself is live in both; only the `rd lp` rendering differs, and that divergence is independent of these deletion-semantics items.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two-phase resource deletion now properly surfaced with a DELETE flag to track deletion state.
  * Single replica deletion now succeeds independently of snapshot existence.
  * Snapshots now block resource definition deletion while single replica deletion remains allowed.
  * Resource definitions can now be reassigned to other resource groups to enable deletion.

* **Tests**
  * Added comprehensive e2e and operator-harness tests for deletion scenarios and snapshot management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->