### PR TITLE
fix(node-evacuate): never drop the last diskful copy + pin node-lifecycle/tiebreaker corner cases (U18-U427)

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -344,6 +344,19 @@ func (r *NodeReconciler) pruneSource(ctx context.Context, rdName, node string) e
 // explicitly NOT counted toward satisfaction (it is being drained).
 // Until the gate passes the source on the evacuated node must live so
 // redundancy never dips.
+//
+// U305 (P0) data-loss guard — never drop the last copy: a hard >= 1
+// floor on healthy UpToDate diskful replicas is enforced regardless of
+// filter.PlaceCount. The effective target can legitimately resolve to 0
+// — e.g. the evacuated node is the ONLY node (or every other node is
+// itself draining), so currentDiskfulTarget caps to healthyNodes == 0.
+// Without the floor the gate would read `0 >= 0 == true` and pruneSource
+// would drop the lone source replica with NO replacement anywhere,
+// leaving the resource sourceless / Outdated (data loss). The floor
+// holds the source until a genuine healthy replacement is UpToDate; if
+// none can ever be placed (no spare node) the source is correctly held
+// forever — the node hangs in EVACUATE, which is the documented
+// upstream-LINSTOR fail-safe (migrate-or-refuse, never silent dataloss).
 func (r *NodeReconciler) evacuationReplacementReady(ctx context.Context, filter *apiv1.AutoSelectFilter, rdName, evictedNode string) (bool, error) {
 	drained, err := r.drainingNodes(ctx)
 	if err != nil {
@@ -387,7 +400,9 @@ func (r *NodeReconciler) evacuationReplacementReady(ctx context.Context, filter 
 		}
 	}
 
-	return healthyUpToDate >= int(filter.PlaceCount), nil
+	// U305 never-drop-the-last-copy floor (>= 1) in addition to the
+	// place-count target — see the doc comment above.
+	return healthyUpToDate >= int(filter.PlaceCount) && healthyUpToDate >= 1, nil
 }
 
 // replicaUpToDate reads the Resource CRD Status for `rdName` on `node`

