### PR TITLE
fix(satellite): force-promote lone peerless diskful replica wedged below UpToDate

### DIFF
--- a/pkg/drbd/drbdadm.go
+++ b/pkg/drbd/drbdadm.go
@@ -1055,6 +1055,114 @@ func scanRecoveryPromotePeers(conns []drbdsetupStatusConnection, myID int32) (bo
 	return anyPeerInconsistent, weAreLowestUpToDate, peerPrimary
 }
 
+// NeedsSoloPromote probes the live kernel via `drbdsetup status <res>
+// --json` and reports whether THIS node is a lone, peerless diskful
+// replica wedged below UpToDate — the case where a force-primary is the
+// ONLY way to reach UpToDate because there is no peer to SyncTarget
+// from.
+//
+// Why (solo diskless→diskful toggle wedge): when the operator flips the
+// LAST/ONLY replica of an RD from diskless to diskful (r-full Phase 6:
+// every prior diskful was deleted, a diskless witness re-added, then
+// `r td -s <pool>`), the satellite carves a fresh lower disk and the
+// replica comes up Inconsistent. Two upstream-aligned data-safety gates
+// then conspire to leave it Inconsistent forever:
+//
+//   - the dispatcher suppresses the `auto-primary` seed on an
+//     INITIALIZED RD (BuildDesired's `!rdInitialized(rd)` gate, the
+//     respawn-StandAlone fix), so no force-primary / case-B UpToDate
+//     winner seed fires;
+//   - resolveVolumeSeed refuses the day0 skip when SkipInitialSync==false
+//     (the offline-safety fix), so the replica is seeded to SyncTarget a
+//     peer rather than declare itself UpToDate.
+//
+// Both are correct in their multi-replica intent: never fabricate an
+// UpToDate-empty replica while a real data peer exists. But for a SOLO
+// replica with ZERO peers there is no other copy to diverge from and no
+// SyncSource to wait for — the operator's explicit toggle to diskful IS
+// the instruction to make this the authoritative copy. NeedsRecoveryPromote
+// cannot cover it: that predicate requires the local to be ALREADY
+// UpToDate and a PEER to be Inconsistent — the exact inverse of the solo
+// case. Hence this dedicated peerless predicate.
+//
+// Returns true ONLY when ALL hold, so the promote is data-safe and
+// self-limiting:
+//   - the kernel slot exists and reports a my-node-id;
+//   - there are ZERO peer connections (a genuinely solo replica — never
+//     act when any peer slot exists, where the recovery / SyncTarget
+//     paths own convergence and a force-primary could mint a divergent
+//     Current UUID);
+//   - the local role is not already Primary (nothing to do);
+//   - the local replica is diskful but NOT UpToDate (Inconsistent /
+//     Consistent / Outdated): a diskless local has no disk to promote,
+//     and an already-UpToDate local needs no promote.
+//
+// Self-limiting: once `primary --force` flips the lone slot to UpToDate
+// the predicate stops holding, so it never re-fires. Conservative on any
+// probe/parse failure (returns false) — a missed promote just retries on
+// the next reconcile.
+func (a *Adm) NeedsSoloPromote(ctx context.Context, resource string) bool {
+	out, err := a.exec.Run(ctx, "drbdsetup", "status", resource, "--json")
+	if err != nil {
+		return false
+	}
+
+	var status drbdsetupStatusRoot
+
+	err = json.Unmarshal(out, &status)
+	if err != nil || len(status) == 0 || status[0].NodeID == nil {
+		return false
+	}
+
+	res := status[0]
+
+	// Solo only: any peer connection means another replica exists, and
+	// the recovery-promote / SyncTarget paths own convergence there. A
+	// force-primary against a peer could mint a divergent Current UUID
+	// and split-brain.
+	if len(res.Connections) != 0 {
+		return false
+	}
+
+	// Never disturb an already-Primary slot.
+	if Role(res.Role).IsPrimary() {
+		return false
+	}
+
+	// Promote only a diskful-but-not-UpToDate local: a diskless local
+	// has no disk to promote, an already-UpToDate one needs none.
+	return localIsDiskfulBelowUpToDate(res.Devices)
+}
+
+// localIsDiskfulBelowUpToDate reports whether the local replica has at
+// least one diskful volume and EVERY diskful volume sits below UpToDate
+// (Inconsistent / Consistent / Outdated). A Diskless device disqualifies
+// the replica (nothing to promote); an empty device list (slot mid-
+// negotiation) yields false — conservative. Used by NeedsSoloPromote to
+// confirm a lone replica genuinely needs the force-primary nudge.
+func localIsDiskfulBelowUpToDate(devices []drbdsetupStatusDevice) bool {
+	if len(devices) == 0 {
+		return false
+	}
+
+	for _, d := range devices {
+		switch DiskState(d.DiskState) {
+		case DiskStateInconsistent, DiskStateConsistent, DiskStateOutdated:
+			// A diskful volume below UpToDate — the promote target.
+		case DiskStateUpToDate, DiskStateDiskless, DiskStateAttaching,
+			DiskStateDetaching, DiskStateFailed, DiskStateNegotiating,
+			DiskStateDUnknown:
+			// UpToDate (no promote needed), diskless (nothing to
+			// promote), or a transient/failed state — do not act.
+			return false
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
 // localIsUpToDate reports whether at least one local diskful volume is
 // UpToDate and none is in a non-UpToDate diskful state. A diskless
 // local replica (no disk to be a SyncSource) yields false. Empty

--- a/pkg/drbd/needs_solo_promote_test.go
+++ b/pkg/drbd/needs_solo_promote_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drbd_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/drbd"
+	"github.com/cozystack/blockstor/pkg/storage"
+)
+
+// Regression pin for the solo diskless→diskful toggle wedge (r-full
+// Phase 6). NeedsSoloPromote must return true ONLY for a lone, peerless
+// diskful replica that is below UpToDate — the exact kernel shape a
+// `r td -s <pool>` on the last/only replica of an initialized RD lands
+// in, where the dispatcher's auto-primary suppression and the
+// offline-safety seed-refusal leave it Inconsistent with no SyncSource.
+
+const soloPromoteKey = "drbdsetup status pvc-solo --json"
+
+// errSoloProbe is the static probe-failure sentinel for the
+// conservative-on-error case.
+var errSoloProbe = errors.New("drbdsetup status: exit 1")
+
+func admWithStatus(t *testing.T, json string) (*drbd.Adm, *storage.FakeExec) {
+	t.Helper()
+
+	fx := storage.NewFakeExec()
+	fx.Responses[soloPromoteKey] = storage.FakeResponse{Stdout: []byte(json)}
+
+	return drbd.NewAdm(fx), fx
+}
+
+// TestNeedsSoloPromote_LoneInconsistent: a single resource block, zero
+// connections, Secondary role, local disk Inconsistent → promote needed.
+func TestNeedsSoloPromote_LoneInconsistent(t *testing.T) {
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":0,"role":"Secondary",
+	  "devices":[{"volume":0,"disk-state":"Inconsistent"}],
+	  "connections":[]
+	}]`)
+
+	if !adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=true for a lone Inconsistent diskful replica")
+	}
+}
+
+// TestNeedsSoloPromote_LoneConsistent: Consistent (below UpToDate) is
+// also a promote target for a peerless replica.
+func TestNeedsSoloPromote_LoneConsistent(t *testing.T) {
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":1,"role":"Secondary",
+	  "devices":[{"volume":0,"disk-state":"Consistent"}],
+	  "connections":[]
+	}]`)
+
+	if !adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=true for a lone Consistent diskful replica")
+	}
+}
+
+// TestNeedsSoloPromote_HasPeer: a peer connection exists → NOT solo;
+// the recovery-promote / SyncTarget paths own convergence, and a
+// force-primary against a peer could mint a divergent Current UUID.
+func TestNeedsSoloPromote_HasPeer(t *testing.T) {
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":0,"role":"Secondary",
+	  "devices":[{"volume":0,"disk-state":"Inconsistent"}],
+	  "connections":[{"peer-node-id":1,"name":"n2","connection-state":"Connected","peer-role":"Secondary",
+	    "peer_devices":[{"volume":0,"peer-disk-state":"UpToDate"}]}]
+	}]`)
+
+	if adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=false when a peer connection exists")
+	}
+}
+
+// TestNeedsSoloPromote_AlreadyUpToDate: nothing to promote.
+func TestNeedsSoloPromote_AlreadyUpToDate(t *testing.T) {
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":0,"role":"Secondary",
+	  "devices":[{"volume":0,"disk-state":"UpToDate"}],
+	  "connections":[]
+	}]`)
+
+	if adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=false when the local replica is already UpToDate")
+	}
+}
+
+// TestNeedsSoloPromote_AlreadyPrimary: never disturb a Primary slot.
+func TestNeedsSoloPromote_AlreadyPrimary(t *testing.T) {
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":0,"role":"Primary",
+	  "devices":[{"volume":0,"disk-state":"Inconsistent"}],
+	  "connections":[]
+	}]`)
+
+	if adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=false when the local replica is already Primary")
+	}
+}
+
+// TestNeedsSoloPromote_Diskless: a diskless local has no disk to promote.
+func TestNeedsSoloPromote_Diskless(t *testing.T) {
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":0,"role":"Secondary",
+	  "devices":[{"volume":0,"disk-state":"Diskless"}],
+	  "connections":[]
+	}]`)
+
+	if adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=false for a diskless local replica")
+	}
+}
+
+// TestNeedsSoloPromote_MultiVolumeAllBelow: every diskful volume below
+// UpToDate qualifies; one already-UpToDate volume does not block the
+// others — but a Diskless volume disqualifies the whole replica.
+func TestNeedsSoloPromote_MultiVolumeMixed(t *testing.T) {
+	// vol0 Inconsistent, vol1 UpToDate → mixed: at least one volume is
+	// already UpToDate, so the replica is not uniformly below UpToDate.
+	adm, _ := admWithStatus(t, `[{
+	  "name":"pvc-solo","node-id":0,"role":"Secondary",
+	  "devices":[{"volume":0,"disk-state":"Inconsistent"},{"volume":1,"disk-state":"UpToDate"}],
+	  "connections":[]
+	}]`)
+
+	if adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=false when any volume is already UpToDate")
+	}
+}
+
+// TestNeedsSoloPromote_ProbeError: a failed drbdsetup probe is
+// conservative (false).
+func TestNeedsSoloPromote_ProbeError(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Responses[soloPromoteKey] = storage.FakeResponse{Err: errSoloProbe}
+	adm := drbd.NewAdm(fx)
+
+	if adm.NeedsSoloPromote(t.Context(), "pvc-solo") {
+		t.Fatal("expected NeedsSoloPromote=false on probe error")
+	}
+}

