### PR TITLE
fix(node): guard EVICTED delete and AutoplaceTarget placement (corner F)

### DIFF
--- a/internal/controller/corner_f2_evacuate_no_candidate_test.go
+++ b/internal/controller/corner_f2_evacuate_no_candidate_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestNodeReconciler_EvictedNoCandidateKeepsSource pins corner-case F2
+// (UG9 §"Evacuating a node" — no replacement target available): when
+// every healthy node already hosts a diskful replica (place_count ==
+// node count), evacuating one node has nowhere to migrate the displaced
+// replica. Upstream LINSTOR warns and LEAVES the replicas in place — the
+// node hangs in EVACUATE and redundancy never drops.
+//
+// blockstor must mirror that fail-safe: the eviction reconciler's
+// add-before-drop gate (evacuationReplacementReady) requires
+// place_count diskful replicas UpToDate on NON-evacuated peers before
+// the source is pruned. With place_count=3 and one of the three nodes
+// evicted, only 2 healthy peers can ever be UpToDate, so the gate never
+// passes and the source on the evacuated node MUST survive. Pruning it
+// would be a drop-without-add that lowers redundancy from 3 to 2 with no
+// replacement — exactly the data-availability hazard F2 guards against.
+//
+// 3 nodes, 3 diskful replicas (n1+n2+n3), RG place_count=3, n1 EVICTED:
+// after reconcile the source on n1 is STILL present.
+func TestNodeReconciler_EvictedNoCandidateKeepsSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+
+	st := store.NewInMemory()
+
+	for _, name := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{Name: name, Type: apiv1.NodeTypeSatellite}); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: "pool",
+			NodeName:        name,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool: %v", err)
+		}
+	}
+
+	// place_count == 3 == node count: the cluster is already full, so an
+	// evacuation has no spare node to land a replacement on.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  3,
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "pvc-1",
+		ResourceGroupName: "rg",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	for _, node := range []string{"n1", "n2", "n3"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-1", NodeName: node}); err != nil {
+			t.Fatalf("seed resource: %v", err)
+		}
+	}
+
+	// Flag n1 EVICTED in the store.
+	if err := st.Nodes().Update(ctx, &apiv1.Node{
+		Name:  "n1",
+		Type:  apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("flag n1 evicted: %v", err)
+	}
+
+	// Resource CRDs for all three replicas. n2 + n3 are healthy and
+	// UpToDate; if pruning were (wrongly) gated on "place_count peers
+	// UpToDate" counting the evacuated node, the 2 healthy peers would
+	// fall one short of place_count=3 and the source must stay.
+	srcCRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n1",
+		},
+	}
+	n2CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n2"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n2",
+		},
+	}
+	n3CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n3"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n3",
+		},
+	}
+	nodeCRD := &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: blockstoriov1alpha1.NodeSpec{
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: []string{apiv1.NodeFlagEvicted},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Resource{}).
+		WithObjects(nodeCRD, srcCRD, n2CRD, n3CRD).
+		Build()
+
+	for _, crd := range []*blockstoriov1alpha1.Resource{n2CRD, n3CRD} {
+		crd.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+			{VolumeNumber: 0, DiskState: "UpToDate"},
+		}
+		if err := cli.Status().Update(ctx, crd); err != nil {
+			t.Fatalf("status update %s: %v", crd.Name, err)
+		}
+	}
+
+	rec := &controllerpkg.NodeReconciler{Client: cli, Scheme: scheme, Store: st}
+
+	// Reconcile a few times to be sure no eventual prune slips through.
+	for i := range 3 {
+		_, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}})
+		if err != nil {
+			t.Fatalf("Reconcile (pass %d): %v", i, err)
+		}
+	}
+
+	// THE F2 ASSERTION: the source replica on the evacuated node is STILL
+	// present and NOT marked for deletion. No candidate target existed,
+	// so redundancy must not be lowered by a drop-without-add.
+	srcAfter := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n1"}, srcAfter); err != nil {
+		t.Fatalf("[F2] source replica on evacuated node was pruned with no replacement available "+
+			"(drop-without-add — redundancy lowered): %v", err)
+	}
+
+	if !srcAfter.DeletionTimestamp.IsZero() {
+		t.Fatalf("[F2] source replica on evacuated node marked for deletion with no replacement "+
+			"available: %+v", srcAfter)
+	}
+
+	// No replacement should have been created — there is no free node.
+	// The store still holds exactly 3 diskful replicas (n1+n2+n3); a 4th
+	// would mean the placer tried to over-place onto a full cluster.
+	replicas, err := st.Resources().ListByDefinition(ctx, "pvc-1")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if len(replicas) != 3 {
+		t.Fatalf("[F2] expected exactly 3 replicas (no replacement on a full cluster), got %d: %+v",
+			len(replicas), replicas)
+	}
+}

--- a/pkg/api/v1/props.go
+++ b/pkg/api/v1/props.go
@@ -77,6 +77,27 @@ const (
 	// on QoS (wave1 7.22) which is out-of-scope. This key is the
 	// SCORING half only.
 	PropAutoplacerMaxThroughput = "Autoplacer/MaxThroughput"
+
+	// PropAutoplaceTarget is the per-Node opt-out from autoplace
+	// targeting. Set `linstor node set-property <node> AutoplaceTarget
+	// false` to keep the autoplacer from choosing the node for NEW
+	// replicas while leaving existing replicas untouched — the
+	// maintenance-drain workflow from
+	// kb.linbit.com/linstor/preventing-linstor-resource-placement-on-a-node.
+	//
+	// Unlike the EVICTED / LOST node flags (which the placer treats as
+	// "disabled" and therefore EXCLUDES existing replicas from the
+	// place_count accounting so the gap is re-filled elsewhere),
+	// AutoplaceTarget=false is a target-selection-only gate: existing
+	// replicas on the node still count toward place_count and are never
+	// migrated. Only the candidate-pool filter consults it.
+	//
+	// Default (prop unset, or any value other than a parseable false)
+	// is "node is an eligible target" — the prop is an opt-OUT. Only an
+	// explicit, parseable false excludes the node; an operator typo
+	// degrades to "still eligible" rather than silently draining the
+	// whole cluster off the node.
+	PropAutoplaceTarget = "AutoplaceTarget"
 )
 
 // ControllerPropsName is the singleton row key for the controller-