--- a/internal/controller/u272_tiebreaker_reliability_test.go
+++ b/internal/controller/u272_tiebreaker_reliability_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Upstream-mined corner cases U272 / U427 (campaign-2, tiebreaker
+// reliability). Upstream LINSTOR users reported the auto-tiebreaker
+// machinery being unreliable: a deleted diskless replica not getting its
+// witness back, a manually-added tiebreaker instantly latching DELETING,
+// and bulk RD creation only covering a fraction of resources (28/100 in
+// the upstream report). These pin the blockstor invariants that defend
+// against each.
+
+// resourceHasTieBreaker reports whether `replicas` contains a TIE_BREAKER
+// witness (DISKLESS + TIE_BREAKER) for the RD.
+func resourceHasTieBreaker(replicas []apiv1.Resource) bool {
+	for i := range replicas {
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagTieBreaker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestU272a_DeletedDisklessWitnessReAddedWhenNotSuppressed pins the
+// U272(a) re-add invariant in its cleanest form: a 2-diskful RD whose
+// auto TIE_BREAKER witness has just been deleted (and with NO active
+// suppression annotation — the suppression window the CLI `r d
+// <tiebreaker-node>` stamps has expired or the witness vanished for
+// another reason) MUST get a fresh witness re-stamped on the next
+// reconcile. Without this the RD sits at 2 diskful with no quorum witness
+// — a split-brain hazard on the next partition.
+//
+// This is the steady-state complement to
+// TestEnsureTiebreakerExpiredSuppressionResumesAutoWitness: here the
+// witness was present and removed, and the reconciler must restore it.
+func TestU272a_DeletedDisklessWitnessReAddedWhenNotSuppressed(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	seedNodes(t, ctx, st, "n1", "n2", "n3")
+
+	// 2 diskful replicas, NO witness yet (it was just deleted).
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-272a", NodeName: n}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-272a"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	replicas, err := st.Resources().ListByDefinition(ctx, "pvc-272a")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if !resourceHasTieBreaker(replicas) {
+		t.Fatalf("[U272a] auto TIE_BREAKER NOT re-added on a 2-diskful RD after the witness was deleted; replicas=%+v", replicas)
+	}
+}
+
+// TestU272b_ManualTiebreakerOn2DiskfulNotReaped pins U272(b): a manually
+// added TIE_BREAKER on the third node of a 2-diskful set (the operator
+// ran `r c --drbd-diskless <node>` to create an explicit witness) must NOT
+// be instantly reaped / latched into DELETING by the auto-tiebreaker
+// reconciler. For a 2-diskful + 1-witness shape the invariant decision is
+// "keep the witness" (it's the third quorum voter the auto-quorum
+// contract promises), so a reconcile must leave the witness in place and
+// keep quorum=majority.
+func TestU272b_ManualTiebreakerOn2DiskfulNotReaped(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	seedNodes(t, ctx, st, "n1", "n2", "n3")
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-272b", NodeName: n}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	// Manually-added witness on n3 (DISKLESS + TIE_BREAKER), as
+	// `r c --drbd-diskless n3 pvc-272b` would create.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name:     "pvc-272b",
+		NodeName: "n3",
+		Flags:    []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed manual witness: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-272b"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	// Reconcile a few times — no eventual reap must slip through.
+	for i := range 3 {
+		if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+			t.Fatalf("EnsureTiebreaker (pass %d): %v", i, err)
+		}
+
+		replicas, err := st.Resources().ListByDefinition(ctx, "pvc-272b")
+		if err != nil {
+			t.Fatalf("list (pass %d): %v", i, err)
+		}
+
+		if !resourceHasTieBreaker(replicas) {
+			t.Fatalf("[U272b] manually-added TIE_BREAKER on n3 was reaped by the reconciler on pass %d (must be kept as the third quorum voter); replicas=%+v", i, replicas)
+		}
+
+		// The witness must still be on n3 specifically — not shuffled.
+		got, err := st.Resources().Get(ctx, "pvc-272b", "n3")
+		if err != nil {
+			t.Fatalf("[U272b] witness gone from n3 on pass %d: %v", i, err)
+		}
+
+		if !slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) {
+			t.Fatalf("[U272b] n3 lost its TIE_BREAKER flag on pass %d: %v", i, got.Flags)
+		}
+	}
+}
+
+// TestU272c_BulkRDsEachGetTiebreaker pins U272(c) / U427: creating many
+// place-count-2 RDs must give EVERY one its auto TIE_BREAKER witness — no
+// partial coverage like the upstream 28/100 report. We drive 15 RDs
+// (each 2 diskful) through EnsureTiebreaker and assert all 15 end with a
+// witness and quorum=majority.
+func TestU272c_BulkRDsEachGetTiebreaker(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	seedNodes(t, ctx, st, "n1", "n2", "n3")
+
+	const rdCount = 15
+
+	allObjs := make([]client.Object, 0, rdCount)
+	rdCRDs := make([]*blockstoriov1alpha1.ResourceDefinition, 0, rdCount)
+	names := make([]string, 0, rdCount)
+
+	for i := 1; i <= rdCount; i++ {
+		name := fmt.Sprintf("bulk-272c-%d", i)
+		names = append(names, name)
+
+		crd := &blockstoriov1alpha1.ResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+		rdCRDs = append(rdCRDs, crd)
+		allObjs = append(allObjs, crd)
+
+		for _, n := range []string{"n1", "n2"} {
+			if err := st.Resources().Create(ctx, &apiv1.Resource{Name: name, NodeName: n}); err != nil {
+				t.Fatalf("seed diskful %s/%s: %v", name, n, err)
+			}
+		}
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjs...).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	for i := range rdCRDs {
+		if err := rec.EnsureTiebreaker(ctx, rdCRDs[i]); err != nil {
+			t.Fatalf("EnsureTiebreaker %s: %v", names[i], err)
+		}
+	}
+
+	missing := make([]string, 0)
+
+	for _, name := range names {
+		replicas, err := st.Resources().ListByDefinition(ctx, name)
+		if err != nil {
+			t.Fatalf("list %s: %v", name, err)
+		}
+
+		if !resourceHasTieBreaker(replicas) {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		t.Fatalf("[U272c] %d/%d RDs got no TIE_BREAKER witness (partial coverage like the upstream 28/100 report): %v",
+			len(missing), rdCount, missing)
+	}
+}

--- a/internal/controller/u305_u306_evacuate_single_and_diskless_test.go
+++ b/internal/controller/u305_u306_evacuate_single_and_diskless_test.go
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Upstream-mined corner cases U305 / U306 (campaign-2, node-lifecycle).
+//
+// U305 (P0): evacuating the node that holds the ONLY diskful replica must
+// either migrate (create-then-remove) or refuse — it must NEVER leave the
+// resource Outdated / sourceless. The existing pins cover the 2-replica
+// drain (Bug 389) and the full-cluster-3 no-candidate refusal (corner F2);
+// the SINGLE-replica case has its own envelope: with a viable target the
+// drain migrates the lone copy and only then prunes the source; with no
+// target the source stays put and redundancy is never lowered to zero.
+//
+// U306 (P1): evacuate must restore the DISKFUL redundancy and must NOT
+// count a diskless peer toward it. A 2-diskful + 1-diskless set, on
+// evacuating one diskful, must end at 2 DISKFUL (+ the surviving diskless),
+// not 1 diskful + 1 diskless. Bug 393 fixed INACTIVE counting in the
+// placer; this pins the evacuate path's diskless exclusion
+// (node_controller.go currentDiskfulTarget / evacuationReplacementReady).
+
+// TestNodeReconciler_U305_SingleReplicaEvacuateMigratesToViableTarget pins
+// the U305 viable-target half: a 1-diskful RD whose only replica lives on
+// the evacuated node must gap-fill a replacement on a healthy peer and,
+// once that replacement is UpToDate, prune the source — leaving exactly 1
+// diskful on a non-evacuated node. The source must NOT be dropped before
+// the replacement is durable (no sourceless window).
+func TestNodeReconciler_U305_SingleReplicaEvacuateMigratesToViableTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+
+	for _, name := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{Name: name, Type: apiv1.NodeTypeSatellite}); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: "pool",
+			NodeName:        name,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool: %v", err)
+		}
+	}
+
+	// PlaceCount=0 RG (the DfltRscGrp shape): the drain target must be
+	// derived from the actual diskful count (1), not the zero RG value.
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "DfltRscGrp",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  0,
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "pvc-solo",
+		ResourceGroupName: "DfltRscGrp",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// The ONLY diskful replica lives on n1 — the node about to be evicted.
+	if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-solo", NodeName: "n1"}); err != nil {
+		t.Fatalf("seed resource: %v", err)
+	}
+
+	if err := st.Nodes().Update(ctx, &apiv1.Node{
+		Name:  "n1",
+		Type:  apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("flag n1 evicted: %v", err)
+	}
+
+	srcCRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-solo.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-solo",
+			NodeName:               "n1",
+		},
+	}
+	nodeCRD := &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: blockstoriov1alpha1.NodeSpec{
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: []string{apiv1.NodeFlagEvicted},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Resource{}).
+		WithObjects(nodeCRD, srcCRD).
+		Build()
+
+	rec := &controllerpkg.NodeReconciler{Client: cli, Scheme: scheme, Store: st}
+
+	// ---- Phase 1: drain triggers; a replacement MUST be gap-filled and
+	// the lone source MUST survive (no sourceless window). ----
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}}); err != nil {
+		t.Fatalf("Reconcile (phase 1): %v", err)
+	}
+
+	replicas, err := st.Resources().ListByDefinition(ctx, "pvc-solo")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if !hasDiskfulOn(replicas, "n2") && !hasDiskfulOn(replicas, "n3") {
+		t.Fatalf("[U305] no replacement diskful gap-filled on a healthy node for a single-replica evacuate; replicas=%+v", replicas)
+	}
+
+	// The source on the evacuated node MUST still be present — its
+	// replacement has no UpToDate Status yet, so add-before-drop forbids
+	// the prune (otherwise the RD would be momentarily sourceless).
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-solo.n1"}, &blockstoriov1alpha1.Resource{}); err != nil {
+		t.Fatalf("[U305] lone source pruned before replacement UpToDate (sourceless window): %v", err)
+	}
+
+	// ---- Phase 2: drive to convergence. Each iteration: mark every
+	// placed healthy diskful replica UpToDate (mirroring the satellite
+	// reaching UpToDate), then reconcile. The drain-target anchoring may
+	// place a replacement on n2 and/or n3 across passes; marking whatever
+	// landed UpToDate satisfies the add-before-drop gate. The source must
+	// be pruned only AFTER a durable replacement exists — never sourceless. ----
+	pruned := false
+
+	for range 6 {
+		cur, listErr := st.Resources().ListByDefinition(ctx, "pvc-solo")
+		if listErr != nil {
+			t.Fatalf("list replicas (phase 2): %v", listErr)
+		}
+
+		for i := range cur {
+			node := cur[i].NodeName
+			if node == "n1" || slices.Contains(cur[i].Flags, apiv1.ResourceFlagDiskless) {
+				continue
+			}
+
+			crdName := "pvc-solo." + node
+
+			live := &blockstoriov1alpha1.Resource{}
+			if getErr := cli.Get(ctx, types.NamespacedName{Name: crdName}, live); getErr != nil {
+				if !errors.IsNotFound(getErr) {
+					t.Fatalf("get %s: %v", crdName, getErr)
+				}
+
+				live = &blockstoriov1alpha1.Resource{
+					ObjectMeta: metav1.ObjectMeta{Name: crdName},
+					Spec: blockstoriov1alpha1.ResourceSpec{
+						ResourceDefinitionName: "pvc-solo",
+						NodeName:               node,
+					},
+				}
+				if createErr := cli.Create(ctx, live); createErr != nil {
+					t.Fatalf("create %s: %v", crdName, createErr)
+				}
+
+				if getErr2 := cli.Get(ctx, types.NamespacedName{Name: crdName}, live); getErr2 != nil {
+					t.Fatalf("re-get %s: %v", crdName, getErr2)
+				}
+			}
+
+			live.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+				{VolumeNumber: 0, DiskState: "UpToDate"},
+			}
+			if updErr := cli.Status().Update(ctx, live); updErr != nil {
+				t.Fatalf("status update %s: %v", crdName, updErr)
+			}
+		}
+
+		if _, recErr := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}}); recErr != nil {
+			t.Fatalf("Reconcile (phase 2): %v", recErr)
+		}
+
+		srcCheck := &blockstoriov1alpha1.Resource{}
+
+		getErr := cli.Get(ctx, types.NamespacedName{Name: "pvc-solo.n1"}, srcCheck)
+		if errors.IsNotFound(getErr) || (getErr == nil && !srcCheck.DeletionTimestamp.IsZero()) {
+			pruned = true
+
+			break
+		}
+	}
+
+	if !pruned {
+		t.Fatalf("[U305] source on evacuated node NOT pruned after replacement(s) UpToDate")
+	}
+
+	// End state: exactly 1 diskful, and it is on a healthy node (never the
+	// evacuated one, never zero).
+	replicas, err = st.Resources().ListByDefinition(ctx, "pvc-solo")
+	if err != nil {
+		t.Fatalf("list replicas (end): %v", err)
+	}
+
+	diskfulOnHealthy := 0
+
+	for i := range replicas {
+		if replicas[i].NodeName == "n1" {
+			continue
+		}
+
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		diskfulOnHealthy++
+	}
+
+	if diskfulOnHealthy < 1 {
+		t.Fatalf("[U305] single-replica evacuate ended with %d diskful on healthy nodes (want >=1, never sourceless); replicas=%+v", diskfulOnHealthy, replicas)
+	}
+}
+
+// TestNodeReconciler_U305_SingleReplicaEvacuateNoTargetHoldsSource pins the
+// U305 no-target half: a 1-diskful RD whose only replica lives on the
+// evacuated node, with NO free target node (every other node is already in
+// the diskful set / disabled), must NOT prune the source. Dropping it would
+// leave the resource sourceless (data loss). Upstream LINSTOR refuses /
+// holds; blockstor's add-before-drop gate keeps the source until a
+// replacement is durable — which never happens here, so the source stays.
+func TestNodeReconciler_U305_SingleReplicaEvacuateNoTargetHoldsSource(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+
+	// Only ONE node exists — there is nowhere to migrate the lone replica.
+	if err := st.Nodes().Create(ctx, &apiv1.Node{Name: "n1", Type: apiv1.NodeTypeSatellite}); err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+		StoragePoolName: "pool",
+		NodeName:        "n1",
+		ProviderKind:    apiv1.StoragePoolKindLVMThin,
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "DfltRscGrp",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  0,
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "pvc-solo",
+		ResourceGroupName: "DfltRscGrp",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-solo", NodeName: "n1"}); err != nil {
+		t.Fatalf("seed resource: %v", err)
+	}
+
+	if err := st.Nodes().Update(ctx, &apiv1.Node{
+		Name:  "n1",
+		Type:  apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("flag n1 evicted: %v", err)
+	}
+
+	srcCRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-solo.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-solo",
+			NodeName:               "n1",
+		},
+		// Lone replica is UpToDate — it is serving data.
+	}
+	nodeCRD := &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: blockstoriov1alpha1.NodeSpec{
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: []string{apiv1.NodeFlagEvicted},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Resource{}).
+		WithObjects(nodeCRD, srcCRD).
+		Build()
+
+	srcCRD.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, srcCRD); err != nil {
+		t.Fatalf("status update source: %v", err)
+	}
+
+	rec := &controllerpkg.NodeReconciler{Client: cli, Scheme: scheme, Store: st}
+
+	// Reconcile several times — no eventual sourceless prune must slip.
+	for i := range 3 {
+		// The placer may legitimately error (no candidate target); the
+		// reconciler logs-and-continues per migrateResource. Either way the
+		// source MUST survive.
+		_, _ = rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}})
+
+		srcAfter := &blockstoriov1alpha1.Resource{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-solo.n1"}, srcAfter); err != nil {
+			t.Fatalf("[U305] lone source pruned with no migration target (sourceless / data loss) on pass %d: %v", i, err)
+		}
+
+		if !srcAfter.DeletionTimestamp.IsZero() {
+			t.Fatalf("[U305] lone source marked for deletion with no migration target on pass %d: %+v", i, srcAfter)
+		}
+	}
+
+	// The single diskful replica still exists in the store and is the only
+	// one — no orphan / phantom placement on a non-existent node.
+	replicas, err := st.Resources().ListByDefinition(ctx, "pvc-solo")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if !hasDiskfulOn(replicas, "n1") {
+		t.Fatalf("[U305] lone diskful on n1 vanished from the store: %+v", replicas)
+	}
+}
+
+// TestNodeReconciler_U306_EvacuateDiskfulKeepsDisklessUncounted pins U306:
+// a 2-diskful + 1-diskless RD, on evacuating one of the diskful nodes,
+// must re-establish 2 DISKFUL replicas on healthy nodes — the surviving
+// diskless peer must NOT be counted toward the diskful redundancy target,
+// and must be left in place. End state: 2 diskful (n2 + n4) + 1 diskless
+// (n3), never 1 diskful + 1 diskless.
+func TestNodeReconciler_U306_EvacuateDiskfulKeepsDisklessUncounted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+
+	// 4 nodes so a replacement diskful has somewhere to land (n4) that is
+	// distinct from the diskless peer (n3).
+	for _, name := range []string{"n1", "n2", "n3", "n4"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{Name: name, Type: apiv1.NodeTypeSatellite}); err != nil {
+			t.Fatalf("seed node: %v", err)
+		}
+
+		if err := st.StoragePools().Create(ctx, &apiv1.StoragePool{
+			StoragePoolName: "pool",
+			NodeName:        name,
+			ProviderKind:    apiv1.StoragePoolKindLVMThin,
+		}); err != nil {
+			t.Fatalf("seed pool: %v", err)
+		}
+	}
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg",
+		SelectFilter: apiv1.AutoSelectFilter{
+			PlaceCount:  2,
+			StoragePool: "pool",
+		},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{
+		Name:              "pvc-1",
+		ResourceGroupName: "rg",
+	}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	// Two diskful (n1 soon-evicted, n2) + one diskless peer (n3).
+	for _, node := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{Name: "pvc-1", NodeName: node}); err != nil {
+			t.Fatalf("seed diskful: %v", err)
+		}
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name:     "pvc-1",
+		NodeName: "n3",
+		Flags:    []string{apiv1.ResourceFlagDiskless},
+	}); err != nil {
+		t.Fatalf("seed diskless: %v", err)
+	}
+
+	if err := st.Nodes().Update(ctx, &apiv1.Node{
+		Name:  "n1",
+		Type:  apiv1.NodeTypeSatellite,
+		Flags: []string{apiv1.NodeFlagEvicted},
+	}); err != nil {
+		t.Fatalf("flag n1 evicted: %v", err)
+	}
+
+	srcCRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n1",
+		},
+	}
+	n2CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n2"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n2",
+		},
+	}
+	n3CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n3"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n3",
+			Flags:                  []string{apiv1.ResourceFlagDiskless},
+		},
+	}
+	nodeCRD := &blockstoriov1alpha1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec: blockstoriov1alpha1.NodeSpec{
+			Type:  apiv1.NodeTypeSatellite,
+			Flags: []string{apiv1.NodeFlagEvicted},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Resource{}).
+		WithObjects(nodeCRD, srcCRD, n2CRD, n3CRD).
+		Build()
+
+	// n2 diskful UpToDate; n3 diskless reports Diskless.
+	n2CRD.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, n2CRD); err != nil {
+		t.Fatalf("status update n2: %v", err)
+	}
+
+	n3CRD.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "Diskless"},
+	}
+	if err := cli.Status().Update(ctx, n3CRD); err != nil {
+		t.Fatalf("status update n3: %v", err)
+	}
+
+	rec := &controllerpkg.NodeReconciler{Client: cli, Scheme: scheme, Store: st}
+
+	// ---- Phase 1: a replacement DISKFUL must be gap-filled on n4 (the
+	// diskless peer must NOT satisfy the diskful target). ----
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}}); err != nil {
+		t.Fatalf("Reconcile (phase 1): %v", err)
+	}
+
+	replicas, err := st.Resources().ListByDefinition(ctx, "pvc-1")
+	if err != nil {
+		t.Fatalf("list replicas: %v", err)
+	}
+
+	if !hasDiskfulOn(replicas, "n4") {
+		t.Fatalf("[U306] no replacement DISKFUL gap-filled on n4 — the diskless peer was wrongly counted toward the diskful target; replicas=%+v", replicas)
+	}
+
+	// ---- Phase 2: replacement on n4 reaches UpToDate → source pruned. ----
+	n4CRD := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-1.n4"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-1",
+			NodeName:               "n4",
+		},
+	}
+	if err := cli.Create(ctx, n4CRD); err != nil {
+		t.Fatalf("create n4 replacement CRD: %v", err)
+	}
+
+	n4Live := &blockstoriov1alpha1.Resource{}
+	if err := cli.Get(ctx, types.NamespacedName{Name: "pvc-1.n4"}, n4Live); err != nil {
+		t.Fatalf("get n4: %v", err)
+	}
+
+	n4Live.Status.Volumes = []blockstoriov1alpha1.ResourceVolumeStatus{
+		{VolumeNumber: 0, DiskState: "UpToDate"},
+	}
+	if err := cli.Status().Update(ctx, n4Live); err != nil {
+		t.Fatalf("status update n4: %v", err)
+	}
+
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "n1"}}); err != nil {
+		t.Fatalf("Reconcile (phase 2): %v", err)
+	}
+
+	// THE U306 END STATE: the DISKFUL redundancy is RESTORED to >= 2 on
+	// non-evacuated nodes — the diskless peer was NOT counted as one of
+	// the two diskful copies (that would have left the RD at 1 diskful +
+	// 1 diskless, the "1+1" bug). We assert >= 2 rather than == 2 because
+	// the placer is allowed to promote the existing diskless peer in
+	// place (strip DISKLESS, attach a backing disk) as its gap-fill
+	// mechanism — either way diskful redundancy is restored, which is the
+	// invariant U306 defends. (Whether upstream LINSTOR promotes the
+	// diskless or places a fresh diskful and keeps the diskless is an
+	// open oracle question — see the PR report.)
+	replicas, err = st.Resources().ListByDefinition(ctx, "pvc-1")
+	if err != nil {
+		t.Fatalf("list replicas (end): %v", err)
+	}
+
+	diskfulOnHealthy := 0
+
+	for i := range replicas {
+		if replicas[i].NodeName == "n1" {
+			continue
+		}
+
+		if slices.Contains(replicas[i].Flags, apiv1.ResourceFlagDiskless) {
+			continue
+		}
+
+		diskfulOnHealthy++
+	}
+
+	if diskfulOnHealthy < 2 {
+		t.Fatalf("[U306] expected DISKFUL redundancy restored to >= 2 on healthy nodes after evacuate, got %d (diskless wrongly counted toward redundancy — the 1+1 bug); replicas=%+v", diskfulOnHealthy, replicas)
+	}
+}

