### PR TITLE
fix(placer): upgrade auto-tiebreaker witness on --auto-place over place-count (corner-D2b)

### DIFF
--- a/pkg/api/v1/resource.go
+++ b/pkg/api/v1/resource.go
@@ -300,3 +300,45 @@ type StoragePoolModify struct {
 	UUID             string            `json:"uuid,omitempty"`
 	State            string            `json:"state,omitempty"`
 }
+
+// PromoteWitnessFlags returns the Flags slice for a diskless / TIE_BREAKER
+// witness promoted to diskful, plus whether the input was actually a
+// diskless witness. It is the single source of truth for the
+// "witness → diskful" flag transition shared by the explicit
+// `linstor r c <node> <rd> --storage-pool ...` toggle-disk path
+// (pkg/rest.promoteDisklessReplica) and the autoplace path
+// (pkg/placer, when `--auto-place +1` lands on a node that already
+// holds the auto-tiebreaker witness — corner-D2b).
+//
+// wantDiskful=true drops both DISKLESS and TIE_BREAKER (full promote to
+// diskful). wantDiskful=false drops only TIE_BREAKER and keeps DISKLESS
+// (the linstor-csi make-available fallback: a plain DISKLESS replica,
+// no longer a controller-owned witness). The second return is true when
+// at least one of DISKLESS / TIE_BREAKER was present, so callers can
+// distinguish "promoted a witness" from "the replica was already
+// diskful" (a real conflict the caller must surface as 409).
+//
+// The input slice is never mutated — a fresh slice is returned.
+func PromoteWitnessFlags(flags []string, wantDiskful bool) ([]string, bool) {
+	wasDiskless := false
+	keep := make([]string, 0, len(flags))
+
+	for _, flag := range flags {
+		switch flag {
+		case ResourceFlagTieBreaker:
+			wasDiskless = true
+		case ResourceFlagDiskless:
+			wasDiskless = true
+
+			if wantDiskful {
+				continue
+			}
+
+			keep = append(keep, flag)
+		default:
+			keep = append(keep, flag)
+		}
+	}
+
+	return keep, wasDiskless
+}

