### PR TITLE
test(corner-a): pin VlmNr allocation (reuse-after-delete, explicit-then-plain) + DRBD consistency group; document shrink-reject delta

### DIFF
--- a/docs/cli-parity-known-deltas.md
+++ b/docs/cli-parity-known-deltas.md
@@ -26,6 +26,7 @@ Row IDs match the command-catalogue indexes used by `cli-parity-refresh.sh` (see
 | 53 | `backup l` | MISSING_FEATURE | 2026-12-31 | Backup/restore subsystem (F20 follow-up: orchestration only — DTO already lands). |
 | 54 | `schedule l` | MISSING_FEATURE | 2026-12-31 | Schedules subsystem deferred to follow-up wave. |
 | 55 | `key-value-store list` | WIRE_SHAPE | 2026-09-30 | BS exposes the KVS endpoints but the wire shape lacks `props.LinstorKvs/...` namespace nesting; CSI uses a flat key set so unblocked. |
+| 60 | `vd s <rd> <vn> <smaller>` (shrink) | BEHAVIOR | permanent | BLOCKSTOR_STRICTER: upstream LINSTOR has permitted `vd set-size` downward since 1.8.0 for layer stacks that support it (e.g. STORAGE/ZFS-only); BS rejects ALL shrinks with `FAIL_INVLD_VLM_SIZE` (HTTP 400) unless the operator opts in with `force=true` (body field or `?force=true`). Rationale: every BS RD is DRBD-backed and DRBD cannot shrink past the on-disk metadata position without destroying it, so an unconditional reject is the safe default. The `force=true` escape hatch covers the post-`resize2fs -s` operator. Pinned by `tests/e2e/cli-matrix/vd-shrink-rejected.sh` (L6), `replay/vd-resize-full-lifecycle.yaml` (L7), and `pkg/rest/volume_definitions_test.go::TestVolumeDefinitionsUpdateShrink{Rejected,WithForceAccepted}` + `pkg/rest/bug_383_*` (L1). |
 
 ## Open (block merge until addressed)
 

--- a/pkg/rest/vd_number_reuse_corner_a_test.go
+++ b/pkg/rest/vd_number_reuse_corner_a_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Corner-case campaign item A2b/A3 — volume-number allocation semantics.
+//
+// The upstream LINSTOR controller (CtrlVlmDfnCrtApiCallHandler) assigns
+// the SMALLEST FREE volume number on an auto-assign `vd c` — it does NOT
+// append max+1. Two operator-observable consequences fall out of that
+// rule and were verified identical against the upstream Java oracle on
+// the shared stand (piraeus-server v1.33.2):
+//
+//   A2b — reuse after delete: rd with vols 0+1, `vd d 0`, then a plain
+//         `vd c` lands at the freed 0 (NOT 2). Affects the rendered
+//         `.res` volume{} block ordering and the device minor.
+//
+//   A3  — explicit-then-plain: `vd c --vlmnr 5` first, then a plain
+//         `vd c` lands at 0 (the smallest free), NOT 6.
+//
+// Bug 191's TestBug191VDCreateAutoAssignFillsGaps already pins the
+// pre-seeded-gap variant; these two cases drive the allocation through
+// the live DELETE + explicit-create handler paths so a future change to
+// autoAssignVolumeNumber (e.g. a regression to max+1) is caught at the
+// operator-observable wire boundary, not just at the unit helper.
+
+// TestCornerA2bVolumeNumberReusedAfterDelete drives the exact A2b
+// operator sequence end to end through the REST handlers: create VD 0
+// and VD 1, DELETE VD 0, then POST a plain `vd c` (no volume_number).
+// The freed VlmNr=0 MUST be re-assigned — matching upstream's
+// smallest-free rule — not VlmNr=2 (max+1).
+func TestCornerA2bVolumeNumberReusedAfterDelete(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const rdName = "pvc-corner-a2b-reuse"
+
+	err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName})
+	if err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	vdURL := base + "/v1/resource-definitions/" + rdName + "/volume-definitions"
+
+	// Seed vols 0 and 1 via the auto-assign create path (no
+	// volume_number key) so the allocator picks 0 then 1.
+	for i := range 2 {
+		resp := httpPost(t, vdURL, []byte(`{"volume_definition":{"size_kib":32768}}`))
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("seed vd #%d POST status: got %d, want 200", i, resp.StatusCode)
+		}
+	}
+
+	assertVDNumbers(t, ctx, st, rdName, []int32{0, 1})
+
+	// Delete VD 0 — freeing the lowest number.
+	delResp := httpDelete(t, vdURL+"/0")
+	_ = delResp.Body.Close()
+
+	if delResp.StatusCode != http.StatusOK {
+		t.Fatalf("vd d 0 status: got %d, want 200", delResp.StatusCode)
+	}
+
+	assertVDNumbers(t, ctx, st, rdName, []int32{1})
+
+	// Plain `vd c` (no volume_number) — MUST reuse the freed 0, not
+	// append 2.
+	reuseResp := httpPost(t, vdURL, []byte(`{"volume_definition":{"size_kib":32768}}`))
+	_ = reuseResp.Body.Close()
+
+	if reuseResp.StatusCode != http.StatusOK {
+		t.Fatalf("reuse vd c POST status: got %d, want 200", reuseResp.StatusCode)
+	}
+
+	// The defining assertion: the re-added volume took the freed 0.
+	assertVDNumbers(t, ctx, st, rdName, []int32{0, 1})
+}
+
+// TestCornerA3ExplicitThenPlainGetsSmallestFree drives the A3 sequence:
+// `vd c --vlmnr 5` first (explicit), then a plain `vd c`. The plain
+// create MUST land at 0 (smallest free), NOT 6 (max+1). Pins that the
+// explicit-create path does not poison the auto-assign allocator into a
+// high-water-mark mode.
+func TestCornerA3ExplicitThenPlainGetsSmallestFree(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	const rdName = "pvc-corner-a3-explicit"
+
+	err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rdName})
+	if err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	vdURL := base + "/v1/resource-definitions/" + rdName + "/volume-definitions"
+
+	// First create with an explicit high volume_number.
+	explicitBody, _ := json.Marshal(apiv1.VolumeDefinitionCreate{
+		VolumeDefinition: apiv1.VolumeDefinition{VolumeNumber: 5, SizeKib: 32 * 1024},
+	})
+
+	explicitResp := httpPost(t, vdURL, explicitBody)
+	_ = explicitResp.Body.Close()
+
+	if explicitResp.StatusCode != http.StatusOK {
+		t.Fatalf("explicit vd c --vlmnr 5 status: got %d, want 200", explicitResp.StatusCode)
+	}
+
+	assertVDNumbers(t, ctx, st, rdName, []int32{5})
+
+	// Plain `vd c` — smallest free is 0, NOT 6.
+	plainResp := httpPost(t, vdURL, []byte(`{"volume_definition":{"size_kib":32768}}`))
+	_ = plainResp.Body.Close()
+
+	if plainResp.StatusCode != http.StatusOK {
+		t.Fatalf("plain vd c status: got %d, want 200", plainResp.StatusCode)
+	}
+
+	// 0 and 5 present; 6 absent — the smallest-free rule held.
+	assertVDNumbers(t, ctx, st, rdName, []int32{0, 5})
+}
+
+// assertVDNumbers fails the test unless the VD set under rd is EXACTLY
+// the want list (order-independent). Centralised so the corner-case
+// allocation assertions share one diagnostic shape.
+func assertVDNumbers(t *testing.T, ctx context.Context, st store.Store, rd string, want []int32) {
+	t.Helper()
+
+	vds, err := st.VolumeDefinitions().List(ctx, rd)
+	if err != nil {
+		t.Fatalf("VD list: %v", err)
+	}
+
+	have := map[int32]bool{}
+	for i := range vds {
+		have[vds[i].VolumeNumber] = true
+	}
+
+	if len(have) != len(want) {
+		t.Fatalf("VD count: got %v, want %v", vdNums(vds), want)
+	}
+
+	for _, w := range want {
+		if !have[w] {
+			t.Fatalf("missing VlmNr=%d; have=%v want=%v", w, vdNums(vds), want)
+		}
+	}
+}