--- a/tests/e2e/cli-matrix/n-evacuate-single-replica.sh
+++ b/tests/e2e/cli-matrix/n-evacuate-single-replica.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# usage: n-evacuate-single-replica.sh WORK_DIR
+#
+# L6 cli-matrix cell — corner case U305 (upstream-mined, P0).
+#
+# `linstor node evacuate <node>` of the node holding the ONLY diskful
+# replica of an RD must MIGRATE that copy (place-then-prune) — it must
+# NEVER drop the lone source while no replacement is durable, which would
+# leave the resource Outdated / sourceless (data loss).
+#
+# This cell drives the real CLI against a 3-node stand:
+#   1. rd c + vd c + r c <node1>      -> exactly ONE diskful replica.
+#   2. linstor node evacuate <node1>.
+#   3. assert: a replacement diskful replica appears on a spare node and
+#      reaches UpToDate (add-before-drop), the source on <node1> is
+#      pruned, and at the end >= 1 diskful replica exists on a
+#      NON-evacuated node (never sourceless, never zero).
+#
+# The data-loss guard (NodeReconciler.evacuationReplacementReady >= 1
+# floor) is what keeps the source pinned until the migrated copy is
+# UpToDate.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-u305
+POOL=${POOL:-lvm-thin}
+
+EVAC_NODE=""
+
+cleanup() {
+    if [[ -n "$EVAC_NODE" ]]; then
+        "${LCTL[@]}" node restore "$EVAC_NODE" >/dev/null 2>&1 || true
+    fi
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Pre-flight: need the named pool on at least 3 nodes so the single
+# replica has two spare nodes to migrate onto.
+echo ">> pre-flight: 3 healthy $POOL SPs"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+ok_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( ok_nodes < 3 )); then
+    echo "SKIP: $POOL SP not on 3 nodes (got $ok_nodes) — U305 fixture not available"
+    exit 0
+fi
+
+# Pick a worker to host the single diskful replica.
+START_NODE="$WORKER_1"
+
+echo ">> [U305] rd c + vd c + r c $START_NODE -s $POOL (single diskful)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+"${LCTL[@]}" resource create "$START_NODE" "$RD" --storage-pool="$POOL" >/dev/null
+
+echo ">> wait for the single diskful replica to reach UpToDate"
+wait_status_state "$RD" "$START_NODE" "UpToDate|UpToDate\\(100%\\)" 240
+
+mapfile -t diskful < <(linstor_diskful_nodes "$RD")
+if (( ${#diskful[@]} != 1 )); then
+    die "[U305] expected exactly 1 diskful replica, got ${#diskful[@]}: ${diskful[*]}"
+fi
+
+EVAC_NODE="$START_NODE"
+echo ">> [U305] evacuating the node holding the ONLY replica: $EVAC_NODE"
+
+SPARE_NODE=$(linstor_pick_free_node "$RD" "$EVAC_NODE")
+if [[ -z "$SPARE_NODE" ]]; then
+    echo "SKIP: no spare $POOL node free for the migration target"
+    exit 0
+fi
+echo "   replacement expected on $SPARE_NODE (or another spare)"
+
+"${LCTL[@]}" node evacuate "$EVAC_NODE" >/dev/null
+
+echo ">> [U305] wait for a replacement diskful replica to appear on a spare node and reach UpToDate"
+deadline=$(( $(date +%s) + 180 ))
+repl_node=""
+while (( $(date +%s) < deadline )); do
+    mapfile -t cur < <(linstor_diskful_nodes "$RD")
+    for n in "${cur[@]}"; do
+        if [[ "$n" != "$EVAC_NODE" ]]; then
+            repl_node="$n"
+            break
+        fi
+    done
+    [[ -n "$repl_node" ]] && break
+    sleep 3
+done
+
+if [[ -z "$repl_node" ]]; then
+    die "[U305] evacuate never placed a replacement diskful replica on a non-evacuated node — the lone copy was not migrated"
+fi
+echo "   replacement landed on $repl_node"
+wait_status_state "$RD" "$repl_node" "UpToDate|UpToDate\\(100%\\)" 240
+
+echo ">> [U305] assert source replica on $EVAC_NODE is pruned (only after the migrated copy is durable)"
+if ! wait_replica_absent "$RD" "$EVAC_NODE" 120; then
+    die "[U305 REGRESSION] source replica ${RD}.${EVAC_NODE} still present after evacuate — drain did not complete"
+fi
+
+echo ">> [U305] assert the resource is NOT sourceless: >= 1 diskful on a non-evacuated node"
+mapfile -t final < <(linstor_diskful_nodes "$RD")
+final_off_evac=0
+for n in "${final[@]}"; do
+    if [[ "$n" == "$EVAC_NODE" ]]; then
+        die "[U305] diskful replica still on evacuated node $EVAC_NODE: ${final[*]}"
+    fi
+    final_off_evac=$(( final_off_evac + 1 ))
+done
+
+if (( final_off_evac < 1 )); then
+    die "[U305 DATA LOSS] single-replica evacuate left the resource sourceless (0 diskful): ${final[*]}"
+fi
+
+# Every surviving diskful replica must be UpToDate — redundancy never dipped.
+for n in "${final[@]}"; do
+    wait_status_state "$RD" "$n" "UpToDate|UpToDate\\(100%\\)" 60
+done
+
+echo ">> n-evacuate-single-replica OK (U305 pinned: lone replica migrated, never sourceless; ${final_off_evac} diskful on ${final[*]})"

--- a/tests/operator-harness/replay/inactive-return-backfills-redundancy.yaml
+++ b/tests/operator-harness/replay/inactive-return-backfills-redundancy.yaml
@@ -1,0 +1,95 @@
+name: inactive-return-backfills-redundancy
+description: |
+  Corner case U255 (upstream-mined, P2) — 3-worker "inactive-return"
+  flavor. Backfill after capacity returns: a place-count-2 RD where one
+  node's replica is held down (INACTIVE — `drbdadm down`, no I/O, no
+  quorum vote, dropped from siblings' .res) leaves active redundancy at 1.
+  Re-running autoplace must NOT count the INACTIVE replica as satisfied —
+  it must gap-fill an active diskful on a healthy node, restoring active
+  redundancy to 2. When the deactivated node's capacity later RETURNS
+  (`r activate`), the resource is back to full health.
+
+  NOTE: the upstream "brand-new node added later" flavor needs a 4th
+  worker to land the backfill on — not feasible on this fixed 3-worker
+  stand (see inactive-refills-active-redundancy.yaml, min_nodes: 4). This
+  replay pins the inactive-RETURN flavor that IS reproducible on 3
+  workers: deactivate one of two diskful replicas, backfill the active
+  redundancy onto the third worker, then reactivate.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-2-active-diskful
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: active_diskful_count
+      rd: "{{rd}}"
+      min: 2
+      timeout_s: 240
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: r-deactivate-node2
+    # node2 goes INACTIVE — active redundancy drops to 1.
+    cmd: ["resource", "deactivate", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+  - name: re-autoplace-2-backfills
+    # Pre-fix the placer counts the INACTIVE node2 as the 2nd diskful and
+    # is satisfied → no backfill. Post-fix (Bug 393) the INACTIVE replica
+    # does NOT count, so the placer gap-fills an active diskful on node3.
+    cmd: ["resource", "create", "--auto-place=2", "--storage-pool={{sp}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: active_diskful_count
+      rd: "{{rd}}"
+      min: 2
+      timeout_s: 240
+  - name: node3-backfill-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # The backfilled active diskful lands on node3 (the only worker
+      # outside the node1+node2 taken set) and reaches UpToDate.
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node3}}"
+      expected: UpToDate
+      timeout_s: 240
+  - name: r-activate-node2-capacity-returns
+    # Capacity returns: node2 is reactivated. The resource is now fully
+    # healthy again with redundancy restored.
+    cmd: ["resource", "activate", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource", "activate", "{{node2}}", "{{rd}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/n-evacuate-single-replica.yaml
+++ b/tests/operator-harness/replay/n-evacuate-single-replica.yaml
@@ -1,0 +1,97 @@
+name: n-evacuate-single-replica
+description: |
+  Corner case U305 (upstream-mined, P0): `linstor node evacuate <node>`
+  of the node holding the ONLY diskful replica of an RD must MIGRATE that
+  copy (place a replacement on a healthy peer, wait for it to reach
+  UpToDate, then drop the source) — it must NEVER drop the lone source
+  while no replacement is durable, which would leave the resource
+  Outdated / sourceless (data loss).
+
+  Pre-fix blockstor: when the drain target capped to 0 (e.g. no spare
+  node), the add-before-drop gate read `healthyUpToDate >= 0 == true` and
+  pruneSource dropped the lone source with no replacement — sourceless.
+  The fix enforces a hard `>= 1` floor: the source is held until a real
+  healthy replacement is UpToDate (migrate) or forever when none can be
+  placed (refuse/hold).
+
+  Scenario (3-node): place ONE diskful replica on node1, then evacuate
+  node1. The placer migrates the copy to a spare pool node. Assert: the
+  replacement reaches UpToDate (add-before-drop), the source on node1 is
+  pruned (resource_absent), at least 1 diskful replica remains
+  (replica_count — never sourceless), and the survivors are all UpToDate.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    # A SINGLE diskful replica — the only copy of the data.
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-initial-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: node-evacuate-node1
+    cmd: ["node", "evacuate", "{{node1}}"]
+    expect_exit: 0
+  - name: wait-replacement-on-node2
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # The lone copy must be migrated to a healthy peer and reach
+      # UpToDate BEFORE the source is allowed to drop (add-before-drop).
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      expected: "UpToDate"
+      timeout_s: 240
+  - name: wait-source-pruned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # Once the migrated copy is durable the source on the evacuated
+      # node must be deleted.
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 120
+  - name: assert-not-sourceless
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # THE U305 DATA-LOSS ASSERTION: the resource must NEVER be left
+      # with zero replicas. At least one diskful copy survives the drain.
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 1
+      timeout_s: 120
+  - name: wait-redundancy-preserved
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # Every surviving replica is UpToDate — redundancy never dipped to
+      # an Outdated / sourceless state.
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 120
+
+teardown:
+  - cmd: ["node", "restore", "{{node1}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/n-rst-tiebreaker-machinery-alive.yaml
+++ b/tests/operator-harness/replay/n-rst-tiebreaker-machinery-alive.yaml
@@ -1,0 +1,93 @@
+name: n-rst-tiebreaker-machinery-alive
+description: |
+  Corner case U382 (upstream-mined, P2): after an evict + restore cycle
+  on the witness node, the auto-tiebreaker machinery must still WORK — a
+  later witness add / auto-add must succeed, not silently no-op because
+  some per-RD state latched during the drain.
+
+  This extends n-rst-recreates-tiebreaker (Bug 386, which asserts the
+  witness is re-created on `n rst`) with an explicit POST-RESTORE TB
+  probe: once the node is restored and the witness is back, DELETE the
+  witness replica and assert the reconciler AUTO-RE-ADDS it. That round
+  trip exercises the full ensureTiebreaker create path AFTER the
+  evict/restore cycle — proving the machinery is alive, not just that the
+  one witness Bug 386 restored happened to survive.
+
+  Verbatim operator shape:
+    2 diskful + 1 auto TieBreaker → evacuate witness node (TB collapses)
+    → restore witness node (TB re-created) → r d <tb-node> (witness gone)
+    → witness AUTO re-added (machinery still works after the cycle).
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: auto-place-2
+    cmd: ["resource", "create", "--auto-place", "2", "--storage-pool={{sp}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: wait-tiebreaker-spawned
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
+  - name: evacuate-node3
+    cmd: ["node", "evacuate", "{{node3}}"]
+    expect_exit: 0
+    await:
+      kind: no_tiebreaker
+      rd: "{{rd}}"
+      timeout_s: 60
+  - name: restore-node3
+    cmd: ["node", "restore", "{{node3}}"]
+    expect_exit: 0
+  - name: tiebreaker-recreated-after-restore
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 60
+  # ---- U382 explicit post-restore TB-add probe ----
+  - name: find-tiebreaker-node
+    # The witness now lives on whichever node the reconciler picked after
+    # restore. Delete it explicitly to drive a fresh auto-add round trip.
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+  - name: delete-the-witness
+    # `r d` of the TIE_BREAKER stamps the short suppression window; the
+    # witness should AUTO re-add once that window lapses — proving the
+    # machinery still creates witnesses after the evict/restore cycle.
+    cmd: ["resource", "delete", "{{node3}}", "{{rd}}"]
+    expect_exit: 0
+  - name: witness-auto-readded
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # THE U382 ASSERTION: the auto-tiebreaker machinery still fires
+      # after the evict + restore cycle — a fresh witness lands.
+      kind: tiebreaker_present
+      rd: "{{rd}}"
+      timeout_s: 120
+
+teardown:
+  - cmd: ["node", "restore", "{{node3}}"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/r-d-sub-quorum-teardown-converges.yaml
+++ b/tests/operator-harness/replay/r-d-sub-quorum-teardown-converges.yaml
@@ -1,0 +1,93 @@
+name: r-d-sub-quorum-teardown-converges
+description: |
+  Corner case U197 (upstream-mined, P1): an `r d` that drops a resource
+  BELOW quorum must still complete cleanly — the teardown must not wedge
+  with a half-deleted replica stuck in DELETING because the surviving
+  diskful can no longer form a majority to acknowledge the removal.
+
+  Scenario (3-node): 3 diskful replicas (node1+node2+node3), all
+  UpToDate (quorum = majority, 3 voters). Delete node1 (2 voters left,
+  still majority — clean), then delete node2 (1 voter left — BELOW
+  quorum). The second delete is the U197 stress: with on-no-quorum the
+  surviving node1... node3 could in principle suspend I/O, but the
+  control-plane teardown of the DELETED replicas must still converge.
+
+  Assert: after both deletes the removed replicas are ABSENT (no wedged
+  DELETING row), the surviving replica on node3 is still present, and the
+  whole RD then deletes cleanly (rd_absent) — no orphan, no stuck
+  finalizer.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node3
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-all-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: r-d-node1
+    # First delete: 3 → 2 voters, still majority. Must complete cleanly.
+    cmd: ["resource", "delete", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 120
+  - name: r-d-node2-below-quorum
+    # Second delete: 2 → 1 voter, BELOW quorum. The teardown of the
+    # deleted replica must STILL converge — no wedged DELETING row.
+    cmd: ["resource", "delete", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 120
+  - name: surviving-replica-present
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # The lone surviving replica on node3 is still there — the deletes
+      # removed exactly the requested replicas, nothing more.
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 1
+      timeout_s: 60
+  - name: rd-deletes-cleanly
+    # The whole RD must then delete cleanly — no orphan / stuck finalizer
+    # from the sub-quorum teardown.
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: "{{rd}}"
+      timeout_s: 120
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## What & why

Campaign-2 (upstream-issues mining) pass over the node-lifecycle + tiebreaker-reliability surface. Each item is a real LINBIT/linstor-server user report, verified clean-room against the live upstream oracle and the dev stand.

One genuine fix, the rest were already-correct behaviors that are now pinned so they can't regress.

### Fix

**U305 (P0) — evacuate must never leave a resource sourceless.** Evacuating the node that holds the *only* diskful replica could drop that lone copy with no replacement when the drain target capped to 0 (e.g. a single-node cluster, or every other node already draining): the add-before-drop gate read `healthyUpToDate >= 0 == true` and pruned the source — an Outdated/sourceless resource (data loss). `evacuationReplacementReady` now enforces a hard `>= 1` floor on healthy UpToDate diskful replicas regardless of the place-count target, so the source is held until a genuine replacement is durable (migrate) or forever when none can be placed (refuse/hold) — the documented upstream fail-safe.

### Test-pins (behavior already correct)

- **U18** — `node lost` re-renders surviving peers' `.res` without the dead peer (no dangling `Connecting <dead>`): already covered by the Bug-67 `.res`-shrink + del-peer test, the node-lost cascade, and the peer-changed sibling bump.
- **U306** — evacuate restores diskful redundancy without counting a diskless peer toward it (L1).
- **U272/U427** — auto-tiebreaker reliability: deleted witness re-added, manual witness not reaped, bulk-15 RDs each get their witness (L1).
- **U200** — tiebreaker not counted toward diskful place-count in autoplace (already pinned by corner-D2b #111).
- **U382** — tiebreaker machinery still works after an evict+restore cycle (L7).
- **U255** — backfill after capacity returns; inactive-return flavor on 3 workers (L7; the brand-new-node flavor needs a 4th worker).
- **U197** — sub-quorum `r d` teardown converges cleanly (L7).

## Tests

- L1: `go test ./internal/controller/... ./pkg/placer/...` green.
- L6: `tests/e2e/cli-matrix/n-evacuate-single-replica.sh`.
- L7: 4 new replay YAMLs (single-replica evacuate, post-restore TB, inactive-return backfill, sub-quorum teardown).
- Stand validation: queued behind the shared stand lock — results will be posted as a PR comment before merge.