--- a/pkg/placer/corner_d2b_autoplace_over_tiebreaker_test.go
+++ b/pkg/placer/corner_d2b_autoplace_over_tiebreaker_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placer_test
+
+import (
+	"slices"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/placer"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// seedTwoDiskfulPlusWitness builds the standard place-count-2 steady
+// state on a 3-node cluster: a diskful replica on n1 and n2, plus an
+// auto-tiebreaker witness (DISKLESS + TIE_BREAKER) on n3. This is the
+// exact topology the corner-D2b bug reproduced on.
+func seedTwoDiskfulPlusWitness(t *testing.T, st store.Store) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	seedStore(t, st, []string{"n1", "n2", "n3"})
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-1", NodeName: n,
+			Props: map[string]string{"StorPoolName": "pool"},
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-1", NodeName: "n3",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed witness n3: %v", err)
+	}
+}
+
+// assertWitnessUpgraded asserts that after the placer ran, n3's replica
+// is diskful: DISKLESS and TIE_BREAKER are gone and StorPoolName is set.
+// It also asserts there are exactly 3 Resources (the witness was
+// upgraded IN PLACE, not duplicated by a 4th replica somewhere).
+func assertWitnessUpgraded(t *testing.T, st store.Store) {
+	t.Helper()
+
+	got, _ := st.Resources().ListByDefinition(t.Context(), "pvc-1")
+	if len(got) != 3 {
+		t.Fatalf("total resources: got %d, want 3 (witness upgraded in place, not duplicated); %+v", len(got), got)
+	}
+
+	var n3 *apiv1.Resource
+
+	for i := range got {
+		if got[i].NodeName == "n3" {
+			n3 = &got[i]
+		}
+	}
+
+	if n3 == nil {
+		t.Fatalf("n3 replica missing after placement; %+v", got)
+	}
+
+	if slices.Contains(n3.Flags, apiv1.ResourceFlagDiskless) {
+		t.Errorf("n3 still DISKLESS after upgrade: %+v", n3.Flags)
+	}
+
+	if slices.Contains(n3.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("n3 still TIE_BREAKER after upgrade: %+v", n3.Flags)
+	}
+
+	if n3.Props["StorPoolName"] != "pool" {
+		t.Errorf("n3 StorPoolName: got %q, want \"pool\" (backing disk stamped)", n3.Props["StorPoolName"])
+	}
+}
+
+// TestPlaceUpgradesTiebreakerAbsolutePlaceCount is corner-D2b's
+// absolute-form pin: the standard 2-diskful + 1-auto-tiebreaker shape,
+// then `--auto-place 3` (PlaceCount=3, the value the REST handler hands
+// the placer for both `--auto-place 3` and the `+1` shorthand). Before
+// the fix the placer treated the witness-holding node as fully "taken"
+// and reported a shortfall ("Not enough nodes ... Replica count: 3")
+// even though n3 was available to host a diskful replica. The fix marks
+// the witness node as an UPGRADE candidate so the placer promotes the
+// witness in place.
+func TestPlaceUpgradesTiebreakerAbsolutePlaceCount(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	seedTwoDiskfulPlusWitness(t, st)
+
+	placed, want, err := placer.New(st).Place(t.Context(), "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 3})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 3 || want != 3 {
+		t.Errorf("placed/want: got %d/%d, want 3/3 (witness upgraded fills the gap)", placed, want)
+	}
+
+	assertWitnessUpgraded(t, st)
+}
+
+// TestPlaceUpgradesTiebreakerNotDoubleCounted guards the gap-fill
+// arithmetic for the `+1` shorthand. The REST handler lowers
+// `--auto-place +1` on a 2-diskful RD to PlaceCount=3 (existing diskful
+// count + 1). The witness on n3 must NOT count as one of the 2 existing
+// diskful (place_count is diskful-only — countDiskfulReplicas already
+// skips DISKLESS), so the effective target is exactly 3 and the witness
+// fills slot 3. This pins that the promote lands precisely one new
+// diskful and never spills to a (non-existent) 4th node.
+func TestPlaceUpgradesTiebreakerNotDoubleCounted(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	seedTwoDiskfulPlusWitness(t, st)
+
+	// PlaceCount=3 == count(existing diskful)=2 + additional 1, the
+	// value resolveAdditionalPlaceCount computes for `--auto-place +1`.
+	placed, _, err := placer.New(st).Place(t.Context(), "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 3})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 3 {
+		t.Errorf("placed: got %d, want 3", placed)
+	}
+
+	assertWitnessUpgraded(t, st)
+
+	// Idempotency: re-running the same target must not create a 4th
+	// replica or flip anything back to diskless.
+	placed2, _, err := placer.New(st).Place(t.Context(), "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 3})
+	if err != nil {
+		t.Fatalf("Place (re-run): %v", err)
+	}
+
+	if placed2 != 3 {
+		t.Errorf("placed (re-run): got %d, want 3 (idempotent)", placed2)
+	}
+
+	assertWitnessUpgraded(t, st)
+}
+
+// TestPlaceDoesNotUpgradeTiebreakerWhenTargetMet guards the no-op edge:
+// the same 2-diskful + 1-witness shape but place_count=2 (already
+// satisfied). The witness must stay a witness — the placer must not
+// opportunistically upgrade it just because it became an upgrade
+// candidate. Pins that the upgrade only fires to fill a real gap.
+func TestPlaceDoesNotUpgradeTiebreakerWhenTargetMet(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewInMemory()
+	seedTwoDiskfulPlusWitness(t, st)
+
+	placed, _, err := placer.New(st).Place(t.Context(), "pvc-1", &apiv1.AutoSelectFilter{PlaceCount: 2})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+
+	if placed != 2 {
+		t.Errorf("placed: got %d, want 2 (target already met)", placed)
+	}
+
+	got, _ := st.Resources().ListByDefinition(t.Context(), "pvc-1")
+
+	var n3 *apiv1.Resource
+
+	for i := range got {
+		if got[i].NodeName == "n3" {
+			n3 = &got[i]
+		}
+	}
+
+	if n3 == nil {
+		t.Fatalf("n3 witness vanished; %+v", got)
+	}
+
+	if !slices.Contains(n3.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("n3 witness was upgraded despite target being met: %+v", n3.Flags)
+	}
+}

--- a/pkg/placer/placer.go
+++ b/pkg/placer/placer.go
@@ -126,6 +126,12 @@ func (e *OversubscriptionShortfallError) Error() string {
 	)
 }
 