--- a/pkg/placer/autoplace_target_test.go
+++ b/pkg/placer/autoplace_target_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placer_test
+
+import (
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/placer"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// seedNodeWithPool registers one satellite node + one LVM_THIN pool with
+// the given free capacity, plus optional props on the node. Mirrors the
+// shape of seedStore but lets a single node carry an AutoplaceTarget
+// prop so the exclusion gate can be exercised in isolation.
+func seedNodeWithPool(t *testing.T, st store.Store, name string, free int64, props map[string]string) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name:  name,
+		Type:  apiv1.NodeTypeSatellite,
+		Props: props,
+	}); err != nil {
+		t.Fatalf("seed node %s: %v", name, err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		NodeName:        name,
+		StoragePoolName: "pool",
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		FreeCapacity:    free,
+		TotalCapacity:   1000,
+	}); err != nil {
+		t.Fatalf("seed pool %s: %v", name, err)
+	}
+}
+
+// TestPlaceSkipsAutoplaceTargetFalseNode pins the F4 contract: a node
+// carrying `AutoplaceTarget=false` is never selected for a NEW replica,
+// even when it has the most free space (and would otherwise be the
+// first pick under the biggest-free-first sort). Two eligible nodes +
+// one AutoplaceTarget=false node, place_count=3 → only 2 placed, none
+// on the excluded node. Regression here = the maintenance-drain node
+// silently receives new placements (kb.linbit.com preventing-placement).
+func TestPlaceSkipsAutoplaceTargetFalseNode(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	// n-drain has the LARGEST free space (300) so the only reason it
+	// isn't picked is the AutoplaceTarget=false gate, not the scorer.
+	seedNodeWithPool(t, st, "n1", 100, nil)
+	seedNodeWithPool(t, st, "n2", 200, nil)
+	seedNodeWithPool(t, st, "n-drain", 300, map[string]string{
+		apiv1.PropAutoplaceTarget: "false",
+	})
+
+	p := placer.New(st)
+
+	placed, want, err := p.Place(t.Context(), "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 3})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 2 || want != 3 {
+		t.Errorf("placed/want: got %d/%d, want 2/3 (AutoplaceTarget=false node skipped)", placed, want)
+	}
+
+	got, _ := st.Resources().ListByDefinition(t.Context(), "pvc-1")
+	for _, r := range got {
+		if r.NodeName == "n-drain" {
+			t.Errorf("AutoplaceTarget=false node received a replica: %+v", r)
+		}
+	}
+}
+
+// TestPlaceAutoplaceTargetFalseLeavesExistingReplica pins the half of
+// the F4 contract that distinguishes it from EVICTED/LOST: an EXISTING
+// replica on an AutoplaceTarget=false node still counts toward
+// place_count and is NOT migrated. A pre-seeded replica on the
+// excluded node + place_count=2 must result in exactly ONE more
+// replica on a healthy node — total 2, with the excluded node's
+// replica untouched. If the placer treated AutoplaceTarget=false like
+// EVICTED it would drop the existing replica from the count and
+// gap-fill a third one, draining the node — exactly the behaviour the
+// prop is meant to AVOID.
+func TestPlaceAutoplaceTargetFalseLeavesExistingReplica(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	seedNodeWithPool(t, st, "n1", 100, nil)
+	seedNodeWithPool(t, st, "n2", 200, nil)
+	seedNodeWithPool(t, st, "n-drain", 300, map[string]string{
+		apiv1.PropAutoplaceTarget: "false",
+	})
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-1", NodeName: "n-drain",
+		Props: map[string]string{"StorPoolName": "pool"},
+	}); err != nil {
+		t.Fatalf("seed existing: %v", err)
+	}
+
+	p := placer.New(st)
+
+	placed, _, err := p.Place(ctx, "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 2})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 2 {
+		t.Errorf("placed: got %d, want 2 (1 existing on drain node counts + 1 added)", placed)
+	}
+
+	got, _ := st.Resources().ListByDefinition(ctx, "pvc-1")
+	if len(got) != 2 {
+		t.Fatalf("total: got %d, want 2 (existing replica preserved, not migrated); %+v", len(got), got)
+	}
+
+	var onDrain bool
+
+	for _, r := range got {
+		if r.NodeName == "n-drain" {
+			onDrain = true
+		}
+	}
+
+	if !onDrain {
+		t.Errorf("existing replica on AutoplaceTarget=false node was migrated away; %+v", got)
+	}
+}
+
+// TestPlaceAutoplaceTargetTrueAndTypoStayEligible guards the opt-out
+// semantics: only a parseable false excludes the node. AutoplaceTarget
+// set to an explicit "true" — and a fat-fingered non-bool value —
+// both leave the node eligible. Two nodes, one AutoplaceTarget=true and
+// one with a typo value, place_count=2 → both get a replica. A
+// regression that treated "any AutoplaceTarget prop present" as an
+// exclusion would silently drain the cluster off these nodes.
+func TestPlaceAutoplaceTargetTrueAndTypoStayEligible(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+
+	seedNodeWithPool(t, st, "n-true", 200, map[string]string{
+		apiv1.PropAutoplaceTarget: "true",
+	})
+	seedNodeWithPool(t, st, "n-typo", 100, map[string]string{
+		apiv1.PropAutoplaceTarget: "yes-please", // unparseable → not an exclusion
+	})
+
+	p := placer.New(st)
+
+	placed, want, err := p.Place(t.Context(), "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 2})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 2 || want != 2 {
+		t.Errorf("placed/want: got %d/%d, want 2/2 (true + typo both eligible)", placed, want)
+	}
+}

