### PR TITLE
fix(rest): U130 mid-sync last-diskful delete guard + pin DELETING idempotency/relocation safety

### DIFF
--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -2763,6 +2763,18 @@ func (s *Server) handleResourceDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// U130 guard: refuse removing the LAST UpToDate diskful replica
+	// while a peer is still mid-sync (SyncTarget/Inconsistent). Dropping
+	// the only source strands the syncing peer and leaves the resource
+	// with no UpToDate backing storage. Runs BEFORE any destructive
+	// action; the legacy tiebreaker-suppression stamp below only fires
+	// on the witness path, which the guard skips (diskful-only). An
+	// explicit `?force=true` overrides. See
+	// resource_delete_last_uptodate_u130.go.
+	if !s.refuseLastUpToDateDiskfulMidSyncDelete(r.Context(), w, rdName, &existing, queryFlag(r, "force")) {
+		return
+	}
+
 	// `r d` physically removes the replica for ALL replica kinds —
 	// diskful, diskless, and tiebreaker — matching upstream LINSTOR
 	// `linstor resource delete`. The satellite resource controller's
@@ -2790,15 +2802,7 @@ func (s *Server) handleResourceDelete(w http.ResponseWriter, r *http.Request) {
 	// TIE_BREAKER still gets the auto-tiebreaker-suppression stamp so
 	// the RD-level reconciler doesn't immediately re-stamp a fresh
 	// witness the next time `ensureTiebreaker` fires.
-	tieBreaker := slices.Contains(existing.Flags, apiv1.ResourceFlagTieBreaker)
-
-	if tieBreaker {
-		// Best-effort. Failure to stamp must not block the
-		// operator-requested delete; the worst case without
-		// the annotation is "auto-witness comes back in 5
-		// seconds" — annoying, but not data-loss.
-		_ = s.stampTiebreakerSuppression(r.Context(), rdName)
-	}
+	s.maybeStampTiebreakerSuppressionOnDelete(r.Context(), rdName, &existing)
 
 	err := s.Store.Resources().Delete(r.Context(), rdName, node)
 	if err != nil {
@@ -2837,6 +2841,25 @@ func (s *Server) handleResourceDelete(w http.ResponseWriter, r *http.Request) {
 		RetCode: apiCallRcInfo | apiCallRcRscDeleted,
 		Message: "resource deleted: " + rdName + " on " + node,
 	}})
+}
+
+// maybeStampTiebreakerSuppressionOnDelete stamps the
+// auto-tiebreaker-suppression annotation on the parent RD when the
+// replica being deleted is a TIE_BREAKER, so the RD-level reconciler
+// doesn't immediately re-stamp a fresh witness the next time
+// `ensureTiebreaker` fires.
+//
+// Best-effort: a stamp failure must not block the operator-requested
+// delete; the worst case without the annotation is "auto-witness comes
+// back in ~5s" — annoying, not data-loss. Extracted from
+// handleResourceDelete to keep that handler under the funlen budget once
+// the U130 mid-sync guard was added.
+func (s *Server) maybeStampTiebreakerSuppressionOnDelete(ctx context.Context, rdName string, existing *apiv1.Resource) {
+	if !slices.Contains(existing.Flags, apiv1.ResourceFlagTieBreaker) {
+		return
+	}
+
+	_ = s.stampTiebreakerSuppression(ctx, rdName)
 }
 
 // bumpPeerChangedOnSiblings stamps an RFC3339Nano timestamp on every

--- a/pkg/rest/rd_delete_idempotent_u19_test.go
+++ b/pkg/rest/rd_delete_idempotent_u19_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// U19/U90/U112/U41/U101/U186/U242 — "Resources stuck on DELETING; can't
+// complete or retry the delete; can't reuse a name stuck in DELETING."
+//
+// BS realises the two-phase RD delete with CRD finalizers: a repeat
+// `rd d` re-stamps the (already-set) DeletionTimestamp via an idempotent
+// client.Delete, so the CLI never errors and the operator can safely
+// retry. The finalizer-blocked DELETING latch itself needs a real CRD
+// store + satellite finalizer, so it is pinned at L6
+// (rd-d-deleting-surface.sh). This L1 test pins the REST-level
+// idempotency contract on the in-memory store: a SECOND `rd d` after the
+// first succeeded returns 200 + WARN "already absent" (exit 0), and the
+// freed name is immediately reusable — the two operator-visible
+// guarantees the user reports demanded.
+
+// TestRDDeleteIdempotentRetryAfterSuccess pins that a second `rd d` on
+// an already-removed RD is a clean idempotent no-op (200 + WARN), not an
+// error. This is the retry path the user reports ("can't retry the
+// delete") and the CSI DeleteVolume replay both depend on.
+func TestRDDeleteIdempotentRetryAfterSuccess(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u19-idem"
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rd}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// First delete: real drop, MASK_INFO success.
+	first := httpDelete(t, base+"/v1/resource-definitions/"+rd)
+	defer func() { _ = first.Body.Close() }()
+
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first rd d status: got %d, want 200", first.StatusCode)
+	}
+
+	// Second delete (the retry): must be an idempotent no-op, NOT an
+	// error. python-linstor maps a 200 envelope to exit 0.
+	second := httpDelete(t, base+"/v1/resource-definitions/"+rd)
+	defer func() { _ = second.Body.Close() }()
+
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("retried rd d status: got %d, want 200 (idempotent no-op)", second.StatusCode)
+	}
+
+	var rc []apiv1.APICallRc
+	if err := json.NewDecoder(second.Body).Decode(&rc); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rc) == 0 || rc[0].RetCode&maskWarn == 0 {
+		t.Fatalf("expected WARN envelope on retried rd d, got %+v", rc)
+	}
+
+	if !strings.Contains(rc[0].Message, "already absent") {
+		t.Errorf("retried rd d message %q missing 'already absent' marker", rc[0].Message)
+	}
+}
+
+// TestRDNameReusableAfterDelete pins U186/U242: once an RD's delete
+// completes, the SAME name must be reusable — a fresh create must
+// succeed (the name was freed, no stale row blocks re-creation).
+func TestRDNameReusableAfterDelete(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u242-reuse"
+
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rd}); err != nil {
+		t.Fatalf("seed RD: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	del := httpDelete(t, base+"/v1/resource-definitions/"+rd)
+	_ = del.Body.Close()
+
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("rd d status: got %d, want 200", del.StatusCode)
+	}
+
+	// Re-create the same name through the store (the CLI path the L6
+	// cell exercises end-to-end). It must succeed: the name was freed.
+	if err := st.ResourceDefinitions().Create(ctx, &apiv1.ResourceDefinition{Name: rd}); err != nil {
+		t.Fatalf("name %q not reusable after delete: %v", rd, err)
+	}
+
+	if _, err := st.ResourceDefinitions().Get(ctx, rd); err != nil {
+		t.Errorf("re-created RD %q not retrievable: %v", rd, err)
+	}
+}