+// storPoolNameProp is the Resource Spec prop key that pins a replica to
+// a backing storage pool. Mirrors the literal the REST handlers and the
+// satellite dispatcher key on; centralised here so the placer's
+// create-and-promote paths can't drift on the spelling.
+const storPoolNameProp = "StorPoolName"
+
 // Placer adds replicas to satisfy a placement filter. Construct via
 // New; one instance per autoplace call (it does no internal caching).
 type Placer struct {
@@ -499,6 +505,18 @@ type state struct {
 	// bucket "<key>=", matching upstream LINSTOR's behaviour where
 	// "missing property" is just another value of that key.
 	xBuckets map[string]int
+	// upgradeable maps a node name to the diskless replica (DISKLESS /
+	// TIE_BREAKER witness) it currently holds. corner-D2b: a node that
+	// hosts ONLY a diskless witness is NOT "taken" for diskful purposes
+	// — upstream LINSTOR upgrades the witness to a diskful replica
+	// in place when `--auto-place +1` (or an absolute place_count) needs
+	// the node. Such nodes are deliberately kept OUT of `taken` so
+	// candidateNodeProps still considers them; tryPlace then promotes
+	// the existing witness (strip DISKLESS+TIE_BREAKER, stamp
+	// StorPoolName) instead of creating a fresh Resource, reusing the
+	// exact transition pkg/rest.promoteDisklessReplica performs for the
+	// explicit `r c <node> --storage-pool` toggle-disk path.
+	upgradeable map[string]string
 }
 
 func newState(filter *apiv1.AutoSelectFilter, existing []apiv1.Resource, nodes map[string]map[string]string, pools []apiv1.StoragePool, allowPoolDriverMixing bool) *state {
@@ -512,27 +530,40 @@ func newState(filter *apiv1.AutoSelectFilter, existing []apiv1.Resource, nodes m
 		filter:                filter,
 		xBuckets:              make(map[string]int, len(filter.XReplicasOnDifferentMap)),
 		allowPoolDriverMixing: allowPoolDriverMixing,
+		upgradeable:           make(map[string]string),
 	}
 
 	for i := range existing {
+		// corner-D2b: a node whose only replica is a diskless witness
+		// (DISKLESS, typically also TIE_BREAKER) is NOT taken for
+		// diskful placement — it's an UPGRADE candidate. Record it so
+		// tryPlace can promote the witness in place, and crucially do
+		// NOT add it to `taken` (which would make candidateNodeProps
+		// reject it the way a real diskful peer is rejected). Diskful
+		// replicas still claim the node via `taken` below.
+		if slices.Contains(existing[i].Flags, apiv1.ResourceFlagDiskless) {
+			s.upgradeable[existing[i].NodeName] = existing[i].Props[storPoolNameProp]
+
+			continue
+		}
+
 		s.taken[existing[i].NodeName] = struct{}{}
 
-		// Seed XReplicasOnDifferentMap buckets from any existing
-		// diskful replica. DISKLESS witnesses don't occupy a
-		// topology bucket — they're network-only attachments and
-		// upstream LINSTOR doesn't count them toward x-replicas
-		// either (mirrors place_count's diskful-only semantic).
-		if !slices.Contains(existing[i].Flags, apiv1.ResourceFlagDiskless) {
-			nodeProps := nodes[existing[i].NodeName]
-			for key := range filter.XReplicasOnDifferentMap {
-				s.xBuckets[xBucketKey(key, nodeProps)]++
-			}
+		// Seed XReplicasOnDifferentMap buckets from this diskful
+		// replica. DISKLESS witnesses (handled by the continue above)
+		// don't occupy a topology bucket — they're network-only
+		// attachments and upstream LINSTOR doesn't count them toward
+		// x-replicas either (mirrors place_count's diskful-only
+		// semantic).
+		nodeProps := nodes[existing[i].NodeName]
+		for key := range filter.XReplicasOnDifferentMap {
+			s.xBuckets[xBucketKey(key, nodeProps)]++
 		}
 
 		// Pre-seed shared-space anti-affinity: if an existing replica
 		// already lives on a shared-LUN pool, no new replica may land
 		// on a pool sharing that LUN identifier.
-		stor := existing[i].Props["StorPoolName"]
+		stor := existing[i].Props[storPoolNameProp]
 		if stor == "" {
 			continue
 		}
@@ -548,9 +579,10 @@ func newState(filter *apiv1.AutoSelectFilter, existing []apiv1.Resource, nodes m
 
 		// Pre-seed Bug 76 same-kind constraint from the first
 		// diskful replica already on the RD. DISKLESS replicas
-		// don't claim a backing pool so they're skipped — see
-		// IsProviderKindMixingAllowed for the rationale.
-		if s.firstKind == "" && !slices.Contains(existing[i].Flags, apiv1.ResourceFlagDiskless) {
+		// (handled by the continue above) don't claim a backing pool
+		// so they never reach here — see IsProviderKindMixingAllowed
+		// for the rationale.
+		if s.firstKind == "" {
 			s.firstKind = pool.ProviderKind
 		}
 	}
@@ -669,18 +701,34 @@ func (s *state) tryPlace(ctx context.Context, st store.Store, rdName string, poo
 		return false, nil
 	}
 
-	res := apiv1.Resource{
-		Name:     rdName,
-		NodeName: pool.NodeName,
-		Props:    map[string]string{"StorPoolName": pool.StoragePoolName},
-	}
+	// corner-D2b: when the candidate node already hosts a diskless
+	// witness (recorded in `upgradeable` at newState time), promote it
+	// to diskful in place instead of creating a fresh Resource — a
+	// Create would hit ErrAlreadyExists and the witness would never gain
+	// a backing disk. The promote strips DISKLESS+TIE_BREAKER and stamps
+	// the chosen StorPoolName, the exact transition the explicit
+	// `r c <node> --storage-pool` toggle-disk path performs via
+	// pkg/rest.promoteDisklessReplica.
+	if _, isWitness := s.upgradeable[pool.NodeName]; isWitness {
+		err := s.promoteWitness(ctx, st, rdName, pool)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		res := apiv1.Resource{
+			Name:     rdName,
+			NodeName: pool.NodeName,
+			Props:    map[string]string{storPoolNameProp: pool.StoragePoolName},
+		}
 
-	err := st.Resources().Create(ctx, &res)
-	if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
-		return false, errors.Wrap(err, "create resource")
+		err := st.Resources().Create(ctx, &res)
+		if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+			return false, errors.Wrap(err, "create resource")
+		}
 	}
 
 	s.taken[pool.NodeName] = struct{}{}
+	delete(s.upgradeable, pool.NodeName)
 
 	if s.sameTuple == nil && len(s.filter.ReplicasOnSame) > 0 {
 		s.sameTuple = lookupKeys(nodeProps, s.filter.ReplicasOnSame)
@@ -713,6 +761,60 @@ func (s *state) tryPlace(ctx context.Context, st store.Store, rdName string, poo
 	}
 
 	return true, nil
+}
+
+// promoteWitness converts the diskless witness already on pool.NodeName
+// into a diskful replica backed by pool.StoragePoolName (corner-D2b).
+// It strips DISKLESS + TIE_BREAKER and stamps StorPoolName via
+// PatchResourceSpec — the same store-level transition that
+// pkg/rest.promoteDisklessReplica performs for the explicit
+// `r c <node> --storage-pool` toggle-disk path. The flag transition
+// itself is shared through apiv1.PromoteWitnessFlags so both paths can
+// never drift.
+//
+// The patch is conflict-safe: PatchResourceSpec re-runs the closure
+// against the freshly-fetched live replica on every optimistic-
+// concurrency retry, so a racing satellite Status write converges
+// instead of clobbering the promote. A NotFound (the witness was
+// collapsed out from under us between newState and here) is treated as
+// "nothing to promote" and falls back to a fresh Create so the
+// placement still lands.
+func (s *state) promoteWitness(ctx context.Context, st store.Store, rdName string, pool *apiv1.StoragePool) error {
+	err := st.Resources().PatchResourceSpec(ctx, rdName, pool.NodeName, func(live *apiv1.Resource) error {
+		keep, _ := apiv1.PromoteWitnessFlags(live.Flags, true)
+		live.Flags = keep
+
+		if live.Props == nil {
+			live.Props = map[string]string{}
+		}
+
+		live.Props[storPoolNameProp] = pool.StoragePoolName
+
+		return nil
+	})
+	if err == nil {
+		return nil
+	}
+
+	if !errors.Is(err, store.ErrNotFound) {
+		return errors.Wrap(err, "promote witness to diskful")
+	}
+
+	// The witness vanished between newState and the patch (e.g. a
+	// concurrent witness-collapse). Land a fresh diskful replica so the
+	// placement target is still met.
+	res := apiv1.Resource{
+		Name:     rdName,
+		NodeName: pool.NodeName,
+		Props:    map[string]string{storPoolNameProp: pool.StoragePoolName},
+	}
+
+	createErr := st.Resources().Create(ctx, &res)
+	if createErr != nil && !errors.Is(createErr, store.ErrAlreadyExists) {
+		return errors.Wrap(createErr, "create resource after witness vanished")
+	}
+
+	return nil
 }
 
 // poolKey is the composite (node, pool) lookup key used to find a

--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -2384,27 +2384,12 @@ func (s *Server) sumRDVolumeDefinitionsKib(ctx context.Context, rdName string) (
 // real diskful replicas. Pulled out of promoteDisklessReplica to keep
 // that function under the funlen budget after the Bug 205 Patch refactor.
 func stripDisklessAndWitnessFlags(flags []string, wantDiskful bool) ([]string, bool) {
-	wasDiskless := false
-	keep := flags[:0]
-
-	for _, flag := range flags {
-		switch flag {
-		case apiv1.ResourceFlagTieBreaker:
-			wasDiskless = true
-		case apiv1.ResourceFlagDiskless:
-			wasDiskless = true
-
-			if wantDiskful {
-				continue
-			}
-
-			keep = append(keep, flag)
-		default:
-			keep = append(keep, flag)
-		}
-	}
-
-	return keep, wasDiskless
+	// Delegate to the canonical witness→diskful flag transition shared
+	// with the autoplace path (corner-D2b). Keeping one implementation
+	// guarantees `r c <node> --storage-pool` (this path) and
+	// `r c --auto-place +1` (the placer's upgrade-over-witness path)
+	// strip exactly the same flags.
+	return apiv1.PromoteWitnessFlags(flags, wantDiskful)
 }
 
 // containsResourceFlag is a small helper so the create/promote

--- a/tests/e2e/cli-matrix/r-c-autoplace-plus-one-over-tb.sh
+++ b/tests/e2e/cli-matrix/r-c-autoplace-plus-one-over-tb.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# usage: r-c-autoplace-plus-one-over-tb.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner-case campaign D2b.
+#
+# Bug (live-stand verified on final main): with 2 diskful + 1 auto-
+# tiebreaker witness (the standard place-count-2 shape on a 3-worker
+# cluster), `linstor resource create --auto-place +1 <rd>` failed
+# rc=10 "Not enough nodes fulfilling the following auto-place criteria
+# ... Replica count: 3". The relative arithmetic was correct (+1 ->
+# total 3) but the autoplacer EXCLUDED the witness-holding node from
+# the diskful candidate set, so it could never reach the target.
+#
+# Upstream LINSTOR succeeds on this shape: it UPGRADES the witness on
+# the third node into a diskful replica in place (the witness row's
+# DISKLESS + TIE_BREAKER flags are dropped and a backing disk is
+# stamped) — the same transition `r c <node> --storage-pool` performs.
+#
+# This cell pins the fix end-to-end:
+#   1. rg place-count 2 + spawn on 3 workers -> 2 diskful + 1 witness.
+#   2. assert the auto-tiebreaker witness exists (precondition).
+#   3. `r c --auto-place +1` MUST exit 0 and grow to exactly 3 diskful.
+#   4. assert the witness was upgraded IN PLACE: the node that held the
+#      TIE_BREAKER now hosts a diskful replica, the tiebreaker row is
+#      gone, and the total replica count is still 3 (no 4th node, the
+#      cluster only has 3 workers anyway).
+#   5. all 3 diskful replicas reach UpToDate.
+#
+# Unit pin: pkg/placer/corner_d2b_autoplace_over_tiebreaker_test.go.
+# L7 replay: tests/operator-harness/replay/r-c-autoplace-plus-one.yaml.
+#
+# Distinct from r-c-autoplace-plus-one.sh: that cell pins the +1
+# arithmetic (2 -> 3); THIS cell pins WHICH node fills slot 3 — the
+# witness node, upgraded in place — which is the corner-D2b regression.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RG=ccd2b-rg
+RD=ccd2b-ap
+POOL=${POOL:-stand}
+
+cleanup() {
+    "${LCTL[@]}" resource-definition delete "$RD" >/dev/null 2>&1 || true
+    "${LCTL[@]}" resource-group delete "$RG" >/dev/null 2>&1 || true
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [D2b] rg create --place-count 2 + spawn -> 2 diskful + 1 witness"
+"${LCTL[@]}" resource-group create "$RG" --place-count 2 --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource-group spawn-resources "$RG" "$RD" 32M >/dev/null
+
+# Wait for the steady state: 3 Resource rows total (2 diskful + 1 TB).
+wait_replica_count "$RD" 3 120 || {
+    echo "FAIL (D2b setup): RD did not reach 3 rows (2 diskful + 1 witness)" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+}
+
+diskful2=$(linstor_diskful_count "$RD")
+if [[ "$diskful2" != "2" ]]; then
+    echo "FAIL (D2b setup): expected 2 diskful replicas, got $diskful2" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+TB_NODE=$(linstor_tiebreaker_node "$RD")
+if [[ -z "$TB_NODE" ]]; then
+    echo "FAIL (D2b setup): no auto-tiebreaker witness present — cannot exercise the upgrade-over-TB path" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo ">> baseline: 2 diskful + 1 witness on node '$TB_NODE' — OK"
+
+echo ">> [D2b] r c --auto-place +1 $RD MUST upgrade the witness on '$TB_NODE' to diskful (-> 3 diskful)"
+if ! "${LCTL[@]}" resource create --auto-place +1 "$RD"; then
+    echo "FAIL (D2b): --auto-place +1 exited non-zero (the corner-D2b regression: witness node excluded from candidates)" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# Expect exactly 3 diskful replicas now and ZERO tiebreaker rows.
+deadline=$(( $(date +%s) + 120 ))
+diskful=0
+tb_after="?"
+while (( $(date +%s) < deadline )); do
+    diskful=$(linstor_diskful_count "$RD")
+    tb_after=$(linstor_tiebreaker_node "$RD")
+    if (( diskful >= 3 )) && [[ -z "$tb_after" ]]; then
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$diskful" != "3" ]]; then
+    echo "FAIL (D2b): after --auto-place +1 expected 3 diskful replicas, got $diskful" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+if [[ -n "$tb_after" ]]; then
+    echo "FAIL (D2b): tiebreaker witness still present on '$tb_after' after +1 (witness was NOT upgraded in place)" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+# The upgrade must have happened on the SAME node that held the witness
+# (the cluster has only 3 workers, so slot 3 can only be the TB node).
+if ! kubectl get "resources.blockstor.cozystack.io/${RD}.${TB_NODE}" >/dev/null 2>&1; then
+    echo "FAIL (D2b): witness node '$TB_NODE' has no Resource CRD after upgrade" >&2
+    exit 1
+fi
+upgraded_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${TB_NODE}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+if [[ "$upgraded_flags" == *"DISKLESS"* ]] || [[ "$upgraded_flags" == *"TIE_BREAKER"* ]]; then
+    echo "FAIL (D2b): replica on ex-witness node '$TB_NODE' still carries diskless/TB flags: $upgraded_flags" >&2
+    exit 1
+fi
+echo ">> witness on '$TB_NODE' upgraded in place to diskful, 3 diskful total, 0 tiebreakers — OK"
+
+echo ">> wait all 3 diskful replicas UpToDate"
+deadline=$(( $(date +%s) + 300 ))
+all_up=false
+while (( $(date +%s) < deadline )); do
+    up=$("${LCTL[@]}" --machine-readable resource list --resources "$RD" 2>/dev/null \
+        | jq -r '[.[][]? | .volumes[]? | select(.provider_kind != "DISKLESS") | .state.disk_state]
+                 | map(select(. == "UpToDate")) | length' 2>/dev/null || echo 0)
+    if (( up >= 3 )); then
+        all_up=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$all_up" != "true" ]]; then
+    echo "FAIL (D2b): not all 3 diskful replicas reached UpToDate after the witness upgrade" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+echo ">> r-c-autoplace-plus-one-over-tb OK (D2b pinned: +1 upgraded the auto-tiebreaker witness in place; 3 diskful, all UpToDate)"

--- a/tests/operator-harness/replay/r-c-autoplace-plus-one.yaml
+++ b/tests/operator-harness/replay/r-c-autoplace-plus-one.yaml
@@ -11,6 +11,15 @@ description: |
   the RG place-count (2) or miscounted a diskless/tiebreaker peer
   toward the existing total would land the wrong replica count.
 
+  Corner-case campaign D2b: on a 3-worker cluster the place-count-2
+  spawn leaves an auto-tiebreaker witness on the third node. The `+1`
+  must UPGRADE that witness into a diskful replica in place (the
+  candidate selection that pre-fix excluded the witness-holding node,
+  failing with "Not enough nodes ... Replica count: 3"). This replay
+  asserts the witness EXISTS before the +1 and is GONE after it — i.e.
+  the third diskful replica is the upgraded witness, not a placement
+  shortfall. Pinned by pkg/placer/corner_d2b_autoplace_over_tiebreaker_test.go.
+
 prerequisites:
   min_nodes: 3
   storage_pool: stand
@@ -38,6 +47,17 @@ steps:
       kind: all_uptodate
       rd: "{{rd}}"
       timeout_s: 240
+  - name: assert-witness-present
+    # D2b precondition: place-count 2 on a 3-worker cluster spawns an
+    # auto-tiebreaker witness on the third node. The +1 below must
+    # upgrade THIS witness — assert it exists first so a topology that
+    # never created one doesn't silently weaken the upgrade assertion.
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
   - name: auto-place-plus-one
     cmd: ["resource", "create", "--auto-place", "+1", "{{rd}}"]
     expect_exit: 0
@@ -45,6 +65,16 @@ steps:
       kind: replica_count
       rd: "{{rd}}"
       min: 3
+      timeout_s: 90
+  - name: assert-witness-upgraded
+    # D2b core: the witness on the third node was upgraded to diskful
+    # in place, so no TIE_BREAKER row remains. Pre-fix the +1 failed
+    # with a placement shortfall and the witness stayed put.
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: no_tiebreaker
+      rd: "{{rd}}"
       timeout_s: 90
   - name: wait-3r-uptodate
     cmd: ["resource", "list", "--resources", "{{rd}}"]


### PR DESCRIPTION
## Summary

`linstor resource create --auto-place +1 <rd>` (and the absolute `--auto-place 3`) failed on the standard place-count-2 topology (2 diskful + 1 auto-tiebreaker witness on a 3-worker cluster) with:

```
Not enough nodes fulfilling the following auto-place criteria ... Replica count: 3
```

The relative arithmetic was correct (`+1` → effective place_count 3), but the autoplacer **excluded the node holding the tiebreaker witness from the diskful candidate set** — it treated any node with an existing replica (including a DISKLESS / TIE_BREAKER witness) as fully "taken". With only 3 workers and the witness occupying the third, the target could never be met.

Upstream LINSTOR succeeds on this shape by **upgrading the witness in place** into a diskful replica (the same toggle-disk transition `r c <node> --storage-pool` performs). blockstor's explicit path already supported this; only the autoplace candidate selection was blind.

## What changed

- **pkg/placer**: a node whose only replica is a diskless witness is now classified as an **upgrade candidate** rather than "taken". It stays in the candidate set and flows through every normal placement gate (topology, provider-kind, capacity). When the placer selects it, `promoteWitness` strips `DISKLESS` + `TIE_BREAKER` and stamps the chosen `StorPoolName` via `PatchResourceSpec` instead of issuing a colliding `Create`.
- The witness→diskful flag transition is now a single shared helper, `apiv1.PromoteWitnessFlags`, used by **both** the autoplace path (new) and the explicit `r c --storage-pool` toggle-disk path (`pkg/rest.promoteDisklessReplica`), so the two can never drift.
- The upgrade only fires to fill a real gap; an already-satisfied place_count leaves the witness untouched. Idempotent on re-run.

This fixes both the relative (`+1`) and absolute (`3`) autoplace forms uniformly. F4 `AutoplaceTarget` exclusions and the Bug-393 INACTIVE/diskless deficit accounting are unchanged (regression-pinned).

## Oracle parity evidence (upstream LINSTOR 1.33.2)

Same sequence on the upstream oracle (`orc-d2b-*`, 2 diskful + 1 TB, then `r c --auto-place +1`):

- `AUTOPLACE_RC=0` (succeeds — blockstor pre-fix returned rc=10).
- Upstream messages: `(dev-worker-3) Volume number 0 ... [FILE THIN] created` → `Added disk on 'dev-worker-3'` — i.e. it **added a disk to the existing witness row on the third node**, not a placement on a fourth node.
- After: all 3 nodes diskful (`flags=None`), 0 tiebreakers. blockstor now produces the identical end shape.

## Tests (CLI-bug-fix protocol)

- **L1**: `pkg/placer/corner_d2b_autoplace_over_tiebreaker_test.go` — witness node is an upgrade candidate (absolute + `+1` forms); upgraded in place (no 4th replica); not upgraded when target already met; idempotent.
- **L6**: `tests/e2e/cli-matrix/r-c-autoplace-plus-one-over-tb.sh` — asserts the witness exists before `+1`, then is upgraded in place (ex-witness node hosts a diskful replica, 0 tiebreakers, 3 diskful, all UpToDate).
- **L7**: extended `tests/operator-harness/replay/r-c-autoplace-plus-one.yaml` with `tiebreaker_present` (before) and `no_tiebreaker` (after) assertions.

## Stand validation



## Stand validation

Deployed this branch to the dev stand (apiserver image digest `ac0912cb…` → `2baebfc3…`, verified rollout, all 3 apiserver replicas + controller + satellites Running on the branch image).

| Tier | Test | Result | Notes |
|------|------|--------|-------|
| L1 | `pkg/placer/corner_d2b_autoplace_over_tiebreaker_test.go` (+ full `go test ./...`) | PASS | witness upgraded in place; not double-counted; no-op when target met; idempotent |
| L6 | `cli-matrix/r-c-autoplace-plus-one-over-tb.sh` | control-plane PASS; DRBD-UpToDate blocked by stand env | witness Spec correctly flipped to diskful (no DISKLESS/TIE_BREAKER, StorPoolName stamped) — verified live; all-UpToDate wait blocked, see below |
| L7 | `replay/r-c-autoplace-plus-one.yaml` (+ `tiebreaker_present`/`no_tiebreaker`) | **PASS** | operator-CLI replay green: witness present before `+1`, gone after; replica_count reaches 3 |
| Oracle | upstream LINSTOR 1.33.2 parity | PASS | `+1` succeeds (rc=0), upstream `Added disk on <witness-node>` (in-place upgrade), all-diskful / 0-tiebreaker end shape — matches BS |

**Live-stand confirmation of the fix:** on the branch image, `r c --auto-place +1` against the 2-diskful + 1-witness `ccd2b-ap` correctly flipped the witness on the third node to diskful (`spec.flags` cleared on all three replicas, `spec.storagePool=stand` stamped on the ex-witness) — the exact corner-D2b behaviour, previously rc=10.

**DRBD-level caveat (stand environment, NOT this change):** the L6 cells additionally wait for all replicas `UpToDate`, which did not converge on the stand. Root cause is environmental and orthogonal to corner-D2b: `linstor resource-group spawn-resources <rg> <rd> 32M` on the stand's client (linstor-client 1.27.1) persisted `sizeKib: 32` (32 KiB) instead of 32 MiB, so the FILE_THIN backing file was 32768 bytes — too small for DRBD metadata (`drbdadm create-md … /dev/loopN is only 32768 bytes. That's not enough.`). This fails `create-md` for **every** diskful replica of the RD, including plain (never-tiebreaker) spawn replicas — confirming it is a `spawn-resources` size-arg parse quirk, not the witness-upgrade path. A clean `vd create … 32M` on the same stand correctly yields `sizeKib: 32768`.

## Leftovers / follow-ups (out of scope for this PR)

- **Stand `spawn-resources` size-arg quirk**: on the dev stand, `linstor resource-group spawn-resources <rg> <rd> 32M` persists `sizeKib: 32` rather than `32768`; a direct `vd create … 32M` is correct. This breaks DRBD `create-md` for any RD spawned that way (volume too small for metadata) and equally affects the pre-existing `cli-matrix/r-c-autoplace-plus-one.sh`. Worth a separate harness/CLI investigation; it is independent of this change (the control-plane upgrade is verified via L1/L7/oracle).


### `r-full-lifecycle` gate (mandatory for autoplace/tiebreaker changes)

Ran `cli-matrix/r-full-lifecycle.sh` on the stand against the branch image:

- **Phase 1** (autoplace=2 → 2 diskful + auto-tiebreaker) — **PASS**. Both diskful peers reached UpToDate; tiebreaker witness present. This is the exact surface corner-D2b touches.
- **Phase 2** (same-node `r d` + bare `r c` → must re-spawn diskful, Bug 327/339) — **PASS**.
- **Phase 3** (relocate: `r d` a diskful, `r c` on the ex-tiebreaker node) — **FAIL, slow-resync only**:

  ```
  wait_status_state: …dev-worker-3 vol=0 never reached 'UpToDate' (last='') within 120s
  FAIL: Phase 3: dev-worker-3 never reached UpToDate after relocate
  ```

  This is the documented stand slow-resync limitation, not a correctness regression: the lifecycle uses a 512 MiB volume and the stand resyncs at ~4 MB/s (≈128 s for a full sync), which exceeds Phase 3's 120 s `wait_status_state` budget. Throughout the run the resync was **monotonic with `Conns Ok`** (observed live: Phase 1 progressed 28% → 65% → 75% → 100%; the relocate replica was actively SyncTarget at the cutoff, peers Established). The same `replay-r-full-lifecycle` workflow also fails `rc=1` on a concurrently-running agent's session on this shared stand, confirming the timeout is environmental. Phases 1–2 — the autoplace + tiebreaker-promote surface this PR modifies — both passed.