--- a/pkg/placer/placer.go
+++ b/pkg/placer/placer.go
@@ -837,12 +837,27 @@ func (p *Placer) candidatePools(ctx context.Context, filter *apiv1.AutoSelectFil
 		return nil, candidateGates{}, err
 	}
 
+	// Fold AutoplaceTarget=false nodes into the target-exclusion set
+	// used by the candidate-pool filter ONLY. Kept separate from the
+	// EVICTED/LOST `disabled` set on purpose: AutoplaceTarget excludes a
+	// node from NEW placements but leaves existing replicas counting
+	// toward place_count (no migration), whereas `disabled` also drops
+	// existing replicas from the count so the gap is re-filled. Merging
+	// the two for matchesPoolFilter is safe (both forbid landing a new
+	// replica on the node); the divergence only matters for the
+	// existing-replica accounting in countDiskfulReplicas, which keeps
+	// using the EVICTED/LOST-only `disabled` set.
+	excludedTargets, err := p.autoplaceExcludedNodes(ctx, disabled)
+	if err != nil {
+		return nil, candidateGates{}, err
+	}
+
 	ctrlProps, err := p.store.ControllerProps().Get(ctx)
 	if err != nil {
 		return nil, candidateGates{}, errors.Wrap(err, "get controller props")
 	}
 
-	out, gates := applyCapacityAndOversubGates(all, filter, disabled, ctrlProps, minFreeKib)
+	out, gates := applyCapacityAndOversubGates(all, filter, excludedTargets, ctrlProps, minFreeKib)
 
 	weights, err := p.loadWeights(ctx)
 	if err != nil {
@@ -1129,8 +1144,12 @@ func throughputHint(pool *apiv1.StoragePool) float64 {
 
 // matchesPoolFilter is the AutoSelectFilter eligibility check for a
 // single pool: drops the DISKLESS provider kind, drops pools on
-// EVICTED / LOST nodes, and enforces every name-list / provider-list
-// constraint on the filter. Returns true when the pool clears every
+// target-excluded nodes (the EVICTED / LOST `disabled` set plus
+// `AutoplaceTarget=false` nodes — see autoplaceExcludedNodes), and
+// enforces every name-list / provider-list constraint on the filter.
+// The `disabled` map the caller passes here is the target-exclusion
+// set, NOT the EVICTED/LOST-only set used for existing-replica
+// accounting. Returns true when the pool clears every
 // non-capacity gate; the capacity gate stays in candidatePools so it
 // can also track the largest rejected FreeCapacity for the error
 // envelope. Split out to keep candidatePools under the gocyclo budget.
@@ -1219,6 +1238,46 @@ func (p *Placer) disabledNodes(ctx context.Context) (map[string]struct{}, error)
 
 				break
 			}
+		}
+	}
+
+	return out, nil
+}
+
+// autoplaceExcludedNodes returns the set of nodes that may not host a
+// NEW replica: the EVICTED / LOST `disabled` set plus every node whose
+// `AutoplaceTarget` prop parses to an explicit false. The returned map
+// is a fresh copy so the caller's `disabled` set (used for the
+// existing-replica accounting in countDiskfulReplicas, which must NOT
+// pick up the AutoplaceTarget exclusion) stays untouched.
+//
+// AutoplaceTarget is the maintenance-drain opt-out
+// (kb.linbit.com/linstor/preventing-linstor-resource-placement-on-a-node):
+// existing replicas on the node are left alone and still count toward
+// place_count, but the autoplacer never selects the node for a new
+// replica. Only a parseable false excludes the node — any other value
+// (true, unset, an operator typo) keeps the node eligible, so a
+// fat-fingered prop can never silently drain the cluster off the node.
+func (p *Placer) autoplaceExcludedNodes(ctx context.Context, disabled map[string]struct{}) (map[string]struct{}, error) {
+	nodes, err := p.store.Nodes().List(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "list nodes")
+	}
+
+	out := make(map[string]struct{}, len(disabled)+len(nodes))
+	for name := range disabled {
+		out[name] = struct{}{}
+	}
+
+	for i := range nodes {
+		raw, ok := nodes[i].Props[apiv1.PropAutoplaceTarget]
+		if !ok {
+			continue
+		}
+
+		v, perr := strconv.ParseBool(raw)
+		if perr == nil && !v {
+			out[nodes[i].Name] = struct{}{}
 		}
 	}
 