--- a/pkg/satellite/maybe_solo_promote_test.go
+++ b/pkg/satellite/maybe_solo_promote_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package satellite
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/cozystack/blockstor/pkg/drbd"
+	"github.com/cozystack/blockstor/pkg/satellite/intent"
+	"github.com/cozystack/blockstor/pkg/storage"
+)
+
+// Regression pins for the solo diskless→diskful toggle wedge (r-full
+// Phase 6). maybeSoloPromote must force-primary a lone, peerless diskful
+// replica wedged below UpToDate — and must NOT promote when peers exist
+// or the replica is diskless.
+
+const soloStatusKey = "drbdsetup status pvc-solo --json"
+
+const soloStatusInconsistent = `[{
+  "name":"pvc-solo","node-id":0,"role":"Secondary",
+  "devices":[{"volume":0,"disk-state":"Inconsistent"}],
+  "connections":[]
+}]`
+
+func soloDR(peers ...intent.DesiredPeer) *intent.DesiredResource {
+	return &intent.DesiredResource{
+		Name:     "pvc-solo",
+		NodeName: "n1",
+		Volumes: []*intent.DesiredVolume{
+			{VolumeNumber: 0, SizeKib: 1024 * 1024, StoragePool: "thin1"},
+		},
+		Peers: peers,
+		DrbdOptions: map[string]string{
+			"port": "7000", "node-id": "0", "address": "10.0.0.1", "minor": "1000",
+		},
+	}
+}
+
+// TestMaybeSoloPromote_FiresForLonePeerlessInconsistent: a solo replica
+// (no peers) below UpToDate must be force-primaried, then demoted.
+func TestMaybeSoloPromote_FiresForLonePeerlessInconsistent(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect(soloStatusKey, storage.FakeResponse{Stdout: []byte(soloStatusInconsistent)})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "n1",
+	})
+
+	if err := rec.maybeSoloPromote(context.Background(), soloDR(), false); err != nil {
+		t.Fatalf("maybeSoloPromote: %v", err)
+	}
+
+	cmds := fx.CommandLines()
+	if !slices.Contains(cmds, "drbdadm primary --force pvc-solo") {
+		t.Errorf("expected `drbdadm primary --force pvc-solo`, got: %v", cmds)
+	}
+
+	if !slices.Contains(cmds, "drbdadm secondary pvc-solo") {
+		t.Errorf("expected `drbdadm secondary pvc-solo` (demote after promote), got: %v", cmds)
+	}
+}
+
+// TestMaybeSoloPromote_SkipsWhenPeersPresent: a replica with peers in its
+// desired set is not solo — the recovery / SyncTarget paths own
+// convergence and a force-primary could mint a divergent Current UUID.
+func TestMaybeSoloPromote_SkipsWhenPeersPresent(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect(soloStatusKey, storage.FakeResponse{Stdout: []byte(soloStatusInconsistent)})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "n1",
+	})
+
+	if err := rec.maybeSoloPromote(context.Background(), soloDR(intent.DesiredPeer{Name: "n2"}), false); err != nil {
+		t.Fatalf("maybeSoloPromote: %v", err)
+	}
+
+	if slices.Contains(fx.CommandLines(), "drbdadm primary --force pvc-solo") {
+		t.Errorf("expected NO promote when a desired peer exists, got: %v", fx.CommandLines())
+	}
+}
+
+// TestMaybeSoloPromote_SkipsDiskless: a diskless replica has no disk to
+// promote.
+func TestMaybeSoloPromote_SkipsDiskless(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect(soloStatusKey, storage.FakeResponse{Stdout: []byte(soloStatusInconsistent)})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "n1",
+	})
+
+	if err := rec.maybeSoloPromote(context.Background(), soloDR(), true); err != nil {
+		t.Fatalf("maybeSoloPromote: %v", err)
+	}
+
+	if slices.Contains(fx.CommandLines(), "drbdadm primary --force pvc-solo") {
+		t.Errorf("expected NO promote for a diskless replica, got: %v", fx.CommandLines())
+	}
+}
+
+// TestMaybeSoloPromote_ThrottlesRepeatFire: the second back-to-back call
+// is throttled (recoveryPromoteDue), so the kernel resync from the first
+// promote is not starved by a hot-loop.
+func TestMaybeSoloPromote_ThrottlesRepeatFire(t *testing.T) {
+	fx := storage.NewFakeExec()
+	fx.Expect(soloStatusKey, storage.FakeResponse{Stdout: []byte(soloStatusInconsistent)})
+
+	rec := NewReconciler(ReconcilerConfig{
+		Adm:      drbd.NewAdm(fx),
+		NodeName: "n1",
+	})
+
+	dr := soloDR()
+	if err := rec.maybeSoloPromote(context.Background(), dr, false); err != nil {
+		t.Fatalf("maybeSoloPromote #1: %v", err)
+	}
+
+	before := len(fx.CommandLines())
+
+	if err := rec.maybeSoloPromote(context.Background(), dr, false); err != nil {
+		t.Fatalf("maybeSoloPromote #2: %v", err)
+	}
+
+	// The throttle must suppress a second promote — only the probe
+	// (NeedsSoloPromote's drbdsetup status) may run again, never another
+	// `primary --force`.
+	after := fx.CommandLines()[before:]
+	if slices.Contains(after, "drbdadm primary --force pvc-solo") {
+		t.Errorf("expected throttle to suppress the immediate second promote, got: %v", after)
+	}
+}