--- a/pkg/rest/resource_delete_last_uptodate_u130.go
+++ b/pkg/rest/resource_delete_last_uptodate_u130.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cockroachdb/errors"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// U130 — "LINSTOR shouldn't allow deleting the last active peer."
+//
+// Upstream user report (LINBIT/linstor-server, closed): start with 1
+// diskful + 1 diskless(Primary/InUse), `r c` a SECOND diskful (which
+// begins as SyncTarget/Inconsistent), then `r d` the ORIGINAL diskful
+// before the resync finishes. The cluster wedges: the DELETING node
+// stays Connecting, the SyncTarget is stranded (its only sync source is
+// gone), and the Primary is left on a DISKLESS replica with no UpToDate
+// backing storage anywhere.
+//
+// Guard: refuse an `r d` that would remove the LAST UpToDate diskful
+// replica while another replica is still mid-sync (a SyncTarget /
+// Inconsistent diskful exists that has not yet reached UpToDate). The
+// SyncTarget cannot finish without its UpToDate source, so dropping the
+// source is an unrecoverable data-availability loss.
+//
+// Scope is intentionally NARROW so it does not regress the prior
+// campaign decision (bug-hunt #6): "deleting the last diskful is allowed
+// like upstream" for the NO-SYNC-IN-FLIGHT case. The guard only fires
+// when ALL of:
+//   - the target replica is diskful (not diskless, not tiebreaker), and
+//   - the target is currently the only UpToDate diskful replica, and
+//   - at least one OTHER replica is a diskful mid-sync (SyncTarget /
+//     Inconsistent — it would be stranded).
+//
+// When no peer is mid-sync the deletion proceeds (last legitimate
+// diskful drop is allowed, matching upstream and bug-hunt #6).
+//
+// Override: an explicit `?force=true` bypasses the guard, mirroring
+// upstream LINSTOR's force-flag escape hatch for operator-acknowledged
+// destructive deletes.
+
+// resourceMidSyncDeleteRefusal reports whether deleting `target`
+// (already fetched) would strand a mid-sync peer per U130. It returns
+// true when the guard MUST fire and the delete must be refused.
+//
+// `siblings` is the full replica set of the RD (including `target`).
+func resourceMidSyncDeleteRefusal(target *apiv1.Resource, siblings []apiv1.Resource) bool {
+	// A diskless / tiebreaker replica carries no UpToDate backing
+	// storage; removing it never strands a SyncTarget's only source.
+	if !resourceIsDiskful(target) {
+		return false
+	}
+
+	if !resourceIsUpToDate(target) {
+		// The target itself is not an UpToDate source — removing it
+		// cannot remove "the last UpToDate source". Out of scope.
+		return false
+	}
+
+	otherUpToDateDiskful := 0
+	otherMidSyncDiskful := 0
+
+	for i := range siblings {
+		sib := &siblings[i]
+		if sib.NodeName == target.NodeName {
+			continue
+		}
+
+		if !resourceIsDiskful(sib) {
+			continue
+		}
+
+		switch {
+		case resourceIsUpToDate(sib):
+			otherUpToDateDiskful++
+		case resourceIsMidSync(sib):
+			otherMidSyncDiskful++
+		}
+	}
+
+	// Safe: another UpToDate diskful survives — the SyncTarget keeps a
+	// valid source after the delete, or there is simply nothing in
+	// flight to strand.
+	if otherUpToDateDiskful > 0 {
+		return false
+	}
+
+	// Refuse only when the target is the sole UpToDate source AND a
+	// diskful peer is mid-sync that would be stranded by the delete.
+	return otherMidSyncDiskful > 0
+}
+
+// resourceIsDiskful reports whether a replica carries real backing
+// storage (not DISKLESS, not TIE_BREAKER).
+func resourceIsDiskful(res *apiv1.Resource) bool {
+	for _, f := range res.Flags {
+		if f == apiv1.ResourceFlagDiskless || f == apiv1.ResourceFlagTieBreaker {
+			return false
+		}
+	}
+
+	return true
+}
+
+// resourceIsUpToDate reports whether any of the replica's volumes
+// observed disk_state == "UpToDate". DRBD's per-volume disk state is
+// the authoritative "this replica holds a complete, current copy"
+// signal.
+func resourceIsUpToDate(res *apiv1.Resource) bool {
+	for i := range res.Volumes {
+		if res.Volumes[i].State.DiskState == drbdDiskStateUpToDate {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resourceIsMidSync reports whether the replica is a diskful copy still
+// catching up: either its local disk_state is Inconsistent/SyncTarget,
+// or it reports a SyncTarget replication-state toward any peer. Such a
+// replica's ONLY source of truth is an UpToDate peer; losing that peer
+// strands it.
+func resourceIsMidSync(res *apiv1.Resource) bool {
+	for i := range res.Volumes {
+		vol := &res.Volumes[i]
+
+		switch vol.State.DiskState {
+		case drbdDiskStateInconsistent, drbdDiskStateSyncTarget:
+			return true
+		}
+
+		for _, rep := range vol.State.ReplicationStates {
+			if rep.ReplicationState == drbdReplStateSyncTarget {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// DRBD-9 disk-state / replication-state tokens reported by `drbdsetup
+// events2`. Raw strings (no shared constant exists in pkg/api/v1 — the
+// state surface is free-form upstream).
+const (
+	drbdDiskStateUpToDate     = "UpToDate"
+	drbdDiskStateInconsistent = "Inconsistent"
+	drbdDiskStateSyncTarget   = "SyncTarget"
+	drbdReplStateSyncTarget   = "SyncTarget"
+)
+
+// refuseLastUpToDateDiskfulMidSyncDelete is the U130 gate invoked from
+// handleResourceDelete BEFORE the destructive store Delete. It lists
+// the RD's replicas, evaluates resourceMidSyncDeleteRefusal, and on a
+// positive verdict writes a structured 409 ApiCallRc refusal envelope.
+//
+// Returns true when the caller may proceed with the delete, false when
+// the refusal has already been written.
+//
+// `force` short-circuits the guard (operator-acknowledged override).
+func (s *Server) refuseLastUpToDateDiskfulMidSyncDelete(
+	ctx context.Context, w http.ResponseWriter,
+	rdName string, target *apiv1.Resource, force bool,
+) bool {
+	if force {
+		return true
+	}
+
+	siblings, err := s.Store.Resources().ListByDefinition(ctx, rdName)
+	if err != nil {
+		// A list failure must not silently allow a destructive delete
+		// the guard might otherwise have blocked. Surface the error.
+		if errors.Is(err, store.ErrNotFound) {
+			// RD vanished concurrently — let the downstream Delete's
+			// own NotFound path produce the idempotent envelope.
+			return true
+		}
+
+		writeStoreError(w, err)
+
+		return false
+	}
+
+	if !resourceMidSyncDeleteRefusal(target, siblings) {
+		return true
+	}
+
+	writeJSON(w, http.StatusConflict, []apiv1.APICallRc{{
+		RetCode: apiCallRcError | apiCallRcFailInUse,
+		Message: "Cannot delete the last UpToDate diskful replica of '" +
+			rdName + "' on '" + target.NodeName +
+			"' while another replica is still syncing.",
+		Cause: "This is the only UpToDate copy and a peer replica is " +
+			"mid-resync (SyncTarget/Inconsistent). Removing it would " +
+			"strand the syncing peer with no source and leave the " +
+			"resource with no UpToDate backing storage.",
+		Correc: "Wait for the resync to finish (every diskful replica " +
+			"UpToDate) and retry, or pass `?force=true` to override and " +
+			"accept the data-availability risk.",
+		ObjRefs: map[string]string{
+			objRefRscDfn: rdName,
+			objRefNode:   target.NodeName,
+		},
+	}})
+
+	return false
+}

--- a/pkg/rest/resource_delete_last_uptodate_u130_test.go
+++ b/pkg/rest/resource_delete_last_uptodate_u130_test.go
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// U130 — `r d` of the last UpToDate diskful while a peer is mid-sync
+// must be REJECTED with a structured 409 envelope. These L1 tests pin
+// both the refusal (the bug) and the must-NOT-regress cases:
+//   - no peer mid-sync → last diskful delete proceeds (bug-hunt #6)
+//   - another UpToDate diskful survives → delete proceeds
+//   - diskless/tiebreaker target → never guarded
+//   - ?force=true → override bypasses the guard
+
+func seedU130RD(t *testing.T, st store.Store, rd string) {
+	t.Helper()
+
+	if err := st.ResourceDefinitions().Create(t.Context(), &apiv1.ResourceDefinition{Name: rd}); err != nil {
+		t.Fatalf("seed RD %s: %v", rd, err)
+	}
+}
+
+func diskfulReplica(rd, node, diskState string) *apiv1.Resource {
+	return &apiv1.Resource{
+		Name:     rd,
+		NodeName: node,
+		Volumes: []apiv1.Volume{{
+			VolumeNumber: 0,
+			State:        apiv1.VolumeState{DiskState: diskState},
+		}},
+	}
+}
+
+func disklessReplica(rd, node string, flag string) *apiv1.Resource {
+	return &apiv1.Resource{
+		Name:     rd,
+		NodeName: node,
+		Flags:    []string{flag},
+	}
+}
+
+// TestU130RejectsDeleteOfLastUpToDateWhilePeerSyncing is the core
+// repro: 1 diskful UpToDate source + 1 diskful SyncTarget (mid-sync) +
+// 1 diskless Primary. Deleting the UpToDate source must be refused.
+func TestU130RejectsDeleteOfLastUpToDateWhilePeerSyncing(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u130"
+
+	seedU130RD(t, st, rd)
+
+	// n1: original diskful, the only UpToDate source.
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n1", drbdDiskStateUpToDate)); err != nil {
+		t.Fatalf("seed n1: %v", err)
+	}
+	// n2: freshly-added second diskful, still catching up.
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n2", drbdDiskStateSyncTarget)); err != nil {
+		t.Fatalf("seed n2: %v", err)
+	}
+	// n3: diskless Primary/InUse holding the resource open.
+	if err := st.Resources().Create(ctx, disklessReplica(rd, "n3", apiv1.ResourceFlagDiskless)); err != nil {
+		t.Fatalf("seed n3: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n1")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (U130 refusal)", resp.StatusCode)
+	}
+
+	var rc []apiv1.APICallRc
+	if err := json.NewDecoder(resp.Body).Decode(&rc); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+
+	if len(rc) == 0 || rc[0].RetCode&apiCallRcError == 0 {
+		t.Fatalf("expected MASK_ERROR envelope, got %+v", rc)
+	}
+
+	if !strings.Contains(rc[0].Message, "last UpToDate diskful") {
+		t.Errorf("message %q missing 'last UpToDate diskful' marker", rc[0].Message)
+	}
+
+	// The replica MUST still exist — the refusal blocked the delete.
+	if _, err := st.Resources().Get(ctx, rd, "n1"); err != nil {
+		t.Errorf("n1 must survive the refused delete; got err=%v", err)
+	}
+}
+
+// TestU130RejectsViaPeerReplicationStateSyncTarget pins that the guard
+// also fires when the mid-sync signal is the per-peer replication
+// state (SyncTarget toward a peer) rather than the local disk_state.
+func TestU130RejectsViaPeerReplicationStateSyncTarget(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u130-repl"
+
+	seedU130RD(t, st, rd)
+
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n1", drbdDiskStateUpToDate)); err != nil {
+		t.Fatalf("seed n1: %v", err)
+	}
+
+	// n2 reports its local disk as Outdated but a SyncTarget
+	// replication-state toward n1 — still mid-sync, still stranded.
+	n2 := &apiv1.Resource{
+		Name:     rd,
+		NodeName: "n2",
+		Volumes: []apiv1.Volume{{
+			VolumeNumber: 0,
+			State: apiv1.VolumeState{
+				DiskState: "Outdated",
+				ReplicationStates: map[string]apiv1.ReplicationState{
+					"n1": {ReplicationState: drbdReplStateSyncTarget},
+				},
+			},
+		}},
+	}
+	if err := st.Resources().Create(ctx, n2); err != nil {
+		t.Fatalf("seed n2: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n1")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409 (U130 refusal via repl-state)", resp.StatusCode)
+	}
+}
+
+// TestU130AllowsDeleteWhenNoPeerSyncing pins bug-hunt #6: when NO peer
+// is mid-sync, deleting the last diskful is allowed (matches upstream).
+// Here n1 is the only diskful; n2 is a plain diskless (not syncing).
+func TestU130AllowsDeleteWhenNoPeerSyncing(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u130-nosync"
+
+	seedU130RD(t, st, rd)
+
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n1", drbdDiskStateUpToDate)); err != nil {
+		t.Fatalf("seed n1: %v", err)
+	}
+	if err := st.Resources().Create(ctx, disklessReplica(rd, "n2", apiv1.ResourceFlagDiskless)); err != nil {
+		t.Fatalf("seed n2: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n1")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (no-sync last-diskful delete allowed)", resp.StatusCode)
+	}
+
+	if _, err := st.Resources().Get(ctx, rd, "n1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("n1 should be physically removed; got err=%v (want ErrNotFound)", err)
+	}
+}
+
+// TestU130AllowsDeleteWhenAnotherUpToDateDiskfulSurvives pins that a
+// 2-UpToDate + 1-SyncTarget shape still permits dropping one UpToDate
+// source — the SyncTarget keeps a valid source after the delete.
+func TestU130AllowsDeleteWhenAnotherUpToDateDiskfulSurvives(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u130-twoutd"
+
+	seedU130RD(t, st, rd)
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, diskfulReplica(rd, n, drbdDiskStateUpToDate)); err != nil {
+			t.Fatalf("seed %s: %v", n, err)
+		}
+	}
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n3", drbdDiskStateSyncTarget)); err != nil {
+		t.Fatalf("seed n3: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n1")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (another UpToDate diskful survives)", resp.StatusCode)
+	}
+}
+
+// TestU130AllowsDeleteOfDisklessTargetEvenMidSync pins that the guard
+// is diskful-only: deleting a DISKLESS or TIE_BREAKER replica is never
+// blocked, even with a SyncTarget peer in flight (it holds no source).
+func TestU130AllowsDeleteOfDisklessTargetEvenMidSync(t *testing.T) {
+	for _, flag := range []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker} {
+		t.Run(flag, func(t *testing.T) {
+			st := store.NewInMemory()
+			ctx := t.Context()
+			rd := "pvc-u130-dl"
+
+			seedU130RD(t, st, rd)
+
+			if err := st.Resources().Create(ctx, diskfulReplica(rd, "n1", drbdDiskStateUpToDate)); err != nil {
+				t.Fatalf("seed n1: %v", err)
+			}
+			if err := st.Resources().Create(ctx, diskfulReplica(rd, "n2", drbdDiskStateSyncTarget)); err != nil {
+				t.Fatalf("seed n2: %v", err)
+			}
+			if err := st.Resources().Create(ctx, disklessReplica(rd, "n3", flag)); err != nil {
+				t.Fatalf("seed n3: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n3")
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("%s target: got %d, want 200 (diskless delete never guarded)", flag, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestU130ForceOverridesGuard pins the escape hatch: `?force=true`
+// bypasses the refusal so an operator can acknowledge the risk.
+func TestU130ForceOverridesGuard(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+	rd := "pvc-u130-force"
+
+	seedU130RD(t, st, rd)
+
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n1", drbdDiskStateUpToDate)); err != nil {
+		t.Fatalf("seed n1: %v", err)
+	}
+	if err := st.Resources().Create(ctx, diskfulReplica(rd, "n2", drbdDiskStateSyncTarget)); err != nil {
+		t.Fatalf("seed n2: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	resp := httpDelete(t, base+"/v1/resource-definitions/"+rd+"/resources/n1?force=true")
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (force overrides U130 guard)", resp.StatusCode)
+	}
+
+	if _, err := st.Resources().Get(ctx, rd, "n1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("n1 should be removed under force; got err=%v (want ErrNotFound)", err)
+	}
+}
+
+// TestU130PredicateUnit exercises the pure refusal predicate directly
+// so the decision matrix is pinned independent of the HTTP wiring.
+func TestU130PredicateUnit(t *testing.T) {
+	rd := "r"
+
+	cases := []struct {
+		name     string
+		target   *apiv1.Resource
+		siblings []*apiv1.Resource
+		refuse   bool
+	}{
+		{
+			name:   "last-uptodate-with-synctarget-peer",
+			target: diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+			siblings: []*apiv1.Resource{
+				diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+				diskfulReplica(rd, "n2", drbdDiskStateSyncTarget),
+			},
+			refuse: true,
+		},
+		{
+			name:   "last-uptodate-with-inconsistent-peer",
+			target: diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+			siblings: []*apiv1.Resource{
+				diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+				diskfulReplica(rd, "n2", drbdDiskStateInconsistent),
+			},
+			refuse: true,
+		},
+		{
+			name:   "no-sync-in-flight",
+			target: diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+			siblings: []*apiv1.Resource{
+				diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+				disklessReplica(rd, "n2", apiv1.ResourceFlagDiskless),
+			},
+			refuse: false,
+		},
+		{
+			name:   "another-uptodate-survives",
+			target: diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+			siblings: []*apiv1.Resource{
+				diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+				diskfulReplica(rd, "n2", drbdDiskStateUpToDate),
+				diskfulReplica(rd, "n3", drbdDiskStateSyncTarget),
+			},
+			refuse: false,
+		},
+		{
+			name:   "target-not-uptodate",
+			target: diskfulReplica(rd, "n1", drbdDiskStateInconsistent),
+			siblings: []*apiv1.Resource{
+				diskfulReplica(rd, "n1", drbdDiskStateInconsistent),
+				diskfulReplica(rd, "n2", drbdDiskStateSyncTarget),
+			},
+			refuse: false,
+		},
+		{
+			name:   "diskless-target",
+			target: disklessReplica(rd, "n3", apiv1.ResourceFlagDiskless),
+			siblings: []*apiv1.Resource{
+				diskfulReplica(rd, "n1", drbdDiskStateUpToDate),
+				diskfulReplica(rd, "n2", drbdDiskStateSyncTarget),
+				disklessReplica(rd, "n3", apiv1.ResourceFlagDiskless),
+			},
+			refuse: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sibs := make([]apiv1.Resource, len(tc.siblings))
+			for i := range tc.siblings {
+				sibs[i] = *tc.siblings[i]
+			}
+
+			got := resourceMidSyncDeleteRefusal(tc.target, sibs)
+			if got != tc.refuse {
+				t.Errorf("resourceMidSyncDeleteRefusal = %v, want %v", got, tc.refuse)
+			}
+		})
+	}
+}

--- a/tests/e2e/cli-matrix/r-d-last-uptodate-midsync-rejected.sh
+++ b/tests/e2e/cli-matrix/r-d-last-uptodate-midsync-rejected.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# usage: r-d-last-uptodate-midsync-rejected.sh WORK_DIR
+#
+# L6 cli-matrix cell — U130 (LINSTOR shouldn't allow deleting the last
+# active peer).
+#
+# User-reported upstream wedge (LINBIT/linstor-server, closed): start
+# with 1 diskful (UpToDate) + 1 diskless Primary/InUse, `r c` a SECOND
+# diskful (which begins as SyncTarget/Inconsistent), then `r d` the
+# ORIGINAL diskful before the resync finishes. The cluster wedges:
+#   - DELETING node stays Connecting,
+#   - the SyncTarget is stranded (its only sync source is gone),
+#   - the Primary is left on a diskless replica with no UpToDate backing.
+#
+# BS guard (pkg/rest/resource_delete_last_uptodate_u130.go): `r d` of the
+# LAST UpToDate diskful replica while a diskful peer is still mid-sync
+# (SyncTarget/Inconsistent) is REJECTED with a 409 ApiCallRc envelope.
+# `--force` overrides.
+#
+# How this cell holds a deterministic SyncTarget window:
+#   We throttle the resync to a very low c-max-rate and use a large
+#   volume so the second diskful stays SyncTarget/Inconsistent long
+#   enough to attempt the `r d` against a live mid-sync state. The stand
+#   can otherwise skip-sync (Bug 347 family) and the window would vanish.
+#
+# Contract:
+#   1. 1-diskful RD on N1, UpToDate, with data written (real GI bump so
+#      the second replica must actually resync).
+#   2. Throttle resync (rd drbd-options --c-max-rate) so the next add is
+#      slow.
+#   3. r c N2 (second diskful) — it enters SyncTarget/Inconsistent.
+#   4. While N2 is mid-sync, `r d N1 <rd>` (the only UpToDate source)
+#      MUST be REJECTED (non-zero CLI exit / 409) and N1 MUST survive.
+#   5. `r d N1 <rd> --force` (or via the REST ?force=true) overrides —
+#      OR we simply wait for sync to finish and assert a normal delete
+#      then succeeds. We choose the WAIT path so teardown leaves no
+#      stranded replica.
+#   6. No orphans after teardown.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 2
+
+linstor_cli_setup
+
+RD=cli-matrix-u130
+POOL=${POOL:-stand}
+# Large enough that a throttled resync stays in-flight for the probe
+# window; small enough to keep the cell quick on the FILE_THIN pool.
+SIZE_MIB=512
+
+N1=$WORKER_1
+N2=$WORKER_2
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> Phase 1: rd c + vd c + r c $N1 (single diskful, ${SIZE_MIB} MiB)"
+_out=$("${LCTL[@]}" resource-definition create "$RD" 2>&1) \
+    || { echo "FAIL: rd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" volume-definition create "$RD" "${SIZE_MIB}M" 2>&1) \
+    || { echo "FAIL: vd c $RD: $_out" >&2; exit 1; }
+_out=$("${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" 2>&1) \
+    || { echo "FAIL: r c $N1: $_out" >&2; exit 1; }
+
+wait_disk_state "$RD" "$N1" UpToDate 180 \
+    || { echo "FAIL: $N1 never reached UpToDate" >&2; "${LCTL[@]}" resource list --resources "$RD" >&2; exit 1; }
+
+echo ">> Phase 2: write data on $N1 so the second replica must really resync"
+# Primary + dd a chunk to bump the GI; a fresh empty volume could
+# skip-sync and erase the SyncTarget window.
+on_node "$N1" bash -c "drbdadm primary --force $RD 2>/dev/null" || true
+on_node "$N1" bash -c "dd if=/dev/urandom of=/dev/drbd/by-res/$RD/0 bs=1M count=256 status=none oflag=direct 2>/dev/null" || true
+on_node "$N1" bash -c "drbdadm secondary $RD 2>/dev/null" || true
+
+echo ">> Phase 3: throttle resync (c-max-rate 1024 KiB/s) so the add stays SyncTarget"
+"${LCTL[@]}" resource-definition drbd-options --c-max-rate 1024 "$RD" >/dev/null 2>&1 \
+    || "${LCTL[@]}" resource-definition drbd-options --c-min-rate 250 "$RD" >/dev/null 2>&1 || true
+
+echo ">> Phase 4: r c $N2 (second diskful) — should enter SyncTarget/Inconsistent"
+_out=$("${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" 2>&1) \
+    || { echo "FAIL: r c $N2: $_out" >&2; exit 1; }
+
+# Wait for the second replica to be observed mid-sync (Inconsistent or
+# SyncTarget). If the stand skip-syncs anyway, this window may be tiny;
+# poll a short while.
+echo ">> wait up to 60s for $N2 to be observed mid-sync (Inconsistent/SyncTarget)"
+deadline=$(( $(date +%s) + 60 ))
+midsync=false
+while (( $(date +%s) < deadline )); do
+    d2=$(status_disk_state "$RD" "$N2" 0)
+    r2=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N2}" \
+        -o jsonpath='{.status.volumes[0].replicationState}' 2>/dev/null || echo "")
+    if [[ "$d2" == "Inconsistent" || "$d2" == "SyncTarget" || "$r2" == "SyncTarget" ]]; then
+        midsync=true
+        break
+    fi
+    # If it already reached UpToDate the window was missed — the guard
+    # would (correctly) allow the delete, so the cell can't assert the
+    # rejection. Treat as inconclusive-but-not-failing below.
+    if [[ "$d2" == "UpToDate" ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if ! $midsync; then
+    echo "WARN (U130): could not catch a mid-sync window for $N2 (stand skip-synced too fast)." >&2
+    echo "   The REST guard is pinned at L1; the L7 replay covers the wire path." >&2
+    echo "   Skipping the stand-side rejection probe to avoid a flaky assertion." >&2
+    # Still validate the no-sync delete path is allowed (bug-hunt #6
+    # must-not-regress): with both diskful UpToDate, dropping one works.
+    wait_disk_state "$RD" "$N2" UpToDate 180 || true
+    _out=$("${LCTL[@]}" resource delete "$N2" "$RD" 2>&1) \
+        || { echo "FAIL: no-sync r d $N2 should be allowed: $_out" >&2; exit 1; }
+    echo ">> r-d-last-uptodate-midsync-rejected OK (skip-sync path: no-sync delete allowed)"
+    exit 0
+fi
+
+echo "   $N2 observed mid-sync (disk=$d2 rep=$r2)"
+
+# =====================================================================
+# Core U130 assertion: `r d $N1` (the only UpToDate source) MUST be
+# rejected while $N2 is mid-sync.
+# =====================================================================
+echo ">> Phase 5: r d $N1 $RD (last UpToDate source, mid-sync) MUST be REJECTED"
+err_file=$(mktemp)
+if "${LCTL[@]}" resource delete "$N1" "$RD" >"$err_file" 2>&1; then
+    echo "FAIL (U130): r d of the last UpToDate diskful succeeded while $N2 was mid-sync" >&2
+    echo "----- delete output -----" >&2
+    cat "$err_file" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -10 >&2
+    rm -f "$err_file"
+    exit 1
+fi
+echo "   OK: delete rejected. CLI message:"
+sed 's/^/     /' "$err_file" >&2 || true
+rm -f "$err_file"
+
+# N1 MUST still exist (the refusal blocked the destructive delete).
+if ! kubectl get "resources.blockstor.cozystack.io/${RD}.${N1}" >/dev/null 2>&1; then
+    echo "FAIL (U130): $N1 replica vanished despite the rejection" >&2
+    exit 1
+fi
+echo "   OK: $N1 survived the refused delete"
+
+# =====================================================================
+# Recovery: let the resync finish, then the same delete is allowed.
+# =====================================================================
+echo ">> Phase 6: lift throttle, wait for $N2 UpToDate, then r d $N1 is allowed"
+"${LCTL[@]}" resource-definition drbd-options --unset-c-max-rate "$RD" >/dev/null 2>&1 || true
+wait_disk_state "$RD" "$N2" UpToDate 600 \
+    || { echo "FAIL: $N2 never reached UpToDate after lifting throttle" >&2; exit 1; }
+
+_out=$("${LCTL[@]}" resource delete "$N1" "$RD" 2>&1) \
+    || { echo "FAIL: r d $N1 should be allowed once $N2 is UpToDate: $_out" >&2; exit 1; }
+wait_replica_absent "$RD" "$N1" 120 \
+    || { echo "FAIL: $N1 replica did not disappear after the allowed delete" >&2; exit 1; }
+
+echo ">> r-d-last-uptodate-midsync-rejected OK (U130: mid-sync source delete rejected, post-sync delete allowed)"

--- a/tests/e2e/cli-matrix/rd-d-deleting-surface.sh
+++ b/tests/e2e/cli-matrix/rd-d-deleting-surface.sh
@@ -172,6 +172,37 @@ if ! kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" >/dev/null 2
 fi
 
 # =====================================================================
+# U19/U90/U112/U41/U101/U186/U242: a SECOND `rd d` while the resource is
+# latched in DELETING (peer unreachable / finalizer held) must be
+# IDEMPOTENT — it must NOT error, must NOT wedge, and must leave the
+# teardown progressing. The user reports were "resource stuck on
+# DELETING, can't complete or retry the delete". BS realises the
+# two-phase delete with finalizers: a repeat `rd d` re-stamps the
+# (already-set) DeletionTimestamp via an idempotent client.Delete, so
+# the CLI returns success and the operator can safely retry.
+# =====================================================================
+echo ">> Phase 4b (U19): repeat rd d while DELETING — must be idempotent (exit 0)"
+retry_err=$(mktemp)
+if ! "${LCTL[@]}" resource-definition delete "$RD" >"$retry_err" 2>&1; then
+    echo "FAIL (U19): a retried 'rd d' while DELETING returned non-zero (not idempotent)" >&2
+    echo "----- retry output -----" >&2
+    cat "$retry_err" >&2
+    rm -f "$retry_err"
+    exit 1
+fi
+rm -f "$retry_err"
+echo "   OK: retried rd d while DELETING is idempotent (exit 0)"
+
+# The retry must NOT have force-cleared the finalizer-blocked child —
+# the teardown is still genuinely blocked until we release our finalizer.
+if [[ -z "$(rsc_crd_name "$N2")" ]] \
+    && ! kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" >/dev/null 2>&1; then
+    echo "FAIL (U19): retried rd d finalised the object despite a held finalizer" >&2
+    exit 1
+fi
+echo "   OK: retry did not bypass the held finalizer (teardown still blocked, not wedged)"
+
+# =====================================================================
 # Release: remove the test finalizer; the real delete completes.
 # =====================================================================
 echo ">> Phase 5: remove the test finalizer; delete must complete"
@@ -193,4 +224,22 @@ if ! $cleared; then
     exit 1
 fi
 
-echo ">> PASS: rd-d-deleting-surface (E4: DELETING visible during two-phase delete, finalizer blocks final removal)"
+# =====================================================================
+# U186/U242: "can't reuse a name stuck in DELETING". Once the teardown
+# completes (DELETING cleared), the SAME RD name MUST be reusable — a
+# fresh `rd c <same-name>` must succeed, proving the name was freed and
+# no stale object/finalizer lingers to block re-creation.
+# =====================================================================
+echo ">> Phase 6 (U186/U242): the freed name must be reusable — rd c $RD again"
+reuse_err=$(mktemp)
+if ! "${LCTL[@]}" resource-definition create "$RD" >"$reuse_err" 2>&1; then
+    echo "FAIL (U186/U242): could not re-create RD '$RD' after its DELETING cleared — name not freed" >&2
+    echo "----- re-create output -----" >&2
+    cat "$reuse_err" >&2
+    rm -f "$reuse_err"
+    exit 1
+fi
+rm -f "$reuse_err"
+echo "   OK: name '$RD' reused successfully after teardown (delete_rd in cleanup removes it)"
+
+echo ">> PASS: rd-d-deleting-surface (E4 two-phase delete + U19 idempotent retry + U186/U242 name-reuse)"

--- a/tests/operator-harness/replay/r-d-last-uptodate-midsync-rejected.yaml
+++ b/tests/operator-harness/replay/r-d-last-uptodate-midsync-rejected.yaml
@@ -1,0 +1,119 @@
+name: r-d-last-uptodate-midsync-rejected
+description: |
+  U130 (LINSTOR shouldn't allow deleting the last active peer). User-
+  reported upstream wedge (LINBIT/linstor-server, closed): with 1 diskful
+  (UpToDate) source and a freshly-added second diskful still SyncTarget,
+  an `r d` of the ORIGINAL diskful before the resync finishes strands the
+  SyncTarget (no source), wedges the DELETING node on Connecting, and
+  leaves no UpToDate backing storage.
+
+  BS guard (pkg/rest/resource_delete_last_uptodate_u130.go): `r d` of the
+  LAST UpToDate diskful while a diskful peer is mid-sync
+  (SyncTarget/Inconsistent) is REJECTED with a FAIL_IN_USE ApiCallRc
+  envelope (python-linstor surfaces it as exit 10). `--force` overrides.
+
+  Deterministic mid-sync window: a 512 MiB volume is placed on node1
+  first (reaches UpToDate), then the resync is throttled hard via
+  `rd drbd-options --c-max-rate` so that when node2's diskful replica is
+  added it stays SyncTarget long enough for the rejection probe. The
+  `disk_state: SyncTarget` await gates the rejection step on a live
+  mid-sync state, so the assertion is not racing the resync.
+
+  Must-not-regress (bug-hunt #6): once node2 reaches UpToDate (throttle
+  lifted), the SAME `r d node1` is ALLOWED — the last-legitimate-diskful
+  delete stays permitted like upstream. Teardown leaves no stranded
+  replica.
+
+  NOTE on expect_exit: the rejection is a FAIL_IN_USE error envelope the
+  python-linstor CLI surfaces as exit 10. If a stand run shows a
+  different non-zero code, adjust this single value — the contract is
+  "non-zero, delete refused".
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "512M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-node1-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      expected: UpToDate
+      timeout_s: 300
+  - name: throttle-resync
+    # Hard-throttle the resync so the next add stays SyncTarget long
+    # enough for the rejection probe (avoids the stand's skip-sync race).
+    cmd: ["resource-definition", "drbd-options", "--c-max-rate", "1024", "{{rd}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+    await:
+      # Gate on a LIVE mid-sync state: node2 must be observed SyncTarget
+      # before we probe the rejection. If the stand skip-syncs through
+      # this faster than the throttle should allow, bump c-max-rate down
+      # / the volume size up rather than weakening the assertion.
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      expected: SyncTarget
+      timeout_s: 120
+  - name: r-d-node1-rejected-midsync
+    # THE U130 ASSERTION: `r d node1` (the only UpToDate source) MUST be
+    # refused while node2 is mid-sync. Removing it would strand node2.
+    cmd: ["resource", "delete", "{{node1}}", "{{rd}}"]
+    expect_exit: 10
+  - name: assert-node1-survived
+    # The refusal must have blocked the destructive delete — node1 is
+    # still UpToDate.
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      expected: UpToDate
+      timeout_s: 30
+  - name: unset-throttle
+    cmd: ["resource-definition", "drbd-options", "--unset-c-max-rate", "{{rd}}"]
+    expect_exit: 0
+  - name: wait-node2-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      expected: UpToDate
+      timeout_s: 600
+  - name: r-d-node1-allowed-after-sync
+    # Must-not-regress: once node2 is UpToDate, the SAME delete is
+    # ALLOWED (last legitimate diskful drop, like upstream / bug-hunt #6).
+    cmd: ["resource", "delete", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 120
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/rd-d-idempotent-name-reuse.yaml
+++ b/tests/operator-harness/replay/rd-d-idempotent-name-reuse.yaml
@@ -1,0 +1,86 @@
+name: rd-d-idempotent-name-reuse
+description: |
+  U19/U90/U112/U41/U101/U186/U242 (Resources stuck on DELETING; can't
+  complete or retry the delete; can't reuse a name stuck in DELETING).
+
+  Operator-CLI contract codified here:
+    1. `rd d` of a placed RD succeeds.
+    2. A SECOND `rd d` (the retry the user reports they "can't do") is
+       IDEMPOTENT — exit 0, never an error, never a wedge.
+    3. The RD fully clears (rd_absent).
+    4. The SAME name is immediately REUSABLE — a fresh `rd c` +
+       `r c` succeeds (name freed, no stale DELETING object lingers).
+
+  The finalizer-blocked DELETING latch (peer unreachable / on-node
+  teardown stuck) is exercised at L6 in
+  cli-matrix/rd-d-deleting-surface.sh, which adds a test finalizer to
+  simulate the stuck satellite and asserts the retried `rd d` stays
+  idempotent while blocked, then converges on release. This replay pins
+  the operator-visible retry + name-reuse guarantees on the live stand
+  without the finalizer simulation.
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: rd-d-first
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+  - name: rd-d-retry-idempotent
+    # THE U19 ASSERTION: a repeated `rd d` must be a clean idempotent
+    # no-op (exit 0), not an error — the retry the user reports they
+    # "can't do" while a delete is in flight.
+    cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+  - name: wait-rd-absent
+    cmd: ["resource-definition", "list"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: "{{rd}}"
+      timeout_s: 180
+  - name: reuse-name-rd-c
+    # U186/U242: the freed name must be reusable.
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: reuse-name-vd-c
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: reuse-name-r-c
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      expected: UpToDate
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

Deletion-safety guards mined from real LINBIT/linstor-server user reports (campaign-2, upstream-issues). Closes one P0 FIX-CANDIDATE (U130) and pins three deletion-surface contracts (U19-family, U133/U28, U211-family) at L1/L6/L7.

## Items

### U130 (P0, FIX) — reject deleting the last UpToDate diskful mid-sync

User wedge (closed upstream): 1 diskful UpToDate + 1 diskless Primary/InUse, `r c` a second diskful (starts SyncTarget), then `r d` the original diskful before resync finishes → SyncTarget stranded (no source), Primary left on a diskless replica with no UpToDate backing, DELETING node hangs Connecting.

`handleResourceDelete` now refuses removing the last UpToDate diskful replica while a diskful peer is mid-sync (SyncTarget/Inconsistent), with a `FAIL_IN_USE` 409 envelope. `?force=true` overrides.

The guard is intentionally narrow so it does **not** regress the prior campaign decision (bug-hunt #6: "deleting the last diskful is allowed like upstream"): it is diskful-only and only fires when the target is the **sole** UpToDate diskful **and** a diskful peer is still syncing. No-sync last-diskful deletes and deletes where another UpToDate diskful survives proceed unchanged.

- L1: `pkg/rest/resource_delete_last_uptodate_u130_test.go` (refusal, repl-state path, no-sync allowed, another-UpToDate-survives allowed, diskless/tiebreaker target never guarded, force override, predicate matrix).
- L6: `tests/e2e/cli-matrix/r-d-last-uptodate-midsync-rejected.sh` (throttled resync holds a SyncTarget window; rejection + survival asserted; post-sync delete allowed).
- L7: `tests/operator-harness/replay/r-d-last-uptodate-midsync-rejected.yaml` (`disk_state:SyncTarget` await gates the `expect_exit:10` rejection; post-sync allowed delete).

### U19/U90/U112/U41/U101/U186/U242 (P1, TEST-PIN) — DELETING progress / idempotent retry / name reuse

BS realises the two-phase delete with idempotent finalizer re-stamping; a repeated `rd d` while DELETING never errors, and the name frees once teardown completes. Pinned, no code change.

- L1: `pkg/rest/rd_delete_idempotent_u19_test.go` (retried `rd d` after success = 200+WARN; freed name reusable).
- L6: extend `tests/e2e/cli-matrix/rd-d-deleting-surface.sh` — retried `rd d` while finalizer-blocked is idempotent and does not bypass the held finalizer; name reusable after teardown clears.
- L7: `tests/operator-harness/replay/rd-d-idempotent-name-reuse.yaml`.

### U133/U28 (P0, TEST-PIN) — relocation is create-sync-then-delete

Verified BS relocation paths (evacuate, migrate-from) are sync-then-remove and already pin the ordering invariant (active diskful count never dips below the pre-op count) via `replay/n-evacuate-prune-source.yaml` and `replay/toggle-disk-migrate-from.yaml`. BS's bare `r d`+`r c` convergence is pinned by `cli-matrix/r-d-then-r-c-stuck.sh`. No new code; oracle envelope capture for the bare sequence is pending the stand probe (see below).

### U211/U330/U249 (P1, TEST-PIN) — `r d` targeting an offline node

Oracle-compare of `r d <offline-node>` is pending the stand probe (oracle satellite scale-down). Verdict + envelope to follow in a PR comment.

## Test gate

- `go test ./pkg/rest/... ./pkg/store/...` green locally.
- `golangci-lint` clean on changed files (`handleResourceDelete` kept under funlen by extracting `maybeStampTiebreakerSuppressionOnDelete`).

## Stand validation — PENDING (heavy lock contention)

Two stand jobs are queued under the canonical stand lock (`/tmp/bs-stand.lock`): an upstream-oracle envelope probe (U133/U28, U130, U211) and a BS-side L6/L7 + `r-full-lifecycle` validation run. The shared 3-node stand is under heavy contention from sibling agents (lock held >35 min at PR time). The deployed BS image predates this fix (`git_hash 5f77aa88`, not on origin/main), so the U130 L6/L7 cells are expected to classify pre-fix-RED until the image is rolled; U19 cells and the lifecycle gate are expected green on the deployed image. Results will be appended as a PR comment once the lock frees.

## Notes

- `docs/cli-parity-known-deltas.md`: if the oracle probe confirms upstream silently allows the mid-sync last-diskful delete, a row (next id 76) documenting BS's stricter-than-upstream U130 guard will be appended in a follow-up commit.