--- a/tests/e2e/cli-matrix/vd-number-reuse-after-delete.sh
+++ b/tests/e2e/cli-matrix/vd-number-reuse-after-delete.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# usage: vd-number-reuse-after-delete.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case A2b/A3/A5 (volume-number allocation
+# + single DRBD consistency group).
+#
+# Upstream LINSTOR assigns the SMALLEST FREE volume number on a plain
+# `vd c` (no --vlmnr) and the SMALLEST FREE /dev/drbd<N> minor — it does
+# NOT append max+1. Two operator-observable sequences, verified
+# identical against the upstream Java oracle (piraeus-server v1.33.2):
+#
+#   A2b — reuse after delete: rd with vols 0+1 on 2 diskful replicas,
+#         `vd d 0`, then a plain `vd c` re-takes the freed 0 (NOT 2).
+#         The re-added volume's backing LV is allocated, create-md fires
+#         per-volume, the kernel slot picks it up, and (replica, vol-0)
+#         settles UpToDate.  This exercises the Bug-399 prune path (the
+#         deleted vol-0 must leave Resource.spec.volumes / status.volumes
+#         on every replica) AND the Bug-384 late-add seed path (the
+#         re-added vol-0 must be re-projected + brought UpToDate) in one
+#         shot — a juicy interaction.
+#
+#   A3  — explicit-then-plain: `vd c --vlmnr 5` first, then a plain
+#         `vd c` lands at the smallest free 0 (NOT 6). The explicit-create
+#         must not poison the auto-assign allocator into max+1 mode.
+#
+# L1 pins: pkg/rest/vd_number_reuse_corner_a_test.go
+#   (TestCornerA2bVolumeNumberReusedAfterDelete /
+#    TestCornerA3ExplicitThenPlainGetsSmallestFree).
+# L7 replay: tests/operator-harness/replay/vd-number-reuse-after-delete.yaml.
+# This L6 cell is the kernel-truth half — only the real stand can observe
+# the re-added vol-0 reaching UpToDate and the rendered DRBD minor.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cli-matrix-vd-reuse
+POOL=${POOL:-lvm-thin}
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> pre-flight: 2 healthy $POOL SPs"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+ok_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( ok_nodes < 2 )); then
+    echo "SKIP: $POOL SP not on >=2 nodes (got $ok_nodes)"
+    exit 0
+fi
+
+# vd_numbers <rd> — sorted CSV of the VolumeDefinition numbers under rd.
+vd_numbers() {
+    local rd=$1
+    "${LCTL[@]}" --machine-readable volume-definition list --resource-definitions "$rd" 2>/dev/null \
+        | jq -r '
+            [.[]? | .[]?
+                | (.vlm_dfns // .volume_definitions // [])[]
+                | (.volume_number // .vlm_nr // -1)
+            ] | sort | join(",")' 2>/dev/null || echo ""
+}
+
+##############################################################################
+# A2b — reuse after delete
+##############################################################################
+echo ">> [A2b] rd c + vd c (vol-0) + vd c (vol-1)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 64M >/dev/null   # auto-assign → 0
+"${LCTL[@]}" volume-definition create "$RD" 64M >/dev/null   # auto-assign → 1
+
+got=$(vd_numbers "$RD")
+if [[ "$got" != "0,1" ]]; then
+    echo "FAIL [A2b]: after two plain vd c, expected VlmNrs 0,1 — got '$got'" >&2
+    exit 1
+fi
+
+echo ">> [A2b] r c on 2 nodes + wait both volumes UpToDate"
+mapfile -t nodes < <(
+    jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | .[]' <<<"$sp_json" 2>/dev/null
+)
+n1=${nodes[0]}; n2=${nodes[1]}
+"${LCTL[@]}" resource create "$n1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$n2" "$RD" --storage-pool="$POOL" >/dev/null
+wait_uptodate "$RD" "$n1" "$n2" 0
+wait_uptodate "$RD" "$n1" "$n2" 1
+
+echo ">> [A2b] vd d 0 (delete the lowest number, freeing it)"
+"${LCTL[@]}" volume-definition delete "$RD" 0 >/dev/null
+
+# After delete, only vol-1 remains.
+deadline=$(( $(date +%s) + 60 ))
+while (( $(date +%s) < deadline )); do
+    [[ "$(vd_numbers "$RD")" == "1" ]] && break
+    sleep 2
+done
+got=$(vd_numbers "$RD")
+if [[ "$got" != "1" ]]; then
+    echo "FAIL [A2b]: after vd d 0, expected VlmNrs '1' — got '$got'" >&2
+    exit 1
+fi
+
+echo ">> [A2b] plain vd c — MUST reuse the freed 0 (not append 2)"
+"${LCTL[@]}" volume-definition create "$RD" 64M >/dev/null
+
+deadline=$(( $(date +%s) + 60 ))
+while (( $(date +%s) < deadline )); do
+    [[ "$(vd_numbers "$RD")" == "0,1" ]] && break
+    sleep 2
+done
+got=$(vd_numbers "$RD")
+if [[ "$got" != "0,1" ]]; then
+    echo "FAIL [A2b]: plain vd c after vd d 0 must re-take 0 (smallest free); got VlmNrs '$got'" >&2
+    echo "   upstream LINSTOR reuses the lowest free number, never max+1." >&2
+    exit 1
+fi
+
+echo ">> [A2b] kernel-truth: re-added vol-0 reaches UpToDate on both replicas"
+# This is the Bug-399-prune + Bug-384-late-add interaction: the deleted
+# vol-0 had to leave every replica's projected volume set, and the
+# re-added vol-0 has to be seeded + create-md'd + brought UpToDate.
+wait_uptodate "$RD" "$n1" "$n2" 0
+wait_uptodate "$RD" "$n1" "$n2" 1
+
+# Defensive: the re-added vol-0 must NOT be stuck Diskless on either
+# DISKFUL replica (the late-add seed path must allocate its backing LV).
+# Use the k8s-native LOCAL disk-state reader, NOT a `drbdsetup status`
+# grep: an auto-spawned TieBreaker (diskless witness on a third node)
+# legitimately shows `peer-disk:Diskless` in drbdsetup output and would
+# false-positive a naive grep. status_disk_state reads THIS replica's
+# own kernel disk-state off Resource.Status.volumes[].diskState.
+for dn in "$n1" "$n2"; do
+    ds=$(status_disk_state "$RD" "$dn" 0)
+    if [[ "$ds" == "Diskless" ]]; then
+        echo "FAIL [A2b]: re-added vol-0 stuck Diskless on diskful node $dn (late-add seed regression)" >&2
+        on_node "$dn" drbdsetup status "$RD" >&2 2>/dev/null || true
+        exit 1
+    fi
+done
+
+echo ">> [A2b] OK — vd d 0 freed the number, plain vd c re-took 0, converged UpToDate"
+
+##############################################################################
+# A3 — explicit --vlmnr 5, then plain vd c → smallest free 0 (not 6)
+##############################################################################
+RD2=cli-matrix-vd-explicit
+echo ">> [A3] rd c + vd c --vlmnr 5 + plain vd c"
+"${LCTL[@]}" resource-definition create "$RD2" >/dev/null
+"${LCTL[@]}" volume-definition create --vlmnr 5 "$RD2" 64M >/dev/null   # explicit → 5
+"${LCTL[@]}" volume-definition create "$RD2" 64M >/dev/null            # plain → 0
+
+got=$(vd_numbers "$RD2")
+if [[ "$got" != "0,5" ]]; then
+    echo "FAIL [A3]: vd c --vlmnr 5 then plain vd c must yield VlmNrs 0,5 (smallest free), not 5,6 — got '$got'" >&2
+    delete_rd "$RD2" || true
+    exit 1
+fi
+echo ">> [A3] OK — plain vd c after explicit --vlmnr 5 landed at smallest free 0"
+
+delete_rd "$RD2"
+assert_no_orphans "$RD2"
+
+##############################################################################
+# A5 — multiple VDs land in ONE .res as multiple volume{} blocks (a single
+# DRBD consistency group), NOT one resource per volume.
+#
+# Upstream LINSTOR renders one DRBD `resource <rd> { }` per RD with N
+# nested `volume <N> { }` blocks inside each node's `on { }` stanza — all
+# volumes of an RD share one DRBD connection / consistency group.
+# blockstor's renderresfile must do the same. We assert it against the
+# rendered .res on a diskful node (the artifact handed to `drbdadm
+# adjust`). Convergence is gated by the k8s-native wait_uptodate
+# (status_disk_state + kernel ground truth), NOT the `r l -m` .vlms wire
+# field whose per-volume disk_state lags on a freshly-placed RD.
+##############################################################################
+RD3=cli-matrix-vd-onegroup
+echo ">> [A5] rd c + 3x vd c (vols 0,1,2) on 2 diskful replicas"
+"${LCTL[@]}" resource-definition create "$RD3" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD3" 64M >/dev/null   # 0
+"${LCTL[@]}" volume-definition create "$RD3" 64M >/dev/null   # 1
+"${LCTL[@]}" volume-definition create "$RD3" 64M >/dev/null   # 2
+
+got=$(vd_numbers "$RD3")
+if [[ "$got" != "0,1,2" ]]; then
+    echo "FAIL [A5]: expected VlmNrs 0,1,2 — got '$got'" >&2
+    delete_rd "$RD3" || true
+    exit 1
+fi
+
+"${LCTL[@]}" resource create "$n1" "$RD3" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$n2" "$RD3" --storage-pool="$POOL" >/dev/null
+for v in 0 1 2; do
+    wait_uptodate "$RD3" "$n1" "$n2" "$v"
+done
+
+echo ">> [A5] rendered .res: 3 VDs => 3 distinct volume{} blocks in ONE resource{}"
+# Resolve the satellite --state-dir from the running pod's args so the
+# assertion works whether the deployment uses the binary default
+# (/var/lib/blockstor-satellite) or the stand's override (/etc/drbd.d).
+RES_DIR=${RES_DIR:-$(
+    kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o jsonpath='{.items[0].spec.containers[*].args}' 2>/dev/null \
+        | tr ' ,[]"' '\n' | sed -n 's/^--state-dir=//p' | head -1
+)}
+RES_DIR=${RES_DIR:-/etc/drbd.d}
+res_file="$RES_DIR/$RD3.res"
+echo ">> [A5] reading rendered res file: $res_file (state-dir=$RES_DIR)"
+if res_out=$(on_node "$n1" cat "$res_file" 2>&1); then
+    echo "$res_out"
+    # The .res emits one `volume <N> { }` stanza per (node, volume), so
+    # for a 3-volume RD on 2 diskful nodes the raw count is 6. Reduce to
+    # the DISTINCT volume numbers — must be exactly 0,1,2.
+    distinct_vols=$(grep -oE 'volume[[:space:]]+[0-9]+[[:space:]]*\{' <<<"$res_out" \
+        | grep -oE '[0-9]+' | sort -un | tr '\n' ',' | sed 's/,$//')
+    # Exactly ONE top-level `resource <rd> {` stanza — not one per volume.
+    res_blocks=$(grep -cE '^resource[[:space:]]+"?'"$RD3"'"?[[:space:]]*\{' <<<"$res_out" || true)
+
+    if [[ "$distinct_vols" != "0,1,2" ]]; then
+        echo "FAIL [A5]: expected distinct volume blocks 0,1,2 in $res_file, got '$distinct_vols'" >&2
+        echo "   All VDs of an RD must share ONE DRBD resource / consistency group." >&2
+        delete_rd "$RD3" || true
+        exit 1
+    fi
+    if (( res_blocks != 1 )); then
+        echo "FAIL [A5]: expected exactly 1 'resource $RD3 {' stanza in $res_file, got $res_blocks" >&2
+        echo "   Multiple volumes must NOT be split across separate DRBD resources." >&2
+        delete_rd "$RD3" || true
+        exit 1
+    fi
+    echo ">> [A5] OK — $RD3 renders 1 resource{} with volume blocks $distinct_vols, one consistency group"
+else
+    echo "SKIP-PARTIAL [A5]: cat $res_file on $n1 failed; VlmNr-set + UpToDate pins still asserted"
+fi
+
+delete_rd "$RD3"
+assert_no_orphans "$RD3"
+
+echo ">> vd-number-reuse-after-delete OK (A2b reuse-after-delete + A3 explicit-then-plain + A5 single-consistency-group pinned)"

--- a/tests/operator-harness/replay/vd-number-reuse-after-delete.yaml
+++ b/tests/operator-harness/replay/vd-number-reuse-after-delete.yaml
@@ -1,0 +1,115 @@
+name: vd-number-reuse-after-delete
+description: |
+  Corner-case A2b (volume-number reuse after delete) — operator-level
+  catcher. Upstream LINSTOR assigns the SMALLEST FREE volume number on a
+  plain `vd c` (no --vlmnr): with vols 0+1 present, `vd d 0` frees 0, and
+  the next plain `vd c` re-takes the freed 0 — NOT 2 (max+1). Verified
+  identical against the upstream Java oracle (piraeus-server v1.33.2).
+
+  Sequence:
+    1. rd c + vd c (vol-0) + vd c (vol-1) on 2 diskful replicas.
+    2. Drive BOTH volumes UpToDate.
+    3. `vd d 0` — delete the lowest number, freeing it.
+    4. `vd c` (plain) — MUST re-take the freed 0.
+    5. Assert every Resource converges to EXACTLY the {0,1} volume set
+       (no phantom vol from the delete, the re-added 0 projected onto
+       every replica) AND the re-added vol-0 reaches UpToDate.
+
+  This catcher exercises two fix paths in one shot:
+
+    - Bug-399 prune (REMOVE side): `vd d 0` must drop vol-0 from every
+      replica's Resource.spec.volumes + status.volumes. A stale entry
+      would leave the converged set as a superset of {1} after step 3,
+      or a phantom in status after the re-add.
+
+    - Bug-384 late-add seed (ADD side): the re-added vol-0 must be
+      re-projected onto every diskful replica, get its backing LV +
+      per-volume create-md, and reach UpToDate. A regression here leaves
+      the re-added vol-0 Unintentional-Diskless and all_uptodate fails.
+
+  The volumes_settled await is the no-flap gate: after the re-add settles
+  the per-replica status.volumes SET is EXACTLY {0,1} and byte-stable
+  across the poll window. all_uptodate confirms the re-added vol-0
+  actually converged (not just projected). The smallest-free allocation
+  rule itself (0 reused, not 2) is pinned at L1
+  (pkg/rest/vd_number_reuse_corner_a_test.go) and at L6
+  (tests/e2e/cli-matrix/vd-number-reuse-after-delete.sh, which asserts
+  the exact VlmNr set off `vd l`).
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vol0
+    # 64M: A2b is a deterministic allocation/projection property, not a
+    # sync-timing race — size-independent. Small volume converges in
+    # seconds on the I/O-constrained stand.
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: create-vol1
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: wait-both-volumes-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: vd-d-vol0
+    # Delete the LOWEST number so the freed slot is 0. Every replica must
+    # converge to exactly [1] (Bug-399 prune of the remove side).
+    cmd: ["volume-definition", "delete", "{{rd}}", "0"]
+    expect_exit: 0
+    await:
+      kind: volumes_settled
+      rd: "{{rd}}"
+      expected: "1"
+      settle_s: 8
+      polls: 5
+      timeout_s: 120
+  - name: vd-c-reuse-0
+    # THE A2b PROPERTY: a plain `vd c` after `vd d 0` re-takes the freed
+    # 0 (smallest free), NOT 2. The re-added vol-0 must be re-seeded onto
+    # every diskful replica (Bug-384 late-add) and reach UpToDate.
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+    await:
+      # spec.volumes + status.volumes converge to EXACTLY {0,1} on every
+      # replica with no flap: the re-added 0 is projected (not a phantom)
+      # and the surviving 1 is retained.
+      kind: volumes_settled
+      rd: "{{rd}}"
+      expected: "0,1"
+      settle_s: 8
+      polls: 5
+      timeout_s: 180
+  - name: wait-reused-vol0-uptodate
+    # Kernel-truth: the re-added vol-0 actually converged, not merely
+    # projected. A Bug-384 late-add regression leaves it Diskless and
+    # this fails.
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

Closes corner-case campaign items **A2b, A3, A4, A5** (volume-number allocation + DRBD consistency group). The investigation found blockstor's volume-number and DRBD-minor allocators **already match upstream LINSTOR** — this PR is test-only (L1 + L6 + L7) plus one documented deliberate-delta row. No production code changes were required.

### Verdict

| Item | Property | Verdict | Evidence |
|------|----------|---------|----------|
| **A2b** | reuse after `vd d 0`: rd with vols 0+1, delete 0, plain `vd c` re-takes the freed **0** (not 2) | **MATCHES** upstream | Oracle diff: `BS reuse=[0,1]` == `UP reuse=[0,1]`. Smallest-free allocator: `autoAssignVolumeNumber` (pkg/rest/volume_definitions.go) |
| **A3** | `vd c --vlmnr 5` then plain `vd c` lands at **0** (smallest free, not 6) | **MATCHES** upstream | Oracle diff: `BS=[0,5]` == `UP=[0,5]` |
| **A4** | shrink contract: upstream allows `vd set-size` downward since 1.8.0 for supporting layers; BS rejects all shrinks unless `force=true` | **DELIBERATE DELTA** (whitelisted) | New row in `docs/cli-parity-known-deltas.md`; pinned by existing L1 + L6 + L7 |
| **A5** | two/more VDs land in ONE `.res` as multiple `volume{}` blocks (one DRBD consistency group), not one resource per volume | **MATCHES** upstream | Rendered `.res` on stand: one `resource <rd> {` with `volume 0/1/2` blocks, distinct minors 20002/20003/20004 |

## What changed

- **L1** `pkg/rest/vd_number_reuse_corner_a_test.go` — drives A2b (delete→recreate) and A3 (explicit→plain) through the live REST VD CRUD handlers. Bug 191 only pinned the pre-seeded-gap variant; these exercise the DELETE + explicit-create paths so a regression to a max+1 high-water-mark is caught.
- **L6** `tests/e2e/cli-matrix/vd-number-reuse-after-delete.sh` — operator-CLI cell for A2b/A3/A5 on real DRBD. A2b exercises the Bug-399 prune (deleted vol-0 leaves every replica's projected set) and the Bug-384 late-add seed (re-added vol-0 reaches UpToDate) in one shot. A5 asserts the rendered `.res` is a single consistency group.
- **L7** `tests/operator-harness/replay/vd-number-reuse-after-delete.yaml` — replay codifying the A2b operator sequence with `volumes_settled` + `all_uptodate` convergence gates.
- **Docs** `docs/cli-parity-known-deltas.md` — A4 shrink-reject deliberate-delta row.

## Stand validation (live dev stand, real DRBD)

L6 cell PASS:
```
>> [A2b] OK — vd d 0 freed the number, plain vd c re-took 0, converged UpToDate
>> [A3] OK — plain vd c after explicit --vlmnr 5 landed at smallest free 0
>> [A5] OK — cli-matrix-vd-onegroup renders 1 resource{} with volume blocks 0,1,2, one consistency group
## vd-number-reuse-after-delete EXIT=0
```

L7 replay PASS:
```
PASS: vd-number-reuse-after-delete
```

Oracle diff (BS vs upstream piraeus-server 1.33.2, identical):
```
BS_A2b: before=[0,1] afterdel=[1] reuse=[0,1]
UP_A2b: before=[0,1] afterdel=[1] reuse=[0,1]
BS_A3: explicit5_then_plain=[0,5]
UP_A3: explicit5_then_plain=[0,5]
```

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run` — 0 new issues
- [x] L6 cli-matrix cell PASS on stand
- [x] L7 replay PASS on stand
- [x] Oracle behavior diff confirms MATCHES for A2b/A3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented a known CLI parity delta: volume shrink operations require explicit `force=true` opt-in via request body or query parameter.

* **Tests**
  * Added corner-case tests for volume-number allocation and reuse semantics.
  * Added end-to-end CLI matrix test script validating volume-number reuse scenarios.
  * Added replay scenario configuration for volume-number reuse validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->