--- a/pkg/satellite/reconciler.go
+++ b/pkg/satellite/reconciler.go
@@ -2417,6 +2417,21 @@ func (r *Reconciler) finishDRBDApply(ctx context.Context, dr *intent.DesiredReso
 	// kernel reports an established+UpToDate frame), which does not
 	// race the per-RD apply lane.
 
+	// Steady-state promote self-heals — run after the firstActivation
+	// promote so a wedged replica still converges. Folded into one helper
+	// so finishDRBDApply stays under the gocyclo budget.
+	return r.maybePromoteSelfHeals(ctx, dr, diskless, autoPromote, autoPrimaryReplica)
+}
+
+// maybePromoteSelfHeals runs the two steady-state force-primary self-heals
+// in order: the Bug 366 recovery-promote (a fresh RD whose late replica
+// wedged Inconsistent with a data-bearing peer and no Primary) and the
+// solo-promote (a lone, peerless diskful replica wedged below UpToDate
+// after a diskless→diskful toggle). Both read live kernel state and are
+// self-limiting; their predicates are mutually exclusive (recovery needs a
+// peer, solo needs none), so at most one acts per pass. Extracted from
+// finishDRBDApply to keep that function under the gocyclo budget.
+func (r *Reconciler) maybePromoteSelfHeals(ctx context.Context, dr *intent.DesiredResource, diskless, autoPromote, autoPrimaryReplica bool) error {
 	// Bug 366 recovery-promote self-heal — re-arm the auto-primary seed
 	// when a fresh RD wedged with the late replica stuck Inconsistent and
 	// no Primary anywhere. See maybeRecoveryPromote for the full why.
@@ -2425,7 +2440,67 @@ func (r *Reconciler) finishDRBDApply(ctx context.Context, dr *intent.DesiredReso
 		return err
 	}
 
-	return nil
+	// Solo diskless→diskful toggle self-heal — force-promote a lone,
+	// peerless diskful replica wedged below UpToDate. See maybeSoloPromote
+	// for the full why (the auto-primary suppression × offline-safety
+	// seed-refusal interaction that strands an initialized-RD last copy).
+	return r.maybeSoloPromote(ctx, dr, diskless)
+}
+
+// maybeSoloPromote force-primaries a lone, peerless diskful replica that
+// is wedged below UpToDate so it can become the authoritative copy. It is
+// the self-heal for the solo diskless→diskful toggle (r-full Phase 6:
+// `r td -s <pool>` on the last/only replica of an initialized RD).
+//
+// Why a separate path from the firstActivation auto-promote and from
+// maybeRecoveryPromote:
+//
+//   - the firstActivation auto-promote only fires when the dispatcher
+//     stamped `auto-primary`, which it suppresses on an INITIALIZED RD
+//     (the respawn-StandAlone fix) and which races the diskless→diskful
+//     flag-strip on a fresh RD — so the lone toggled replica frequently
+//     gets no auto-primary at all;
+//   - even when auto-primary IS set, the promote runs only when the RD
+//     requests a filesystem (`needsMkfs`) — a plain block RD with no
+//     filesystem never promotes;
+//   - maybeRecoveryPromote (Bug 366) requires the local to be ALREADY
+//     UpToDate and a PEER to be Inconsistent — the inverse of the solo
+//     wedge (local Inconsistent, zero peers).
+//
+// NeedsSoloPromote reads live kernel state (zero connections + diskful
+// local below UpToDate + not already Primary), so it is data-safe: with
+// no peer there is nothing to diverge from, and the operator's explicit
+// toggle to diskful IS the instruction to make this the authoritative
+// copy. runAutoPromote (primary --force → optional mkfs → secondary)
+// flips the lone slot Inconsistent → UpToDate. The predicate stops
+// holding once that happens, so the self-heal is self-limiting.
+//
+// Throttled via recoveryPromoteDue (shared with the Bug 366 path): the
+// promote churns kernel state and re-triggers this reconcile; firing on
+// every pass would hot-loop. A still-genuine wedge gets a fresh nudge
+// once the window elapses. Skipped for diskless replicas (no disk to
+// promote) and when Adm is unwired (storage-only unit tests).
+func (r *Reconciler) maybeSoloPromote(ctx context.Context, dr *intent.DesiredResource, diskless bool) error {
+	if diskless || r.cfg.Adm == nil {
+		return nil
+	}
+
+	if len(dr.GetPeerNames()) != 0 {
+		return nil
+	}
+
+	if !r.cfg.Adm.NeedsSoloPromote(ctx, dr.GetName()) {
+		return nil
+	}
+
+	if !r.recoveryPromoteDue(dr.GetName()) {
+		return nil
+	}
+
+	log.FromContext(ctx).Info("solo-promote: force-primary on lone peerless diskful replica wedged below UpToDate",
+		"resource", dr.GetName())
+
+	return r.runAutoPromote(ctx, dr)
 }
 
 // resizeAssumeClean decides whether the pickup-time `drbdadm resize`

