### PR TITLE
test(replay): F4 autoplace-target asserts no diskful, not absence

### DIFF
--- a/tests/operator-harness/replay/n-autoplace-target-excludes.yaml
+++ b/tests/operator-harness/replay/n-autoplace-target-excludes.yaml
@@ -54,8 +54,13 @@ steps:
     expect_exit: 0
     await:
       # THE F4 ASSERTION: the AutoplaceTarget=false node never received
-      # a replica — both copies landed on node2 + node3.
-      kind: resource_absent
+      # a DISKFUL replica — both copies landed on node2 + node3. On a
+      # 3-worker stand the auto-tiebreaker witness legitimately lands on
+      # the only remaining node (node1), so a Resource CRD for node1
+      # exists as a diskless TIE_BREAKER and resource_absent can never
+      # hold — assert "not diskful" instead (same lesson as the
+      # toggle-disk --migrate-from replay).
+      kind: replica_diskless
       rd: "{{rd}}"
       node: "{{node1}}"
       timeout_s: 30


### PR DESCRIPTION
## Summary

Post-merge validation of #102's F4 replay on the final main image surfaced the same assertion flaw fixed for the migrate-from replay in #103: pruning/avoiding the diskful placement leaves 2 diskful replicas (even parity), and the auto-tiebreaker witness legitimately lands on the only remaining worker — the very node the replay drained. A Resource CRD for that node therefore exists as a diskless TIE_BREAKER and `resource_absent` can never hold.

The F4 contract is *no DISKFUL replica on the AutoplaceTarget=false node*; the await is now `replica_diskless`. The fix itself works (both copies landed on the other workers; the drained node got only the witness).

## Validation

Stand run of the corrected replay to follow once the in-flight full-sweep session releases the lock (will paste the PASS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to properly validate state handling for diskless replicas in placement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->