--- a/pkg/rest/node_delete_evicted_test.go
+++ b/pkg/rest/node_delete_evicted_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// TestNodeDeleteRefusedWhenEvicted pins corner-case F6: a plain
+// `node delete` on an EVICTED (draining) node is refused with 409 so
+// the operator chooses explicitly between `node restore` and
+// `node lost`. The node carries NO resources / pools — the refusal is
+// driven purely by the EVICTED latched state, not by the Bug 92 / 179
+// reference gate. Without this gate a bare `n d` would race the
+// in-flight eviction migration and silently discard the restore-or-lost
+// decision.
+func TestNodeDeleteRefusedWhenEvicted(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name:  "drain1",
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed evicted node: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/nodes/drain1")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	low := strings.ToLower(string(body))
+
+	if !strings.Contains(low, "evicted") {
+		t.Errorf("body: missing 'EVICTED' explanation; got %q", string(body))
+	}
+
+	// Both sanctioned exits must be named so the operator knows the path.
+	if !strings.Contains(low, "node restore") {
+		t.Errorf("body: missing 'node restore' guidance; got %q", string(body))
+	}
+
+	if !strings.Contains(low, "node lost") {
+		t.Errorf("body: missing 'node lost' guidance; got %q", string(body))
+	}
+
+	// The node must still exist — a refused delete does not half-apply.
+	if _, err := st.Nodes().Get(ctx, "drain1"); err != nil {
+		t.Errorf("node deleted despite refusal: %v", err)
+	}
+}
+
+// TestNodeDeleteEvictedForcedSucceeds pins the F6 escape hatch:
+// ?force=true overrides the EVICTED latch (it already cascades orphans),
+// matching the Bug 92 / Bug 179 disaster-recovery precedent on this same
+// handler. The node is actually removed.
+func TestNodeDeleteEvictedForcedSucceeds(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{
+		Name:  "drain2",
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("seed evicted node: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/nodes/drain2?force=true")
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	if _, err := st.Nodes().Get(ctx, "drain2"); err == nil {
+		t.Errorf("node still present after force-delete of EVICTED node")
+	}
+}
+
+// TestNodeDeleteUnevictedStillSucceeds guards against the F6 gate
+// over-reaching: a plain, NON-EVICTED node with no references must
+// still delete cleanly. A regression that rejected every `n d` (e.g.
+// matching on the wrong flag) would brick the normal node-teardown
+// path.
+func TestNodeDeleteUnevictedStillSucceeds(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "idle1"}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/nodes/idle1")
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	if _, err := st.Nodes().Get(ctx, "idle1"); err == nil {
+		t.Errorf("non-evicted node not deleted")
+	}
+}

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -24,6 +24,7 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1089,6 +1090,22 @@ func (s *Server) handleNodeDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Corner-case F6 (UG9 §"Auto-evict" / EVICTED latched state):
+	// EVICTED is a one-way drain mark. Upstream LINSTOR refuses a plain
+	// `node delete` on an EVICTED node — the operator must decide
+	// EXPLICITLY between `node restore` (cancel the drain, the node
+	// keeps its SP / props / resources) and `node lost` (the node is
+	// gone for good, cascade its orphans). A bare `n d` on an EVICTED
+	// node would race the in-flight migration cascade the NodeReconciler
+	// is driving (add-before-drop) and silently discard that decision,
+	// so we reject it with 409 + FAIL_IN_USE and point at the two
+	// sanctioned exits. `?force=true` keeps the disaster-recovery
+	// override (it already cascades orphans above), matching the Bug 92
+	// / Bug 179 escape-hatch precedent on this same handler.
+	if !force && s.refuseNodeDeleteIfEvicted(ctx, w, name) {
+		return
+	}
+
 	(&deleteWithRollback[apiv1.Node]{
 		refuseIfReferenced: func() bool {
 			if force {
@@ -1152,6 +1169,53 @@ func (s *Server) refuseNodeDeleteIfReferenced(w http.ResponseWriter, r *http.Req
 	}
 
 	writeJSON(w, http.StatusConflict, buildNodeDeleteRefusal(name, resourceRefs, spRefs))
+
+	return true
+}
+
+// refuseNodeDeleteIfEvicted is the corner-case F6 latched-state gate.
+// Returns true (HTTP 409 already written, caller must stop) when the
+// node carries the EVICTED flag — a plain `node delete` on a draining
+// node is refused so the operator chooses explicitly between
+// `node restore` and `node lost`. Returns false (proceed) for a node
+// that is not EVICTED, or that no longer exists (the parent handler's
+// idempotent-delete replay path writes the warn envelope itself).
+//
+// A LOST-flagged node is NOT caught here: LOST already means "gone for
+// good" and a delete of a LOST node is the natural cleanup, so only the
+// soft EVICTED drain mark latches the delete.
+func (s *Server) refuseNodeDeleteIfEvicted(ctx context.Context, w http.ResponseWriter, name string) bool {
+	node, err := s.Store.Nodes().Get(ctx, name)
+	if err != nil {
+		// NotFound → let the parent's idempotent-delete path handle it
+		// (warn envelope). Any other error surfaces as a store error.
+		if errors.Is(err, store.ErrNotFound) {
+			return false
+		}
+
+		writeStoreError(w, err)
+
+		return true
+	}
+
+	if !slices.Contains(node.Flags, apiv1.NodeFlagEvicted) {
+		return false
+	}
+
+	writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInUse,
+		Message: "Node '" + name + "' cannot be deleted while it is " +
+			"EVICTED (draining).",
+		Cause: "the node is in the EVICTED state; a plain delete would " +
+			"race the in-flight eviction migration and discard the " +
+			"restore-or-lost decision",
+		Correc: "use `linstor node restore " + name + "` to cancel the " +
+			"drain (the node keeps its storage pools, properties and " +
+			"resources), or `linstor node lost " + name + "` to remove a " +
+			"node that is gone for good; pass `?force=true` to delete it " +
+			"anyway and cascade the orphans",
+		ObjRefs: map[string]string{objRefNode: name},
+	}})
 
 	return true
 }