--- a/tests/e2e/cli-matrix/toggle-disk-solo-last-copy.sh
+++ b/tests/e2e/cli-matrix/toggle-disk-solo-last-copy.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# usage: toggle-disk-solo-last-copy.sh WORK_DIR
+#
+# L6 cli-matrix cell — solo diskless→diskful toggle on the LAST/ONLY
+# replica of an INITIALIZED RD (the r-full Phase 6 wedge).
+#
+# Reproduction (operator-CLI level):
+#
+#   $ linstor rd c <rd>; linstor vd c <rd> 512M
+#   $ linstor r c <n1> <rd> -s <sp>     # diskful #1
+#   $ linstor r c <n2> <rd> -s <sp>     # diskful #2  → RD.Initialized latches
+#   # both reach UpToDate
+#   $ linstor r d <n1> <rd>             # delete BOTH diskful
+#   $ linstor r d <n2> <rd>             # (RD.Initialized stays latched)
+#   $ linstor r c <n1> <rd> --diskless  # re-add a single diskless witness
+#   $ linstor r td <n1> <rd> -s <sp>    # toggle the LONE replica to diskful
+#
+# Contract: the toggled replica is now the lone, peerless copy of an
+# initialized RD. It MUST converge to UpToDate.
+#
+# Before the satellite solo-promote self-heal it wedged at Inconsistent
+# forever: the dispatcher suppresses the auto-primary seed on an
+# initialized RD (respawn-StandAlone fix), and the offline-safety
+# seed-refusal (SkipInitialSync=false) declines the day0 UpToDate skip —
+# so with no peer to SyncTarget from there was no path to UpToDate. The
+# fix (maybeSoloPromote → NeedsSoloPromote → drbdadm primary --force on a
+# zero-connection diskful-below-UpToDate slot) restores convergence.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-solo-last-copy
+POOL=${POOL:-stand}
+
+N1=$WORKER_1
+N2=$WORKER_2
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> init: 2 diskful ($N1,$N2) on $RD, reach UpToDate (latches RD.Initialized)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 512M >/dev/null
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" >/dev/null
+wait_uptodate "$RD" "$N1" "$N2"
+
+init=$(kubectl get "resourcedefinitions.blockstor.cozystack.io/${RD}" \
+    -o jsonpath='{.spec.initialized}' 2>/dev/null || echo "")
+[[ "$init" == "true" ]] \
+    || die "precondition: RD.Spec.Initialized='$init', want true after 2 diskful UpToDate"
+
+echo ">> collapse: delete BOTH diskful (RD.Initialized stays latched)"
+"${LCTL[@]}" resource delete "$N1" "$RD" >/dev/null
+wait_replica_absent "$RD" "$N1" 60 \
+    || die "collapse: ${RD}.${N1} CRD never disappeared after r d"
+"${LCTL[@]}" resource delete "$N2" "$RD" >/dev/null
+wait_replica_absent "$RD" "$N2" 60 \
+    || die "collapse: ${RD}.${N2} CRD never disappeared after r d"
+
+diskful_left=$(linstor_diskful_count "$RD")
+[[ "$diskful_left" == "0" ]] \
+    || die "collapse: expected 0 diskful after deleting all, got $diskful_left"
+
+echo ">> re-add a single diskless replica on $N1"
+"${LCTL[@]}" resource create "$N1" "$RD" --diskless >/dev/null
+wait_status_diskless "$RD" "$N1" 60 \
+    || die "re-add: ${N1} never reached Diskless within 60s"
+
+echo ">> r td $N1 $RD -s $POOL  (SOLO diskless→diskful on an initialized RD)"
+"${LCTL[@]}" resource toggle-disk --storage-pool="$POOL" "$N1" "$RD" >/dev/null
+
+# The solo-promote self-heal must drive the lone slot Inconsistent →
+# UpToDate. 240s mirrors the r-full Phase-6 budget.
+wait_status_state "$RD" "$N1" UpToDate 240 \
+    || die "Phase-6 solo flip: ${N1} never reached UpToDate after r td -s $POOL (solo-promote wedge)"
+
+# The DISKLESS flag must be gone (real diskful promote, not a flag no-op).
+post_flags=$(kubectl get "resources.blockstor.cozystack.io/${RD}.${N1}" \
+    -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+[[ "$post_flags" != *"DISKLESS"* ]] \
+    || die "solo flip: ${N1} Spec.Flags='$post_flags' still contains DISKLESS after toggle to diskful"
+
+echo "PASS: solo diskless→diskful toggle on initialized RD converged UpToDate"

--- a/tests/operator-harness/replay/toggle-disk-solo-last-copy.yaml
+++ b/tests/operator-harness/replay/toggle-disk-solo-last-copy.yaml
@@ -1,0 +1,87 @@
+name: toggle-disk-solo-last-copy
+description: |
+  Solo diskless→diskful toggle on the LAST/ONLY replica of an initialized
+  RD — the r-full Phase 6 wedge. Initialize the RD with 2 diskful replicas
+  (so RD.Spec.Initialized latches true and SkipInitialSync becomes false),
+  reach UpToDate, then delete BOTH diskful, re-add a single diskless
+  replica, and `r toggle-disk -s <sp>` it to diskful.
+
+  The toggled replica is now the lone, peerless copy. Before the
+  solo-promote self-heal it wedged at Inconsistent forever: the dispatcher
+  suppresses the auto-primary seed on an initialized RD, and the
+  offline-safety seed-refusal (SkipInitialSync=false) declines the day0
+  UpToDate skip — so with no peer to SyncTarget from there was no path to
+  UpToDate. The satellite's maybeSoloPromote now force-primaries the lone
+  slot. It MUST converge to UpToDate.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "512M"]
+    expect_exit: 0
+
+  # --- Initialize: 2 diskful, reach UpToDate (latches RD.Initialized) ---
+  - name: r-c-diskful-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: r-c-diskful-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 120
+
+  # --- Collapse: delete BOTH diskful (RD.Initialized stays latched) ---
+  - name: r-d-node1
+    cmd: ["resource", "delete", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 60
+  - name: r-d-node2
+    cmd: ["resource", "delete", "{{node2}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: resource_absent
+      rd: "{{rd}}"
+      node: "{{node2}}"
+      timeout_s: 60
+
+  # --- Re-add a single diskless replica ---
+  - name: r-c-diskless-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--diskless"]
+    expect_exit: 0
+    await:
+      kind: replica_diskless
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      timeout_s: 60
+
+  # --- Solo toggle diskless→diskful: MUST converge UpToDate ---
+  - name: r-td-solo-diskful
+    cmd: ["resource", "toggle-disk", "--storage-pool", "{{sp}}", "{{node1}}", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: disk_state
+      rd: "{{rd}}"
+      node: "{{node1}}"
+      expected: UpToDate
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Problem

A solo diskless→diskful toggle on the **last/only replica** of an initialized RD wedges at `Inconsistent` forever — it attaches a fresh lower disk but never reaches `UpToDate`. This is the `r-full-lifecycle` Phase 6 failure (`r td <node> <rd> -s <pool>` after every diskful was deleted and a diskless witness re-added), observed as a 240s+ `Inconsistent` wedge on the v0.1.10 dev stand.

## Root cause

Not a v0.1.10 regression — the entire solo-promote/seed/dispatcher-election code path is byte-identical between the v0.1.10 tag and the prior `e26ee8099` baseline (zero diff in `pkg/satellite/reconciler.go`, `pkg/dispatcher/dispatcher.go`, `pkg/drbd/drbdadm.go`, `internal/controller/resource_controller.go`). The initially-suspected #111 (PromoteWitnessFlags) and #112 (rs-discard-granularity) are exonerated: the flag transition is behaviorally identical and the wedge reproduces on LVM_THIN as well as FILE_THIN.

It is a pre-existing latent bug from the interaction of two correct-in-isolation data-safety gates:

- the dispatcher suppresses the `auto-primary` seed on an initialized RD (`!rdInitialized(rd)`, the respawn-StandAlone fix), so no force-primary / case-B UpToDate winner seed fires;
- `resolveVolumeSeed` refuses the day0 skip when `SkipInitialSync==false` (offline-safety fix), seeding the replica to SyncTarget a peer.

For a **solo replica with zero peers** there is no peer to SyncTarget from and no path to UpToDate. The existing self-heals don't cover it: the firstActivation promote needs `auto-primary` stamped AND a filesystem (`needsMkfs`); `maybeRecoveryPromote` needs the local already UpToDate and a peer Inconsistent — the inverse of the solo wedge.

## Fix

Add `drbd.NeedsSoloPromote` (kernel-truth: zero connections + diskful local below UpToDate + not already Primary) and a `maybeSoloPromote` self-heal in `finishDRBDApply` that runs `drbdadm primary --force` on the lone slot. Data-safe (no peer to diverge from), self-limiting (the predicate stops holding once UpToDate), throttled via the shared `recoveryPromoteDue` gate.

## Tests

- **L1:** `NeedsSoloPromote` predicate matrix (`pkg/drbd`) + `maybeSoloPromote` wiring/throttle pins (`pkg/satellite`).
- **L6:** `tests/e2e/cli-matrix/toggle-disk-solo-last-copy.sh`.
- **L7:** `tests/operator-harness/replay/toggle-disk-solo-last-copy.yaml`.

## Stand validation

Fixed satellite built from this branch and deployed to the dev stand: the solo diskless→diskful flip converges to `UpToDate` in **~10s** (3/3 runs) vs stuck `Inconsistent` 240s+ on v0.1.10 (reproduced on both FILE_THIN and LVM_THIN before the fix). `go test ./...` green; `golangci-lint` 0 issues.

Known separate issue surfaced during validation (not addressed here): the `RD.Spec.Initialized` latch stamping shows a controller-side timing flake on both images — tracked as follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic self-healing for diskless-to-diskful replica toggles when the replica is the sole remaining copy and requires recovery.

* **Tests**
  * Added comprehensive test coverage including unit tests, end-to-end scenarios, and operator replay tests for the new self-healing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->