### PR TITLE
fix(controller): read DrbdOptions/auto-quorum from ExtraProps (corner B follow-up)

### DIFF
--- a/internal/controller/ensure_tiebreaker_test.go
+++ b/internal/controller/ensure_tiebreaker_test.go
@@ -628,6 +628,91 @@ func TestEnsureTiebreakerHonoursAutoQuorumDisabled(t *testing.T) {
 	}
 }
 
+// TestEnsureTiebreakerHonoursAutoQuorumDisabledInExtraProps is the B2
+// regression: it reproduces the EXACT production CRD shape the
+// dev-stand replay (auto-quorum-disabled-keeps-manual-quorum) hits.
+//
+// The CRD-backed store's wireToCRDRDSpec strips every `DrbdOptions/*`
+// key out of Spec.Props and routes the section-less, un-typed
+// `DrbdOptions/auto-quorum` into Spec.ExtraProps (only
+// `AutoAddQuorumTiebreaker` is typed). The earlier B1 reconciler test
+// stamped the disable key in Spec.Props — a shape no real CLI write
+// produces on a CRD cluster — so it passed while the live stand still
+// re-stamped quorum=majority over the operator's manual `quorum off`.
+//
+// Here the disable marker lives in ExtraProps (where the store really
+// puts it) and the manual `quorum off` in Props (a non-DRBD... no:
+// quorum IS a DRBD key, but the in-memory fake client keeps whatever
+// we set — we assert the reconciler does NOT overwrite it). Pre-fix
+// isAutoQuorumDisabled read only Spec.Props, returned false, and
+// setQuorum clobbered the value; post-fix it consults ExtraProps,
+// returns true, and ensureTiebreaker short-circuits.
+func TestEnsureTiebreakerHonoursAutoQuorumDisabledInExtraProps(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-b2-extra", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed replica %s: %v", n, err)
+		}
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-b2-extra"},
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			// Production CRD shape: the disable marker lives in
+			// ExtraProps, exactly where the store transcode puts the
+			// CLI-written `DrbdOptions/auto-quorum disabled`.
+			ExtraProps: map[string]string{
+				"DrbdOptions/auto-quorum": "disabled",
+			},
+			Props: map[string]string{
+				"DrbdOptions/Resource/quorum": "off",
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	// Gate must agree with the ExtraProps-borne marker.
+	if !controllerpkg.IsAutoQuorumDisabled(rd) {
+		t.Fatalf("IsAutoQuorumDisabled returned false for ExtraProps auto-quorum=disabled RD")
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	final := &blockstoriov1alpha1.ResourceDefinition{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-b2-extra"}, final); err != nil {
+		t.Fatalf("Get RD: %v", err)
+	}
+
+	// The operator's manual `quorum off` must survive — the auto
+	// reconciler would otherwise compute `majority` and clobber it.
+	if got := final.Spec.Props["DrbdOptions/Resource/quorum"]; got != "off" {
+		t.Errorf("B2: quorum prop got %q, want %q (ExtraProps auto-quorum=disabled "+
+			"must stop the reconciler clobbering the manual value)", got, "off")
+	}
+}
+
 // TestEnsureTiebreakerDisabledDoesNotReseedOnNoQuorum is the B5
 // regression that the dev-stand reproduced against the released
 // (camelCase-bug) binary: with `DrbdOptions/auto-quorum=disabled` set
@@ -791,6 +876,65 @@ func TestIsAutoQuorumDisabled(t *testing.T) {
 			rd: &blockstoriov1alpha1.ResourceDefinition{
 				Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
 					Props: map[string]string{"DrbdOptions/auto-quorum": "io-error"},
+				},
+			},
+			want: false,
+		},
+		{
+			// Corner-case B2 (production CRD shape): the store routes
+			// the section-less `DrbdOptions/auto-quorum` key OUT of
+			// Spec.Props (stripDRBDProps) and into Spec.ExtraProps. The
+			// gate MUST read that bag too, otherwise the operator's
+			// `set-property DrbdOptions/auto-quorum disabled` is silently
+			// ignored on every real cluster. This is the case the B1
+			// fix missed.
+			name: "disabled in ExtraProps (kebab key, CRD store shape)",
+			rd: &blockstoriov1alpha1.ResourceDefinition{
+				Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+					ExtraProps: map[string]string{"DrbdOptions/auto-quorum": "disabled"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Disabled (mixed case) in ExtraProps",
+			rd: &blockstoriov1alpha1.ResourceDefinition{
+				Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+					ExtraProps: map[string]string{"DrbdOptions/auto-quorum": "Disabled"},
+				},
+			},
+			want: true,
+		},
+		{
+			// Legacy camelCase spelling, also routed to ExtraProps by
+			// the store — forward-compat fallback must still opt out.
+			name: "disabled in ExtraProps (legacy camelCase fallback)",
+			rd: &blockstoriov1alpha1.ResourceDefinition{
+				Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+					ExtraProps: map[string]string{"DrbdOptions/AutoQuorum": "disabled"},
+				},
+			},
+			want: true,
+		},
+		{
+			// Mixed bags: Props carries an unrelated key, ExtraProps
+			// carries the real disable instruction. Must still fire.
+			name: "disabled in ExtraProps with unrelated Spec.Props key",
+			rd: &blockstoriov1alpha1.ResourceDefinition{
+				Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+					Props:      map[string]string{"StorPoolName": "stand"},
+					ExtraProps: map[string]string{"DrbdOptions/auto-quorum": "disabled"},
+				},
+			},
+			want: true,
+		},
+		{
+			// A non-disable value in ExtraProps must NOT opt out — the
+			// reconciler keeps managing quorum.
+			name: "suspend-io in ExtraProps (not disable)",
+			rd: &blockstoriov1alpha1.ResourceDefinition{
+				Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+					ExtraProps: map[string]string{"DrbdOptions/auto-quorum": "suspend-io"},
 				},
 			},
 			want: false,

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -492,7 +492,7 @@ func keepExistingWitnessFor(
 // Case-insensitive match: operators sometimes paste `Disabled` from
 // the manual.
 func isAutoQuorumDisabled(rd *blockstoriov1alpha1.ResourceDefinition) bool {
-	if rd == nil || rd.Spec.Props == nil {
+	if rd == nil {
 		return false
 	}
 
@@ -513,12 +513,51 @@ func isAutoQuorumDisabled(rd *blockstoriov1alpha1.ResourceDefinition) bool {
 		legacyPropKey = "DrbdOptions/AutoQuorum"
 	)
 
-	value, ok := rd.Spec.Props[propKey]
-	if !ok {
-		value = rd.Spec.Props[legacyPropKey]
+	// Corner-case B2: the CRD-backed store (wireToCRDRDSpec →
+	// propsToTyped / stripDRBDProps) routes EVERY `DrbdOptions/*` key
+	// OUT of Spec.Props. Recognised keys become typed Spec.DRBDOptions;
+	// the section-less ones we don't type yet — and
+	// `DrbdOptions/auto-quorum` is exactly such a key, only
+	// `DrbdOptions/AutoAddQuorumTiebreaker` is typed — land in
+	// Spec.ExtraProps. The B1 fix corrected the key spelling but still
+	// read only Spec.Props, so on a real (CRD-backed) cluster the
+	// operator's `set-property DrbdOptions/auto-quorum disabled` lived
+	// in Spec.ExtraProps where this gate never looked: it never fired
+	// and setQuorum kept re-stamping quorum=majority over the
+	// operator's manual `quorum off`. Consult both bags — Spec.Props
+	// first (the in-memory / fake-client tests populate it directly),
+	// then Spec.ExtraProps (the production CRD shape).
+	value := rdPropFromBags(rd, propKey)
+	if value == "" {
+		value = rdPropFromBags(rd, legacyPropKey)
 	}
 
 	return strings.EqualFold(value, "disabled")
+}
+
+// rdPropFromBags reads a single property key off an RD, consulting
+// Spec.Props first and falling back to Spec.ExtraProps. The CRD-backed
+// store splits the upstream flat `DrbdOptions/*` prop bag across two
+// CRD fields (Spec.Props keeps non-DRBD keys; recognised DRBD keys
+// become typed Spec.DRBDOptions; unrecognised DRBD keys land in
+// Spec.ExtraProps — see pkg/store/k8s.wireToCRDRDSpec), so any
+// reconciler helper that wants the operator-visible value of a
+// section-less DRBD key MUST look in both. Returns "" when neither bag
+// carries the key.
+func rdPropFromBags(rd *blockstoriov1alpha1.ResourceDefinition, key string) string {
+	if rd.Spec.Props != nil {
+		if v, ok := rd.Spec.Props[key]; ok {
+			return v
+		}
+	}
+
+	if rd.Spec.ExtraProps != nil {
+		if v, ok := rd.Spec.ExtraProps[key]; ok {
+			return v
+		}
+	}
+
+	return ""
 }
 
 // isTiebreakerSuppressed reports whether the operator recently

--- a/tests/operator-harness/lib.sh
+++ b/tests/operator-harness/lib.sh
@@ -181,14 +181,33 @@ substitute() {
 
 await_assertion() {
     local spec=$1
-    local kind timeout_s deadline
+    local kind timeout_s deadline hold_s held_since now
     kind=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('kind',''))" "$spec")
     timeout_s=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('timeout_s',${ASSERT_TIMEOUT_S}))" "$spec")
-    deadline=$(( $(date +%s) + timeout_s ))
+    # Optional hold_s: the assertion must not only become true once but
+    # STAY true for hold_s consecutive seconds. Catches value flapping
+    # (e.g. an operator-set property that a reconciler keeps reverting:
+    # a plain first-match await can sample the lucky instant between
+    # the write and the revert and false-PASS — seen on corner-B2).
+    # Any failed sample resets the hold window. The overall deadline
+    # spans timeout_s + hold_s so a late first success still gets a
+    # full hold window.
+    hold_s=$(python3 -c "import json,sys; print(json.loads(sys.argv[1]).get('hold_s',0))" "$spec")
+    deadline=$(( $(date +%s) + timeout_s + hold_s ))
+    held_since=""
 
     while (( $(date +%s) < deadline )); do
         if check_assertion "$kind" "$spec"; then
-            return 0
+            if (( hold_s == 0 )); then
+                return 0
+            fi
+            now=$(date +%s)
+            [[ -n "$held_since" ]] || held_since=$now
+            if (( now - held_since >= hold_s )); then
+                return 0
+            fi
+        else
+            held_since=""
         fi
         sleep 2
     done

--- a/tests/operator-harness/replay/auto-quorum-disabled-keeps-manual-quorum.yaml
+++ b/tests/operator-harness/replay/auto-quorum-disabled-keeps-manual-quorum.yaml
@@ -85,6 +85,11 @@ steps:
       key: "DrbdOptions/Resource/quorum"
       expected: "off"
       timeout_s: 45
+      # Must HOLD, not merely appear: without hold_s the await can
+      # sample the instant between the operator write and a buggy
+      # reconciler revert and false-PASS (exactly how the pre-B2
+      # image slipped through once).
+      hold_s: 30
   - name: tiebreaker-still-present
     # Disabling auto-quorum does NOT reap the witness — it is gated on
     # a separate prop.


### PR DESCRIPTION
## Summary

Follow-up to #97. The B1 fix corrected the property key spelling (camelCase → kebab) but read the wrong CRD field: the store transcoder (`wireToCRDRDSpec`) strips all `DrbdOptions/*` keys out of `Spec.Props` and routes unrecognized section-less keys — including `DrbdOptions/auto-quorum` — into `Spec.ExtraProps`. `isAutoQuorumDisabled` consulted only `Spec.Props`, so on a real CRD-backed cluster the operator's opt-out still never fired and `setQuorum` kept re-stamping `quorum=majority` over a manual `quorum off`.

Caught by the L7 replay `auto-quorum-disabled-keeps-manual-quorum.yaml` on the live stand with current main deployed (the #97 L1 fixtures stamped `Spec.Props` directly and therefore passed — they did not match the production CRD layout).

## Fix

`isAutoQuorumDisabled` now consults both bags (`Spec.Props` first, then `Spec.ExtraProps`) via a `rdPropFromBags` helper.

## Tests

- L1: 5 new ExtraProps cases in `TestIsAutoQuorumDisabled` + `TestEnsureTiebreakerHonoursAutoQuorumDisabledInExtraProps` reproducing the production CRD layout (red before, green after).
- L6/L7: already exist from #97 and drive the real CLI→CRD→ExtraProps path — they fail on current main and pass with this fix; the launcher will validate the replay PASS on the dev stand with this branch's image before merge.

Live-stand evidence: `Spec.extraProps={"DrbdOptions/auto-quorum":"disabled"}` while `Spec.props` quorum reverted to `majority` at t=5s and held for 50s — the exact replay symptom.