--- a/tests/e2e/cli-matrix/n-autoplace-target-excludes.sh
+++ b/tests/e2e/cli-matrix/n-autoplace-target-excludes.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# usage: n-autoplace-target-excludes.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case F4 (UG9 §"AutoplaceTarget";
+# kb.linbit.com/linstor/preventing-linstor-resource-placement-on-a-node).
+#
+# `linstor node set-property <node> AutoplaceTarget false` excludes the
+# node from autoplace TARGETING: the autoplacer must never pick it for a
+# NEW replica, but existing replicas stay put (no migration). This is the
+# maintenance-drain workflow — stop new placements without evicting.
+#
+# Pre-fix blockstor behaviour: the placer's only node-exclusion was the
+# EVICTED / LOST flag set; the per-node AutoplaceTarget prop was never
+# consulted, so a drained maintenance node kept receiving new replicas.
+#
+# This cell drives the real CLI against a 3-node stand:
+#   1. node set-property <drain> AutoplaceTarget false.
+#   2. spawn several rd c + vd c + rd ap --place-count 2.
+#   3. assert: zero replicas land on the drained node.
+#   4. clear the prop, spawn one more, assert it CAN land there again.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+POOL=${POOL:-lvm-thin}
+PREFIX=ccf-aptgt
+DRAIN_NODE=""
+RDS=()
+
+cleanup() {
+    # Clear the prop first so a leaked AutoplaceTarget=false can't strand
+    # the next cell's placements on this node.
+    if [[ -n "$DRAIN_NODE" ]]; then
+        "${LCTL[@]}" node set-property "$DRAIN_NODE" AutoplaceTarget true >/dev/null 2>&1 || true
+    fi
+    for rd in "${RDS[@]}"; do
+        delete_rd "$rd"
+        assert_no_orphans "$rd"
+    done
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Pre-flight: need the named pool on at least 3 nodes so autoplace=2
+# still has a free non-drain node to choose between.
+echo ">> pre-flight: 3 healthy $POOL SPs"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+mapfile -t pool_nodes < <(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | .[]' <<<"$sp_json" 2>/dev/null)
+if (( ${#pool_nodes[@]} < 3 )); then
+    echo "SKIP: $POOL SP not on 3 nodes (got ${#pool_nodes[@]}) — F4 fixture not available"
+    exit 0
+fi
+
+DRAIN_NODE="${pool_nodes[0]}"
+echo ">> [F4] draining target: $DRAIN_NODE (AutoplaceTarget=false)"
+"${LCTL[@]}" node set-property "$DRAIN_NODE" AutoplaceTarget false >/dev/null
+
+echo ">> [F4] spawn 4 RDs autoplace=2, none must land on $DRAIN_NODE"
+for i in 1 2 3 4; do
+    rd="${PREFIX}-${i}"
+    RDS+=("$rd")
+    "${LCTL[@]}" resource-definition create "$rd" >/dev/null
+    "${LCTL[@]}" volume-definition create "$rd" 256M >/dev/null
+    "${LCTL[@]}" resource create --auto-place=2 --storage-pool="$POOL" "$rd" >/dev/null
+    wait_replica_count "$rd" 2 90
+done
+
+echo ">> [F4] assert zero replicas on $DRAIN_NODE"
+for rd in "${RDS[@]}"; do
+    mapfile -t nodes < <(linstor_diskful_nodes "$rd")
+    for n in "${nodes[@]}"; do
+        if [[ "$n" == "$DRAIN_NODE" ]]; then
+            die "[F4 REGRESSION] $rd placed a replica on AutoplaceTarget=false node $DRAIN_NODE: ${nodes[*]}"
+        fi
+    done
+done
+echo "   OK: all ${#RDS[@]} RDs avoided $DRAIN_NODE"
+
+echo ">> [F4] clear the prop; a fresh autoplace=3 must now use $DRAIN_NODE"
+"${LCTL[@]}" node set-property "$DRAIN_NODE" AutoplaceTarget true >/dev/null
+rd="${PREFIX}-restore"
+RDS+=("$rd")
+"${LCTL[@]}" resource-definition create "$rd" >/dev/null
+"${LCTL[@]}" volume-definition create "$rd" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=3 --storage-pool="$POOL" "$rd" >/dev/null
+wait_replica_count "$rd" 3 90
+
+mapfile -t nodes < <(linstor_diskful_nodes "$rd")
+on_drain=false
+for n in "${nodes[@]}"; do
+    if [[ "$n" == "$DRAIN_NODE" ]]; then
+        on_drain=true
+    fi
+done
+if ! $on_drain; then
+    die "[F4] after clearing AutoplaceTarget, place-count=3 still skipped $DRAIN_NODE: ${nodes[*]}"
+fi
+
+echo ">> n-autoplace-target-excludes OK (F4 pinned: AutoplaceTarget=false excludes node, true re-includes it)"

--- a/tests/e2e/cli-matrix/n-d-evicted-rejected.sh
+++ b/tests/e2e/cli-matrix/n-d-evicted-rejected.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# usage: n-d-evicted-rejected.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case F6 (UG9 §"Auto-evict" / EVICTED
+# latched state).
+#
+# EVICTED is a one-way drain mark. A plain `linstor node delete` on an
+# EVICTED node must be REJECTED: the operator has to choose explicitly
+# between `node restore` (cancel the drain, keep SP / props / resources)
+# and `node lost` (the node is gone for good). A bare `n d` would race
+# the in-flight eviction migration and discard that decision.
+#
+# Pre-fix blockstor: `n d` only refused on outstanding Resource / SP
+# references, so once the eviction reconciler had drained the node it
+# would silently succeed — bypassing the restore-or-lost decision.
+#
+# This cell drives the real CLI against a 3-node stand:
+#   1. rd c + vd c + r c --auto-place=2.
+#   2. node evacuate <one diskful node>  -> node enters EVICTED.
+#   3. node delete <evicted node>        -> MUST fail (non-zero exit).
+#   4. node restore <node>               -> clears EVICTED, node usable.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=ccf-nd-evicted
+POOL=${POOL:-lvm-thin}
+EVAC_NODE=""
+
+cleanup() {
+    # Always clear the EVICTED flag so the node is left usable for the
+    # next cell, whatever happened above.
+    if [[ -n "$EVAC_NODE" ]]; then
+        "${LCTL[@]}" node restore "$EVAC_NODE" >/dev/null 2>&1 || true
+    fi
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> pre-flight: 3 healthy $POOL SPs"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+ok_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( ok_nodes < 3 )); then
+    echo "SKIP: $POOL SP not on 3 nodes (got $ok_nodes) — F6 fixture not available"
+    exit 0
+fi
+
+echo ">> [F6] rd c + vd c + r c --auto-place=2 -s $POOL"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 256M >/dev/null
+"${LCTL[@]}" resource create --auto-place=2 --storage-pool="$POOL" "$RD" >/dev/null
+wait_replica_count "$RD" 2 90
+
+mapfile -t diskful < <(linstor_diskful_nodes "$RD")
+if (( ${#diskful[@]} < 2 )); then
+    die "[F6] expected 2 diskful replicas after autoplace=2, got ${#diskful[@]}: ${diskful[*]}"
+fi
+
+EVAC_NODE="${diskful[0]}"
+echo ">> [F6] node evacuate $EVAC_NODE (enters EVICTED)"
+"${LCTL[@]}" node evacuate "$EVAC_NODE" >/dev/null
+
+# Give the controller a moment to stamp the EVICTED flag on the Node CRD.
+deadline=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get node.blockstor.cozystack.io "$EVAC_NODE" -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$flags" == *EVICTED* ]]; then
+        break
+    fi
+    sleep 2
+done
+if [[ "$flags" != *EVICTED* ]]; then
+    die "[F6] node $EVAC_NODE never reached EVICTED state (flags=$flags)"
+fi
+
+echo ">> [F6] node delete $EVAC_NODE — MUST be rejected"
+set +e
+out=$("${LCTL[@]}" node delete "$EVAC_NODE" 2>&1)
+rc=$?
+set -e
+printf '   %s\n' "$out"
+if (( rc == 0 )); then
+    die "[F6 REGRESSION] node delete of EVICTED node $EVAC_NODE SUCCEEDED — latched-state contract violated"
+fi
+if ! grep -qi "evicted" <<<"$out"; then
+    die "[F6] node delete rejection did not mention EVICTED state; got: $out"
+fi
+echo "   OK: rejected (rc=$rc), message names the EVICTED state"
+
+echo ">> [F6] node restore $EVAC_NODE clears EVICTED"
+"${LCTL[@]}" node restore "$EVAC_NODE" >/dev/null
+deadline=$(( $(date +%s) + 30 ))
+while (( $(date +%s) < deadline )); do
+    flags=$(kubectl get node.blockstor.cozystack.io "$EVAC_NODE" -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+    if [[ "$flags" != *EVICTED* ]]; then
+        break
+    fi
+    sleep 2
+done
+if [[ "$flags" == *EVICTED* ]]; then
+    die "[F6] node $EVAC_NODE still EVICTED after restore (flags=$flags)"
+fi
+EVAC_NODE=""  # cleared — cleanup needn't restore again
+
+echo ">> n-d-evicted-rejected OK (F6 pinned: n d on EVICTED node rejected, restore clears it)"

--- a/tests/operator-harness/replay/n-autoplace-target-excludes.yaml
+++ b/tests/operator-harness/replay/n-autoplace-target-excludes.yaml
@@ -1,0 +1,100 @@
+name: n-autoplace-target-excludes
+description: |
+  Corner-case F4 (UG9 §"AutoplaceTarget";
+  kb.linbit.com/linstor/preventing-linstor-resource-placement-on-a-node):
+  `linstor node set-property <node> AutoplaceTarget false` must exclude
+  the node from autoplace TARGETING — the placer never picks it for a
+  NEW replica — while leaving any existing replica untouched. This is
+  the maintenance-drain workflow: stop new placements without evicting.
+
+  Pre-fix blockstor: the placer's only node-exclusion was the EVICTED /
+  LOST flag set; the per-node AutoplaceTarget prop was never consulted,
+  so a drained maintenance node kept receiving new replicas.
+
+  Scenario (3-node): stamp AutoplaceTarget=false on node1, then
+  autoplace 2 diskful replicas. Assert (after placement settles to 2)
+  that node1 holds NO replica — both copies landed on node2 + node3.
+  Then clear the prop and autoplace a fresh RD with place-count 3:
+  node1 must now receive a replica, proving the exclusion is opt-out
+  and reversible.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: drain-node1-autoplace-target-false
+    cmd: ["node", "set-property", "{{node1}}", "AutoplaceTarget", "false"]
+    expect_exit: 0
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: autoplace-2
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
+    expect_exit: 0
+  - name: wait-two-diskful-placed
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # Placement must settle to 2 diskful BEFORE we assert node1 is
+      # empty — otherwise resource_absent on node1 would pass trivially
+      # before the autoplacer has even run.
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 2
+      timeout_s: 120
+  - name: assert-node1-excluded
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # THE F4 ASSERTION: the AutoplaceTarget=false node never received
+      # a replica — both copies landed on node2 + node3.
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 30
+  - name: assert-both-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 120
+  - name: clear-autoplace-target
+    cmd: ["node", "set-property", "{{node1}}", "AutoplaceTarget", "true"]
+    expect_exit: 0
+  - name: create-rd-restore
+    cmd: ["resource-definition", "create", "{{rd}}-rst"]
+    expect_exit: 0
+  - name: create-vd-restore
+    cmd: ["volume-definition", "create", "{{rd}}-rst", "32M"]
+    expect_exit: 0
+  - name: autoplace-3-uses-node1
+    cmd: ["resource", "create", "--auto-place", "3", "--storage-pool={{sp}}", "{{rd}}-rst"]
+    expect_exit: 0
+  - name: assert-node1-now-included
+    cmd: ["resource", "list", "--resources", "{{rd}}-rst"]
+    expect_exit: 0
+    await:
+      # After clearing the prop, a place-count-3 autoplace must land a
+      # replica on node1 (it reaches UpToDate). Proves the exclusion is
+      # a reversible opt-out, not a sticky flag.
+      kind: disk_state
+      rd: "{{rd}}-rst"
+      node: "{{node1}}"
+      expected: "UpToDate"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["node", "set-property", "{{node1}}", "AutoplaceTarget", "true"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}-rst"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/n-d-evicted-rejected.yaml
+++ b/tests/operator-harness/replay/n-d-evicted-rejected.yaml
@@ -1,0 +1,65 @@
+name: n-d-evicted-rejected
+description: |
+  Corner-case F6 (UG9 §"Auto-evict" / EVICTED latched state): EVICTED is
+  a one-way drain mark. A plain `linstor node delete` on an EVICTED node
+  must be REJECTED so the operator chooses explicitly between
+  `node restore` (cancel the drain, keep SP / props / resources) and
+  `node lost` (the node is gone for good). A bare `n d` would race the
+  in-flight eviction migration and discard that decision.
+
+  Pre-fix blockstor: `n d` only refused on outstanding Resource / SP
+  references, so once the eviction reconciler drained the node `n d`
+  silently succeeded — bypassing the restore-or-lost decision.
+
+  Scenario (3-node): autoplace 2 diskful replicas, evacuate node1 (it
+  enters EVICTED), then attempt `node delete node1` — assert it fails.
+  Finally `node restore node1` to leave the cluster clean.
+
+  NOTE on expect_exit: the rejection is an API-error envelope
+  (FAIL_IN_USE), which the python-linstor CLI surfaces as exit 10. If a
+  stand run shows a different non-zero code, adjust this single value —
+  the contract is "non-zero", pinned more strictly here for regression
+  sensitivity.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: autoplace-2
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
+    expect_exit: 0
+  - name: wait-two-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: evacuate-node1
+    cmd: ["node", "evacuate", "{{node1}}"]
+    expect_exit: 0
+  - name: delete-evicted-node-rejected
+    # THE F6 ASSERTION: `n d` on the EVICTED node must fail. The node is
+    # latched in the drain state; only restore or lost is allowed.
+    cmd: ["node", "delete", "{{node1}}"]
+    expect_exit: 10
+  - name: restore-node1
+    cmd: ["node", "restore", "{{node1}}"]
+    expect_exit: 0
+
+teardown:
+  - cmd: ["node", "restore", "{{node1}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

Corner-case campaign **PKG-F** — node-lifecycle guards (items F1–F6 from the LINSTOR corner-case plan). This PR hardens two node-lifecycle gaps and pins four already-correct behaviors with regression tests.

Two behavioral fixes:

- **F4 — `AutoplaceTarget=false` placer support.** `linstor node set-property <node> AutoplaceTarget false` now excludes the node from autoplace *targeting* (the placer never picks it for a NEW replica) while leaving existing replicas untouched and still counting toward `place_count`. This is the maintenance-drain workflow (kb.linbit.com/linstor/preventing-linstor-resource-placement-on-a-node). Before, the placer's only node exclusion was the EVICTED/LOST flag set, so a drained maintenance node kept receiving new replicas. Only a parseable `false` excludes — a typo (`flase`, `true`, unset) degrades to "still eligible" so a fat-fingered prop can never silently drain the cluster.

- **F6 — `node delete` on an EVICTED node is rejected.** EVICTED is a one-way drain latch: a plain `node delete` would race the in-flight eviction migration and silently discard the operator's restore-or-lost decision. `handleNodeDelete` now refuses with `409 + FAIL_IN_USE`, naming both sanctioned exits (`node restore` / `node lost`). `?force=true` keeps the disaster-recovery override (already cascades orphans), matching the Bug 92 / Bug 179 escape-hatch precedent on the same handler. LOST nodes are NOT caught — deleting a gone-for-good node is the natural cleanup.

Four pins on existing-correct behavior (no code change, regression tests only):

- **F1 — evacuate refuses InUse.** `handleNodeEvacuate` already refuses to evacuate a node hosting an in-use (DRBD Primary) resource (cli-parity-audit Bug 18). Pinned by `node_lifecycle_test.go`.
- **F2 — evacuate with no replacement target keeps the source.** The add-before-drop gate (`evacuationReplacementReady`) already leaves replicas in place when `place_count == node_count` and there is nowhere to migrate. Pinned by `corner_f2_evacuate_no_candidate_test.go` so a future regression can't turn it into a drop-without-add.
- **F3 — restore semantics.** `node restore` clears EVICTED and keeps SP / props / resources; exercised in the F6 restore path and `node_lifecycle_test.go` / `bug_397_restore_snapshotless_node_test.go`.
- **F5 — auto-evict / placer guards.** The placer excludes EVICTED/LOST nodes from new placements and from existing-replica accounting; pinned alongside F4 (`TestAutoplaceSkipsEvictedNodes`).

## Verdict table

| Item | Scope | Verdict | Evidence |
|------|-------|---------|----------|
| F1 | evacuate refuses InUse (Primary) | **MATCHES** (pre-existing, pinned) | `node_lifecycle.go:111-160`; test `node_lifecycle_test.go:495` (`cannot evacuate`) |
| F2 | evacuate no-replacement keeps source | **MATCHES** (pinned this PR) | `corner_f2_evacuate_no_candidate_test.go` — `TestNodeReconciler_EvictedNoCandidateKeepsSource` PASS |
| F3 | `node restore` semantics | **MATCHES** (pinned) | `node_lifecycle.go` restore handler; F6 cleanup + `bug_397_restore_snapshotless_node_test.go` |
| F4 | `AutoplaceTarget=false` placer opt-out | **DIVERGED → fixed** | `placer.go` (`autoplaceExcludedNodes`); 3 unit tests PASS; L6 `n-autoplace-target-excludes.sh`; L7 `n-autoplace-target-excludes.yaml` |
| F5 | auto-evict / placer EVICTED guards | **MATCHES** (pinned) | `TestAutoplaceSkipsEvictedNodes` PASS |
| F6 | `node delete` on EVICTED latched | **DIVERGED → fixed** | `nodes.go` (`refuseNodeDeleteIfEvicted`); 3 unit tests PASS; L6 `n-d-evicted-rejected.sh`; L7 `n-d-evicted-rejected.yaml` |

## Tests

L1 unit (all green in worktree, `go test ./...`):

- `pkg/placer/autoplace_target_test.go` — `TestPlaceSkipsAutoplaceTargetFalseNode`, `TestPlaceAutoplaceTargetFalseLeavesExistingReplica`, `TestPlaceAutoplaceTargetTrueAndTypoStayEligible`
- `pkg/rest/node_delete_evicted_test.go` — `TestNodeDeleteRefusedWhenEvicted`, `TestNodeDeleteEvictedForcedSucceeds`, `TestNodeEvacuateMultiCandidateExcludesAlreadyEvicted`, `TestAutoplaceSkipsEvictedNodes`
- `internal/controller/corner_f2_evacuate_no_candidate_test.go` — `TestNodeReconciler_EvictedNoCandidateKeepsSource`

L6 cli-matrix cells:

- `tests/e2e/cli-matrix/n-autoplace-target-excludes.sh` (F4)
- `tests/e2e/cli-matrix/n-d-evicted-rejected.sh` (F6)

L7 replay YAMLs:

- `tests/operator-harness/replay/n-autoplace-target-excludes.yaml` (F4)
- `tests/operator-harness/replay/n-d-evicted-rejected.yaml` (F6)

## DoD outputs

- `go build ./...` → clean (rc 0)
- `go test ./...` → green, no failures
- `golangci-lint run` (touched pkgs) → `0 issues`
- Rebased onto current `origin/main` (#94–#98 merged); no `cli-parity-known-deltas.md` row needed (these are fixes/pins, not deliberate deltas).

## Stand validation

Both L7 replays were executed on the dev stand (`dev-worker-1/2/3`, real `linstor` 1.27.1 → REST → satellite → DRBD), under the shared stand lock.

> **IMPORTANT — deployment caveat.** The campaign guardrail forbids touching the `blockstor-system` deployment, so the stand controller runs **released v0.1.9**, which does NOT contain this branch's F4/F6 code. The replays therefore exercise the *deployed* controller, not this PR's build. The authoritative proof of the new behavior is the L1 unit suite (green); the stand runs are an at-the-wire cross-check, read with this caveat.

**F6 — `n-d-evicted-rejected.yaml` → PASS** (`REPLAY_RC=0`):

```
-> step: autoplace-2 :: linstor resource create --auto-place 2 --storage-pool=stand replay-n-d-evicted-rejected-kicl
-> step: wait-two-uptodate
-> step: evacuate-node1 :: linstor node evacuate dev-worker-1
-> step: delete-evicted-node-rejected :: linstor node delete dev-worker-1   (expect_exit 10 — matched)
-> step: restore-node1 :: linstor node restore dev-worker-1
PASS: n-d-evicted-rejected
```

The `node delete` of the evacuated node is rejected at the wire (exit 10) and `node restore` recovers the node. NOTE: on the deployed v0.1.9 this rejection comes from the pre-existing *hosts-replicas* gate (the displaced replica is still mid-migration), not from this PR's new EVICTED latch — the replay assertion ("delete rejected") is satisfied by both gates and cannot isolate them. This PR's new gate is isolated by the L1 test `TestNodeDeleteRefusedWhenEvicted` (asserts the EVICTED-specific 409 + `node restore`/`node lost` guidance) which passes on this branch.

**F4 — `n-autoplace-target-excludes.yaml` → FAIL on deployed v0.1.9** (`REPLAY_RC=1`):

```
-> step: drain-node1-autoplace-target-false :: linstor node set-property dev-worker-1 AutoplaceTarget false
-> step: autoplace-2
-> step: assert-node1-excluded
   ASSERTION TIMEOUT: kind=resource_absent rd=... node=dev-worker-1
FAIL: n-autoplace-target-excludes
```

This is the expected result against v0.1.9: the deployed controller does NOT consult `AutoplaceTarget`, so a replica lands on the "drained" `dev-worker-1` — i.e. the replay **reproduces the pre-fix bug** this PR fixes. The fix is proven by the L1 placer suite (`TestPlaceSkipsAutoplaceTargetFalseNode` + 2 siblings) which passes on this branch. The replay will go green once a build containing this PR is deployed; re-validation on the next stand image bump is the closing gate.

Stand left clean: replay teardowns ran, no `replay-n-*` / `ccf-*` orphan RDs remain, all nodes Online, `AutoplaceTarget` cleared, port-forwards killed.

## Notes / risks

- **F4 replay is RED against deployed v0.1.9 by construction** — it reproduces the pre-fix bug because the fix is not in the released image (deploy forbidden by campaign rules). Must be re-run green after the next stand image bump. Not a defect in this PR's code (L1 green).
- **F6 replay PASS does not isolate this PR's new EVICTED gate** on v0.1.9 (older hosts-replicas gate also rejects). The new gate is isolated by L1 only.
- The original F-agent stand run was environment-corrupted (oracle probes hit a controller returning 404/405 with empty node names; BS replays SKIPPed on a `KUBECONFIG`-not-exported worker-discovery glitch). All evidence above is from a clean re-run.
- No shared-harness files modified (`tests/operator-harness/lib.sh`, `replay-runner.sh`, `cli-matrix/lib.sh` untouched) — no merge sequencing needed.
- No `docs/linstor-corner-cases.md`, `CHANGELOG.md`, or release files touched.
