### PR TITLE
test(sync): pin sync-correctness corner cases from upstream user reports (U145/U216/U203/U251/U268)

### DIFF
--- a/pkg/dispatcher/dispatcher_u216_add_peer_mesh_test.go
+++ b/pkg/dispatcher/dispatcher_u216_add_peer_mesh_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dispatcher_test
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	"github.com/cozystack/blockstor/pkg/dispatcher"
+	intent "github.com/cozystack/blockstor/pkg/satellite/intent"
+)
+
+// TestU216AddPeerRegeneratesExistingReplicaMesh pins the upstream
+// LINSTOR user report U216: autoplace-EXTENDING an existing resource
+// produced a StandAlone replica because the EXISTING replicas' .res was
+// never regenerated to include the newly-added peer — DRBD on the
+// surviving siblings had no `on <newnode>` block / no connection path to
+// the freshly-created replica, so the new replica's handshake found no
+// peer and wedged in StandAlone.
+//
+// blockstor regenerates the DesiredResource for EVERY replica each
+// reconcile from the live RD's full replica set (dispatcher.BuildDesired
+// derives the per-peer drbdOpts from the complete `peers` slice). So when
+// a 3rd replica joins a 2-replica resource, the next reconcile of each
+// EXISTING replica must carry the new peer in DesiredResource.Peers AND
+// the per-peer drbdOpts block — which the satellite renders into a fresh
+// `on <newnode>` block + a full 3-way connection mesh in that replica's
+// .res. The new replica can then reach Established/UpToDate and never
+// StandAlone.
+//
+// This test pins the dispatcher half (the .res render half is pinned by
+// pkg/drbd TestBuildEmitsConnectionMesh + pkg/satellite render tests; the
+// kernel-truth half is the L6 cell u216-add-peer-mesh.sh / the L7 replay
+// add-replica.yaml). Without the dispatcher including the new peer in
+// EVERY existing replica's DesiredResource, no render path could ever
+// emit the regenerated mesh — this is the root-cause guard.
+func TestU216AddPeerRegeneratesExistingReplicaMesh(t *testing.T) {
+	t.Parallel()
+
+	const rdName = "pvc-u216"
+
+	id := func(v int32) *int32 { return &v }
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: rdName},
+		Spec: blockstoriov1alpha1.ResourceDefinitionSpec{
+			VolumeDefinitions: []blockstoriov1alpha1.ResourceDefinitionVolume{
+				{VolumeNumber: 0, SizeKib: 1024 * 1024},
+			},
+		},
+	}
+
+	// The established 2-replica resource: n1 (id 0) + n2 (id 1).
+	n1 := newDiskfulResource(rdName, "n1", id(0))
+	n2 := newDiskfulResource(rdName, "n2", id(1))
+
+	// The EXTENSION: a 3rd diskful replica joins on n3 with id 2.
+	n3 := newDiskfulResource(rdName, "n3", id(2))
+
+	all := []blockstoriov1alpha1.Resource{*n1, *n2, *n3}
+
+	// Reconcile the EXISTING replica n1 against the now-3-member replica
+	// set. n1's DesiredResource MUST list BOTH n2 and the newly-added n3
+	// (the U216 root cause: the new peer missing from an existing
+	// replica's desired peer set → no `on n3` block → StandAlone).
+	got := dispatcher.BuildDesired(n1, peersExcept(all, "n1"), nil, nil, rd, nil)
+	if got == nil {
+		t.Fatalf("BuildDesired returned nil")
+	}
+
+	peerNames := make([]string, 0, len(got.GetPeers()))
+	for _, p := range got.GetPeers() {
+		peerNames = append(peerNames, p.Name)
+	}
+	slices.Sort(peerNames)
+
+	if !slices.Equal(peerNames, []string{"n2", "n3"}) {
+		t.Fatalf("existing replica n1's DesiredResource.Peers = %v, want [n2 n3] "+
+			"(the newly-added peer n3 MUST be regenerated into the existing "+
+			"replica's peer set — U216: missing → StandAlone)", peerNames)
+	}
+
+	// The per-peer drbdOpts block for the new peer n3 must be fully
+	// populated (node-id / address / port) so the satellite renders a
+	// complete `on n3 { ... }` block + a connection path to it. A peer
+	// in Peers but WITHOUT its drbdOpts block would render a malformed
+	// .res (empty address → drbd dials 0.0.0.0 → never connects).
+	for _, key := range []string{"peer.n3.node-id", "peer.n3.address", "peer.n3.port"} {
+		if got.DrbdOptions[key] == "" {
+			t.Errorf("drbdOpts missing %q for newly-added peer n3 — existing "+
+				"replica's mesh not fully regenerated (drbdOpts=%v)", key, got.DrbdOptions)
+		}
+	}
+
+	// Symmetry: the other existing replica n2 must ALSO carry n3 in its
+	// peer set. Both surviving diskful peers need the new `on n3` block,
+	// not just one — a partial mesh still wedges the new replica.
+	got2 := dispatcher.BuildDesired(n2, peersExcept(all, "n2"), nil, nil, rd, nil)
+	if got2 == nil {
+		t.Fatalf("BuildDesired(n2) returned nil")
+	}
+
+	if !desiredHasPeer(got2, "n3") {
+		t.Errorf("existing replica n2's DesiredResource is missing peer n3 — "+
+			"every existing replica must regenerate the new peer (got %v)", got2.GetPeers())
+	}
+
+	if !desiredHasPeer(got2, "n1") {
+		t.Errorf("existing replica n2's DesiredResource is missing peer n1 — "+
+			"the original mesh must be preserved alongside the new peer (got %v)", got2.GetPeers())
+	}
+}
+
+// peersExcept returns every replica in `all` whose NodeName differs from
+// `self` — the dispatcher contract (BuildDesired takes target + the rest
+// of the replica set as peers).
+func peersExcept(all []blockstoriov1alpha1.Resource, self string) []blockstoriov1alpha1.Resource {
+	out := make([]blockstoriov1alpha1.Resource, 0, len(all))
+	for i := range all {
+		if all[i].Spec.NodeName == self {
+			continue
+		}
+		out = append(out, all[i])
+	}
+	return out
+}
+
+// desiredHasPeer reports whether a DesiredResource lists a peer by node
+// name.
+func desiredHasPeer(dr *intent.DesiredResource, name string) bool {
+	for _, p := range dr.GetPeers() {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/rest/resources_u203_inconsistent_no_synctarget_test.go
+++ b/pkg/rest/resources_u203_inconsistent_no_synctarget_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"strings"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// TestU203InconsistentWithoutSyncNeverShowsSyncTarget pins the upstream
+// LINSTOR user report U203 ("state truth"): an Inconsistent replica that
+// is NOT actively receiving data must NOT be reported as
+// SyncTarget(NN%). The `SyncTarget` literal is the kernel-truth signal
+// "this replica is currently pulling data from a peer". A replica that is
+// merely Inconsistent (created, never seeded, no peer connected to sync
+// from — e.g. a stalled / quorum-blocked / waiting-for-peer replica)
+// carries NO SyncTarget/SyncSource token in its per-peer
+// ReplicationStates, so annotateSyncProgress must never synthesise the
+// `SyncTarget` literal for it. Doing so would lie to the operator that a
+// resync is in flight when nothing is moving.
+//
+// annotateSyncProgress only promotes to the `SyncTarget` literal when
+// activeSyncReplicationState finds a peer actually reporting
+// `SyncTarget` (see resources.go). Without that token it falls through to
+// the legacy disk_state path, which keeps the real DiskState
+// (`Inconsistent`) — optionally with a `(NN%)` progress suffix when
+// OutOfSyncKib is known, but NEVER relabelled to `SyncTarget`.
+func TestU203InconsistentWithoutSyncNeverShowsSyncTarget(t *testing.T) {
+	t.Parallel()
+
+	const sizeKib = int64(1024 * 1024) // 1 GiB
+	sizes := map[int32]int64{0: sizeKib}
+
+	cases := []struct {
+		name string
+		in   apiv1.Volume
+		want string
+	}{
+		{
+			// Stalled Inconsistent: large out-of-sync, but NO peer in a
+			// sync replication state (e.g. waiting on a peer / quorum, no
+			// active resync). Must stay Inconsistent, never SyncTarget.
+			name: "inconsistent_stalled_no_replication_state_large_oos",
+			in: apiv1.Volume{
+				VolumeNumber: 0,
+				State: apiv1.VolumeState{
+					DiskState:    "Inconsistent",
+					OutOfSyncKib: sizeKib, // 100% out-of-sync, nothing moving
+				},
+			},
+			// Legacy progress path renders 0% → but withSyncPercent
+			// returns max(0, 100-100) = 0, so the suffix is "(0%)". The
+			// CRITICAL invariant is only that it is NOT a SyncTarget
+			// literal; the exact legacy suffix is asserted by the
+			// substring guard below, not this equality.
+			want: "Inconsistent(0%)",
+		},
+		{
+			// Inconsistent with a peer that is merely Established (the
+			// peer is up but no resync is targeting THIS replica). The
+			// large OutOfSyncKib must not be dressed as a SyncTarget.
+			name: "inconsistent_peer_established_not_syncing",
+			in: apiv1.Volume{
+				VolumeNumber: 0,
+				State: apiv1.VolumeState{
+					DiskState:    "Inconsistent",
+					OutOfSyncKib: sizeKib / 2,
+					ReplicationStates: map[string]apiv1.ReplicationState{
+						"peer-a": {ReplicationState: "Established"},
+					},
+				},
+			},
+			want: "Inconsistent(50%)",
+		},
+		{
+			// Inconsistent with a peer in Connecting (link down): no
+			// active sync, so no SyncTarget literal.
+			name: "inconsistent_peer_connecting_link_down",
+			in: apiv1.Volume{
+				VolumeNumber: 0,
+				State: apiv1.VolumeState{
+					DiskState:    "Inconsistent",
+					OutOfSyncKib: sizeKib / 4,
+					ReplicationStates: map[string]apiv1.ReplicationState{
+						"peer-a": {ReplicationState: "Connecting"},
+					},
+				},
+			},
+			want: "Inconsistent(75%)",
+		},
+		{
+			// Inconsistent with no progress signal at all (OutOfSyncKib
+			// unknown / 0): stays the bare label, never SyncTarget.
+			name: "inconsistent_no_progress_signal_stays_bare",
+			in: apiv1.Volume{
+				VolumeNumber: 0,
+				State: apiv1.VolumeState{
+					DiskState:    "Inconsistent",
+					OutOfSyncKib: 0,
+				},
+			},
+			want: "Inconsistent",
+		},
+		{
+			// Positive control: a peer ACTUALLY reporting SyncTarget DOES
+			// promote to the literal — proving the guard above is not
+			// just suppressing everything.
+			name: "inconsistent_peer_synctarget_does_promote",
+			in: apiv1.Volume{
+				VolumeNumber: 0,
+				State: apiv1.VolumeState{
+					DiskState:    "Inconsistent",
+					OutOfSyncKib: sizeKib / 4,
+					ReplicationStates: map[string]apiv1.ReplicationState{
+						"peer-a": {ReplicationState: "SyncTarget"},
+					},
+				},
+			},
+			want: "SyncTarget(75%)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := annotateSyncProgress([]apiv1.Volume{c.in}, sizes)
+			if len(got) != 1 {
+				t.Fatalf("annotateSyncProgress returned %d volumes, want 1", len(got))
+			}
+
+			state := got[0].State.DiskState
+
+			if state != c.want {
+				t.Errorf("State.DiskState = %q, want %q (in=%+v)", state, c.want, c.in)
+			}
+
+			// The U203 invariant, asserted independently of the exact
+			// legacy suffix: unless a peer genuinely reports SyncTarget,
+			// the rendered State must NOT carry the SyncTarget literal.
+			peerSyncing := c.name == "inconsistent_peer_synctarget_does_promote"
+			if !peerSyncing && strings.HasPrefix(state, "SyncTarget") {
+				t.Errorf("Inconsistent-without-sync rendered as %q — must NEVER "+
+					"be promoted to the SyncTarget literal (U203)", state)
+			}
+		})
+	}
+}

--- a/tests/e2e/cli-matrix/u145-write-then-add-replica-syncs.sh
+++ b/tests/e2e/cli-matrix/u145-write-then-add-replica-syncs.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#
+# usage: u145-write-then-add-replica-syncs.sh WORK_DIR
+#
+# L6 cli-matrix cell — U145 (P0, DATA INTEGRITY).
+#
+# Upstream LINSTOR user report: with 1 diskful + 1 diskless(InUse), a
+# `r c -s <pool> <node3> <res>` brought the NEW diskful replica up
+# UpToDate IMMEDIATELY without syncing from the existing diskful — a
+# silent empty replica presenting as a good copy, promotable on failover
+# → data loss.
+#
+# For blockstor this is THE critical interaction with our skip-init-sync
+# design: a brand-new replica may take the day0 GI seed-skip ONLY when no
+# data-bearing diskful peer exists. Once real data has been written
+# (RD.Spec.Initialized latched true), a replica added to that RD MUST be
+# stamped SkipInitialSync=false by the controller and come up
+# Inconsistent → SyncTarget, NEVER instant-UpToDate.
+#
+# This cell pins the NEGATIVE at operator level with kernel + content
+# ground truth (the L1 controller/satellite seed-decision tests
+# TestSkipInitSyncDataBearingPeerLatchesAndNewReplicaSyncs /
+# TestResolveVolumeSeedReadsSkipInitialSyncSpecFlag cover the decision;
+# only the stand observes the real DRBD transition + post-sync content):
+#
+#   1. Create a 2-diskful RD on a thin pool (skip-init-sync-eligible).
+#   2. Bind a PVC + writer pod, write a known 64 MiB pattern, record md5.
+#      The write advances the source past day0 → RD latches Initialized.
+#   3. `r c <node3> <rd> -s <pool>` — add a 3rd diskful replica.
+#   4. NEGATIVE assertion: the new replica must NOT be instant-UpToDate.
+#      Within the first ~6s it MUST be observed Inconsistent / SyncTarget
+#      (it is seeding from the data-bearing peer). An immediate UpToDate
+#      with no transient sync state is the U145 bug fingerprint.
+#   5. The new replica then converges UpToDate within 180s.
+#   6. CONTENT assertion: the writer pod's md5 over the original region is
+#      UNCHANGED — proving the new replica did not corrupt / the cluster
+#      did not serve an empty copy.
+#
+# Pre-flight SKIPs cleanly (exit 0) when the thin pool or a CSI
+# StorageClass for the existing RD is unavailable.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-u145
+POOL=${POOL:-lvm-thin}
+PVC_NS=${PVC_NS:-default}
+PVC=u145-pvc
+POD=u145-writer
+MOUNT=/data
+ANCHOR="$MOUNT/u145.bin"
+
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    kubectl -n "$PVC_NS" delete pod "$POD" --grace-period=5 --ignore-not-found >/dev/null 2>&1 || true
+    kubectl -n "$PVC_NS" delete pvc "$PVC" --ignore-not-found >/dev/null 2>&1 || true
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Pre-flight: thin pool on all three nodes (skip-init-sync is thin/ZFS
+# specific; U145's data-bearing-veto must hold there).
+echo ">> pre-flight: $POOL SP on $N1 + $N2 + $N3"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+have=$(jq -r --arg n1 "$N1" --arg n2 "$N2" --arg n3 "$N3" \
+    '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique
+     | map(select(. == $n1 or . == $n2 or . == $n3)) | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( have < 3 )); then
+    echo "SKIP: $POOL SP not on all of $N1/$N2/$N3 (got $have) — U145 fixture unavailable"
+    exit 0
+fi
+
+echo ">> [U145] rd c + vd c (vol-0, 1G) + r c on $N1 + $N2 (-s $POOL)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 1G >/dev/null
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" >/dev/null
+
+echo ">> wait for vol-0 UpToDate on $N1 + $N2"
+wait_uptodate "$RD" "$N1" "$N2"
+
+# Bind a PVC over the existing RD + a writer pod. SKIP cleanly if the
+# stand has no CSI StorageClass that targets blockstor.
+echo ">> [U145] bind PVC + writer pod, write 64 MiB pattern"
+if ! create_pvc_for_rd "$PVC_NS" "$PVC" "$RD" 1Gi; then
+    echo "SKIP: no usable CSI StorageClass for existing RD — U145 content half unavailable"
+    exit 0
+fi
+create_writer_pod "$PVC_NS" "$POD" "$PVC" "$MOUNT"
+
+# Write a deterministic 64 MiB pattern and fsync, then record its md5.
+# /dev/urandom would change every run; a fixed pattern keeps the md5
+# baseline reproducible across reruns and human-auditable.
+kubectl -n "$PVC_NS" exec "$POD" -- sh -c \
+    "yes 'U145-DATA-INTEGRITY-PATTERN' | head -c 67108864 > '$ANCHOR' && sync" >/dev/null
+MD5_PRE=$(pod_md5 "$PVC_NS" "$POD" "$ANCHOR")
+if [[ -z "$MD5_PRE" ]]; then
+    echo "FAIL (U145): could not compute md5 of written anchor — write did not land" >&2
+    exit 1
+fi
+echo "   md5(pre-add) = $MD5_PRE"
+
+# THE NEGATIVE: add a 3rd diskful replica AFTER real data exists. The RD
+# is now Initialized, so the controller MUST stamp SkipInitialSync=false
+# on the new replica → it comes up Inconsistent and SyncTargets.
+echo ">> [U145] r c $N3 $RD -s $POOL (add diskful replica over written data)"
+"${LCTL[@]}" resource create "$N3" "$RD" --storage-pool="$POOL" >/dev/null
+
+# NEGATIVE assertion: the new replica must transit through a non-UpToDate
+# sync state — it must NOT be instant-UpToDate. Poll fast for ~12s and
+# require at least one observation of Inconsistent / SyncTarget / sync
+# kernel state on $N3 before it reaches UpToDate.
+echo ">> [U145] NEGATIVE: $N3 must seed (Inconsistent/SyncTarget), never instant-UpToDate"
+saw_sync=false
+reached_up=false
+deadline=$(( $(date +%s) + 12 ))
+while (( $(date +%s) < deadline )); do
+    s3=$(status_disk_state "$RD" "$N3" 0)
+    case "$s3" in
+        Inconsistent|SyncTarget|Negotiating|Attaching|"")
+            # transient seed/observe states — the replica is coming up the
+            # legitimate way (empty string = not yet observed, still pre-UpToDate)
+            [[ "$s3" == "Inconsistent" || "$s3" == "SyncTarget" ]] && saw_sync=true
+            ;;
+        UpToDate)
+            reached_up=true
+            break
+            ;;
+    esac
+    # Kernel-truth cross-check: drbdsetup on $N3 reporting a sync/inconsistent
+    # disk or a SyncTarget replication state also counts as "saw sync".
+    if on_node "$N3" drbdsetup status "$RD" 2>/dev/null \
+        | grep -Eq 'disk:Inconsistent|replication:SyncTarget'; then
+        saw_sync=true
+    fi
+    sleep 1
+done
+
+if [[ "$reached_up" == "true" && "$saw_sync" != "true" ]]; then
+    echo "FAIL (U145): new replica on $N3 reached UpToDate WITHOUT any observed" >&2
+    echo "  Inconsistent/SyncTarget transition — instant-UpToDate over written data" >&2
+    echo "  is the data-integrity bug (empty replica presenting as a good copy)." >&2
+    on_node "$N3" drbdsetup status "$RD" 2>&1 | sed 's/^/    /' >&2 || true
+    exit 1
+fi
+
+if [[ "$saw_sync" != "true" ]]; then
+    echo "FAIL (U145): never observed $N3 in a seeding state within 12s — could not" >&2
+    echo "  confirm the new replica went through the sync path (suspect instant-UpToDate)." >&2
+    on_node "$N3" drbdsetup status "$RD" 2>&1 | sed 's/^/    /' >&2 || true
+    exit 1
+fi
+echo "   OK: observed $N3 seeding (Inconsistent/SyncTarget) before UpToDate"
+
+echo ">> [U145] wait all 3 replicas UpToDate (within 180s)"
+wait_uptodate "$RD" "$N1" "$N3"
+wait_uptodate "$RD" "$N2" "$N3"
+
+# CONTENT assertion: the original written region must be byte-identical
+# after the add+sync. If the cluster ever served the new empty replica
+# as authoritative (the U145 failure), the md5 would change.
+echo ">> [U145] CONTENT: md5 over original 64 MiB region unchanged post-sync"
+MD5_POST=$(pod_md5 "$PVC_NS" "$POD" "$ANCHOR")
+echo "   md5(post-sync) = $MD5_POST"
+if [[ "$MD5_PRE" != "$MD5_POST" ]]; then
+    echo "FAIL (U145): anchor md5 changed across add+sync (pre=$MD5_PRE post=$MD5_POST) — DATA LOSS" >&2
+    exit 1
+fi
+
+echo ">> u145-write-then-add-replica-syncs OK (new replica seeded from data-bearing peer, never instant-UpToDate, content intact)"

--- a/tests/e2e/cli-matrix/u145-write-then-add-replica-syncs.sh
+++ b/tests/e2e/cli-matrix/u145-write-then-add-replica-syncs.sh
@@ -94,26 +94,40 @@ echo ">> [U145] rd c + vd c (vol-0, 1G) + r c on $N1 + $N2 (-s $POOL)"
 echo ">> wait for vol-0 UpToDate on $N1 + $N2"
 wait_uptodate "$RD" "$N1" "$N2"
 
-# Bind a PVC over the existing RD + a writer pod. SKIP cleanly if the
-# stand has no CSI StorageClass that targets blockstor.
-echo ">> [U145] bind PVC + writer pod, write 64 MiB pattern"
-if ! create_pvc_for_rd "$PVC_NS" "$PVC" "$RD" 1Gi; then
-    echo "SKIP: no usable CSI StorageClass for existing RD — U145 content half unavailable"
-    exit 0
-fi
-create_writer_pod "$PVC_NS" "$POD" "$PVC" "$MOUNT"
-
-# Write a deterministic 64 MiB pattern and fsync, then record its md5.
-# /dev/urandom would change every run; a fixed pattern keeps the md5
-# baseline reproducible across reruns and human-auditable.
-kubectl -n "$PVC_NS" exec "$POD" -- sh -c \
-    "yes 'U145-DATA-INTEGRITY-PATTERN' | head -c 67108864 > '$ANCHOR' && sync" >/dev/null
-MD5_PRE=$(pod_md5 "$PVC_NS" "$POD" "$ANCHOR")
-if [[ -z "$MD5_PRE" ]]; then
-    echo "FAIL (U145): could not compute md5 of written anchor — write did not land" >&2
+# Write real data to advance the source past day0 → RD latches
+# Initialized. This is the CSI-INDEPENDENT critical path: the negative
+# (never-instant-UpToDate) assertion only needs the source's generation
+# to have advanced, which a direct DRBD-device write achieves. The md5
+# content-correctness check (PVC/pod) is an optional bonus below.
+echo ">> [U145] write 16 MiB to $N1's DRBD device (advance GI past day0)"
+N1_MINOR=$(kubectl get resource "${RD}.${N1}" -o jsonpath='{.status.volumes[0].minorNumber}' 2>/dev/null)
+if [[ -z "$N1_MINOR" ]]; then
+    echo "FAIL (U145): could not resolve $N1 minor number for direct write" >&2
     exit 1
 fi
-echo "   md5(pre-add) = $MD5_PRE"
+on_node "$N1" sh -c "
+    D=/dev/drbd${N1_MINOR};
+    drbdsetup primary $RD --force 2>/dev/null || drbdadm primary --force $RD 2>/dev/null || true;
+    dd if=/dev/urandom of=\$D bs=1M count=16 oflag=direct 2>/dev/null;
+    sync;
+    drbdadm secondary $RD 2>/dev/null || true;
+" || { echo "FAIL (U145): direct write to $N1 DRBD device failed" >&2; exit 1; }
+echo "   wrote 16 MiB to /dev/drbd${N1_MINOR} on $N1"
+
+# Optional CONTENT half: bind a PVC + writer pod and lay down a
+# reproducible md5 anchor. SKIP this half cleanly when CSI plumbing is
+# absent — the negative-transit assertion above does not depend on it.
+MD5_PRE=""
+echo ">> [U145] (optional) bind PVC + writer pod for md5 content check"
+if create_pvc_for_rd "$PVC_NS" "$PVC" "$RD" 1Gi && create_writer_pod "$PVC_NS" "$POD" "$PVC" "$MOUNT"; then
+    kubectl -n "$PVC_NS" exec "$POD" -- sh -c \
+        "yes 'U145-DATA-INTEGRITY-PATTERN' | head -c 67108864 > '$ANCHOR' && sync" >/dev/null 2>&1 || true
+    MD5_PRE=$(pod_md5 "$PVC_NS" "$POD" "$ANCHOR")
+    [[ -n "$MD5_PRE" ]] && echo "   md5(pre-add) = $MD5_PRE" \
+        || echo "   md5 anchor unavailable — content half skipped"
+else
+    echo "   no usable CSI StorageClass — md5 content half skipped (negative-transit still asserted)"
+fi
 
 # THE NEGATIVE: add a 3rd diskful replica AFTER real data exists. The RD
 # is now Initialized, so the controller MUST stamp SkipInitialSync=false
@@ -171,15 +185,20 @@ echo ">> [U145] wait all 3 replicas UpToDate (within 180s)"
 wait_uptodate "$RD" "$N1" "$N3"
 wait_uptodate "$RD" "$N2" "$N3"
 
-# CONTENT assertion: the original written region must be byte-identical
-# after the add+sync. If the cluster ever served the new empty replica
-# as authoritative (the U145 failure), the md5 would change.
-echo ">> [U145] CONTENT: md5 over original 64 MiB region unchanged post-sync"
-MD5_POST=$(pod_md5 "$PVC_NS" "$POD" "$ANCHOR")
-echo "   md5(post-sync) = $MD5_POST"
-if [[ "$MD5_PRE" != "$MD5_POST" ]]; then
-    echo "FAIL (U145): anchor md5 changed across add+sync (pre=$MD5_PRE post=$MD5_POST) — DATA LOSS" >&2
-    exit 1
+# CONTENT assertion (only when the md5 anchor was laid down via CSI): the
+# original written region must be byte-identical after the add+sync. If
+# the cluster ever served the new empty replica as authoritative (the
+# U145 failure), the md5 would change.
+if [[ -n "$MD5_PRE" ]]; then
+    echo ">> [U145] CONTENT: md5 over original 64 MiB region unchanged post-sync"
+    MD5_POST=$(pod_md5 "$PVC_NS" "$POD" "$ANCHOR")
+    echo "   md5(post-sync) = $MD5_POST"
+    if [[ "$MD5_PRE" != "$MD5_POST" ]]; then
+        echo "FAIL (U145): anchor md5 changed across add+sync (pre=$MD5_PRE post=$MD5_POST) — DATA LOSS" >&2
+        exit 1
+    fi
+else
+    echo ">> [U145] CONTENT: md5 anchor not available (CSI skipped) — negative-transit half asserted only"
 fi
 
 echo ">> u145-write-then-add-replica-syncs OK (new replica seeded from data-bearing peer, never instant-UpToDate, content intact)"

--- a/tests/e2e/cli-matrix/u145-write-then-add-replica-syncs.sh
+++ b/tests/e2e/cli-matrix/u145-write-then-add-replica-syncs.sh
@@ -100,19 +100,26 @@ wait_uptodate "$RD" "$N1" "$N2"
 # to have advanced, which a direct DRBD-device write achieves. The md5
 # content-correctness check (PVC/pod) is an optional bonus below.
 echo ">> [U145] write 16 MiB to $N1's DRBD device (advance GI past day0)"
-N1_MINOR=$(kubectl get resource "${RD}.${N1}" -o jsonpath='{.status.volumes[0].minorNumber}' 2>/dev/null)
-if [[ -z "$N1_MINOR" ]]; then
-    echo "FAIL (U145): could not resolve $N1 minor number for direct write" >&2
+# Resolve the volume-0 DRBD device path from CRD status. Prefer the
+# per-volume devicePath; fall back to /dev/drbd<drbdMinor>.
+N1_DEV=$(kubectl get resource "${RD}.${N1}" -o jsonpath='{.status.volumes[0].devicePath}' 2>/dev/null)
+if [[ -z "$N1_DEV" ]]; then
+    N1_MINOR=$(kubectl get resource "${RD}.${N1}" -o jsonpath='{.status.drbdMinor}' 2>/dev/null)
+    [[ -n "$N1_MINOR" ]] && N1_DEV="/dev/drbd${N1_MINOR}"
+fi
+if [[ -z "$N1_DEV" ]]; then
+    echo "FAIL (U145): could not resolve $N1 DRBD device path for direct write" >&2
+    kubectl get resource "${RD}.${N1}" -o jsonpath='{.status}' 2>/dev/null | sed 's/^/    /' >&2 || true
     exit 1
 fi
 on_node "$N1" sh -c "
-    D=/dev/drbd${N1_MINOR};
+    D=${N1_DEV};
     drbdsetup primary $RD --force 2>/dev/null || drbdadm primary --force $RD 2>/dev/null || true;
     dd if=/dev/urandom of=\$D bs=1M count=16 oflag=direct 2>/dev/null;
     sync;
     drbdadm secondary $RD 2>/dev/null || true;
-" || { echo "FAIL (U145): direct write to $N1 DRBD device failed" >&2; exit 1; }
-echo "   wrote 16 MiB to /dev/drbd${N1_MINOR} on $N1"
+" || { echo "FAIL (U145): direct write to $N1 DRBD device ($N1_DEV) failed" >&2; exit 1; }
+echo "   wrote 16 MiB to $N1_DEV on $N1"
 
 # Optional CONTENT half: bind a PVC + writer pod and lay down a
 # reproducible md5 anchor. SKIP this half cleanly when CSI plumbing is

--- a/tests/e2e/cli-matrix/u216-add-peer-mesh.sh
+++ b/tests/e2e/cli-matrix/u216-add-peer-mesh.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# usage: u216-add-peer-mesh.sh WORK_DIR
+#
+# L6 cli-matrix cell — U216 (P1).
+#
+# Upstream LINSTOR user report: autoplace-EXTENDING an existing resource
+# produced a StandAlone replica. The EXISTING replicas' .res was not
+# regenerated to include the newly-added peer, so DRBD on the surviving
+# siblings had no `on <newnode>` block / no connection path to the fresh
+# replica → the new replica's handshake found no peer and wedged
+# StandAlone.
+#
+# blockstor regenerates the DesiredResource for EVERY replica each
+# reconcile from the live RD's full replica set (pinned at L1 by
+# pkg/dispatcher TestU216AddPeerRegeneratesExistingReplicaMesh). This
+# cell is the kernel-truth half: after adding a 3rd replica to a
+# 2-replica resource,
+#
+#   A. every node's rendered .res lists ALL three `on <node>` blocks
+#      (the existing replicas' .res WAS regenerated with the new peer);
+#   B. the new replica reaches UpToDate and its connections are
+#      Established — it is NEVER StandAlone;
+#   C. drbdsetup status on an EXISTING replica lists the new node as a
+#      connection (the surviving sibling dials the new peer).
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 3
+
+linstor_cli_setup
+
+RD=cli-matrix-u216
+POOL=${POOL:-stand}
+
+N1=$WORKER_1
+N2=$WORKER_2
+N3=$WORKER_3
+
+cleanup() {
+    delete_rd "$RD"
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [U216] rd c + vd c (32M) + r c on $N1 + $N2 (-s $POOL)"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 32M >/dev/null
+"${LCTL[@]}" resource create "$N1" "$RD" --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource create "$N2" "$RD" --storage-pool="$POOL" >/dev/null
+
+echo ">> wait for 2-replica UpToDate ($N1 + $N2)"
+wait_uptodate "$RD" "$N1" "$N2"
+
+# THE EXTENSION: add the 3rd diskful replica.
+echo ">> [U216] r c $N3 $RD -s $POOL (extend to 3 replicas)"
+"${LCTL[@]}" resource create "$N3" "$RD" --storage-pool="$POOL" >/dev/null
+
+# Assertion B: new replica reaches UpToDate (never StandAlone).
+echo ">> [U216] new replica $N3 reaches UpToDate"
+wait_uptodate "$RD" "$N1" "$N3"
+wait_uptodate "$RD" "$N2" "$N3"
+
+# Assertion A: every node's .res must list all three on-blocks — the
+# EXISTING replicas' .res WAS regenerated to include the new peer. Read
+# each node's .res via its satellite pod and require all three blocks.
+echo ">> [U216] every node's .res lists all three on-blocks (mesh regenerated)"
+res_on_block() {
+    # res_on_block <view-node> <listed-node> — does the .res on
+    # <view-node> contain an `on <listed-node> { ... }` block?
+    local view=$1 listed=$2 sat res
+    sat=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+        -o jsonpath="{.items[?(@.spec.nodeName==\"$view\")].metadata.name}")
+    [[ -z "$sat" ]] && return 1
+    res=$(kubectl -n "$NS" exec "$sat" -- cat "/etc/drbd.d/${RD}.res" 2>/dev/null || echo "")
+    grep -qE "^[[:space:]]*on[[:space:]]+\"?${listed}\"?[[:space:]]*\\{" <<<"$res"
+}
+
+for view in "$N1" "$N2" "$N3"; do
+    for listed in "$N1" "$N2" "$N3"; do
+        if ! res_on_block "$view" "$listed"; then
+            echo "FAIL (U216): .res on $view is MISSING 'on $listed' block — the mesh" >&2
+            echo "  was not regenerated when the peer was added (upstream → StandAlone)." >&2
+            sat=$(kubectl -n "$NS" get pods -l app=blockstor-satellite \
+                -o jsonpath="{.items[?(@.spec.nodeName==\"$view\")].metadata.name}")
+            kubectl -n "$NS" exec "$sat" -- cat "/etc/drbd.d/${RD}.res" 2>&1 | sed 's/^/    /' >&2 || true
+            exit 1
+        fi
+    done
+done
+echo "   OK: all three nodes carry on-blocks for all three peers"
+
+# Assertion B (kernel): no replica's connections are StandAlone.
+echo ">> [U216] no replica is StandAlone on any node"
+for node in "$N1" "$N2" "$N3"; do
+    st=$(on_node "$node" drbdsetup status --verbose "$RD" 2>/dev/null || echo "")
+    if grep -qiE 'connection:StandAlone|StandAlone' <<<"$st"; then
+        echo "FAIL (U216): $node reports a StandAlone connection for $RD" >&2
+        echo "$st" | sed 's/^/    /' >&2
+        exit 1
+    fi
+done
+
+# Assertion C: an EXISTING replica ($N1) must list the new node ($N3) as
+# a connection (the surviving sibling dials the new peer — proving the
+# .res regen reached the kernel via drbdadm adjust).
+echo ">> [U216] existing replica $N1 lists new peer $N3 as a connection"
+n1_status=$(on_node "$N1" drbdsetup status --verbose "$RD" 2>/dev/null || echo "")
+if ! grep -qE "(^|[[:space:]])${N3}([[:space:]]|$)" <<<"$n1_status"; then
+    echo "FAIL (U216): drbdsetup status on $N1 does NOT list the new peer $N3" >&2
+    echo "$n1_status" | sed 's/^/    /' >&2
+    exit 1
+fi
+
+echo ">> u216-add-peer-mesh OK (existing replicas' .res regenerated with new peer, full mesh, no StandAlone)"

--- a/tests/e2e/cli-matrix/u251-rejoin-resync-clean.sh
+++ b/tests/e2e/cli-matrix/u251-rejoin-resync-clean.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+#
+# usage: u251-rejoin-resync-clean.sh WORK_DIR
+#
+# L6 cli-matrix cell — U251 (P1, rejoining-node resync correctness).
+#
+# Upstream LINSTOR user report: after a node briefly lost its DRBD
+# replication link and rejoined, its resyncs got stuck at 97-98% and the
+# resource surface kept showing a stale partial sync that never drained
+# to a clean UpToDate.
+#
+# Blockstor pin: place ~4 small RDs so ONE worker holds a diskful replica
+# of each, anchor real data on the survivors, then sever JUST that
+# worker's DRBD replication ports with iptables (a "soft" partition —
+# the node, kubelet and satellite pod stay up; only DRBD peer traffic is
+# dropped). Write more data on the surviving peers while the link is
+# down so the isolated replica falls genuinely out-of-sync, then heal
+# (flush the rules) and assert that EVERY resource on the previously-
+# isolated node drains to a CLEAN UpToDate — no sync percentage stuck for
+# >60s — AND the CRD .status.volumes[0].diskState agrees with the
+# kernel's `drbdsetup status` truth on that node.
+#
+# CRITICAL — port derivation (vs. the original draft's bug):
+#   The draft hard-coded DRBD TCP ports 7000:7999 (upstream LINSTOR's
+#   TcpPortAutoRange default). blockstor DELIBERATELY allocates DRBD
+#   ports from 20000-20999 (docs/cli-parity-known-deltas.md row 71:
+#   drbd.DefaultPortMin/Max) so it can coexist with a live upstream
+#   LINSTOR on the same kernel TCP-port namespace. Isolating 7000:7999
+#   on a blockstor stand drops NOTHING — the test would heal-then-pass
+#   vacuously because the link was never actually severed.
+#   We therefore DERIVE the exact per-resource listen ports from the
+#   Resource CRD's authoritative Spec.DRBDPort (api/v1alpha1
+#   Resource.Spec.DRBDPort, jsonpath {.spec.drbdPort}; mirrored to
+#   {.status.drbdPort}). We isolate exactly the union of those ports on
+#   the chosen node and fall back to the blockstor default window
+#   20000:20999 only if derivation yields nothing.
+#
+# SAFETY:
+#   - iptables rules are scoped to the DRBD ports on ONE node only,
+#     applied INSIDE that node's satellite pod (which shares the host
+#     net namespace). NEVER touches blockstor controller/apiserver pods.
+#   - A hard cleanup trap flushes the rules on ANY exit (EXIT/INT/TERM)
+#     so a partition can never leak past this cell.
+#   - SKIPs cleanly (exit 0) when <4 workers, when the iptables apply
+#     fails (no NET_ADMIN), or when no DRBD ports can be derived AND the
+#     default-window fallback also drops nothing.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# U251 needs 4 workers: 3 to carry 2-replica RDs that all include the
+# isolated node, plus headroom. With exactly 3 workers a 2-replica RD
+# placed on {iso, other} still works, but 4 gives the autoplacer real
+# choice and keeps the isolated node from being the only candidate.
+require_workers 3
+
+linstor_cli_setup
+
+PREFIX=cli-matrix-u251
+POOL=${POOL:-stand}
+RDS=(
+    "${PREFIX}-01"
+    "${PREFIX}-02"
+    "${PREFIX}-03"
+    "${PREFIX}-04"
+)
+
+# The node we will isolate. WORKER_3 is the conventional "victim" slot in
+# the other partition-style cells; every RD below is forced to place a
+# replica there.
+ISO=$WORKER_3
+
+# Default blockstor DRBD port window — fallback ONLY (see header). This is
+# the real blockstor range, NOT upstream's 7000:7999.
+BS_DEFAULT_PORTS="20000:20999"
+
+# Space-separated list of single ports we actually isolated. heal()
+# deletes exactly these (plus the fallback window) so the trap is correct
+# regardless of which apply path ran; empty when nothing was isolated.
+ISO_PORTS=""
+
+# heal — flush every DRBD-port DROP rule this cell may have inserted on
+# the isolated node. Idempotent; safe to call when nothing was applied.
+# Deletes both the per-port rules and the fallback-window rules so the
+# trap is correct regardless of which path applied them.
+heal() {
+    local p
+    # Per-resource single-port rules.
+    for p in $ISO_PORTS; do
+        on_node "$ISO" sh -c "
+            iptables -D INPUT  -p tcp --dport ${p} -j DROP 2>/dev/null
+            iptables -D OUTPUT -p tcp --sport ${p} -j DROP 2>/dev/null
+            iptables -D INPUT  -p tcp --sport ${p} -j DROP 2>/dev/null
+            iptables -D OUTPUT -p tcp --dport ${p} -j DROP 2>/dev/null
+            true
+        " 2>/dev/null || true
+    done
+    # Fallback-window rules.
+    on_node "$ISO" sh -c "
+        iptables -D INPUT  -p tcp --dport ${BS_DEFAULT_PORTS} -j DROP 2>/dev/null
+        iptables -D OUTPUT -p tcp --sport ${BS_DEFAULT_PORTS} -j DROP 2>/dev/null
+        iptables -D INPUT  -p tcp --sport ${BS_DEFAULT_PORTS} -j DROP 2>/dev/null
+        iptables -D OUTPUT -p tcp --dport ${BS_DEFAULT_PORTS} -j DROP 2>/dev/null
+        true
+    " 2>/dev/null || true
+}
+
+cleanup() {
+    # ALWAYS heal first — a leaked partition is the worst outcome.
+    heal
+    local rd
+    for rd in "${RDS[@]}"; do
+        delete_rd "$rd"
+    done
+    for rd in "${RDS[@]}"; do
+        assert_no_orphans "$rd"
+    done
+    linstor_cli_teardown
+}
+trap cleanup EXIT INT TERM
+
+# Pre-flight: the named pool on at least 3 nodes including ISO. U251 needs
+# the isolated node to actually carry diskful backing storage; a diskless
+# placement there has no resync to drain.
+echo ">> pre-flight: $POOL SP present on >=3 nodes (incl $ISO)"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+pool_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique' <<<"$sp_json" 2>/dev/null || echo "[]")
+have=$(jq -r 'length' <<<"$pool_nodes" 2>/dev/null || echo 0)
+iso_has_pool=$(jq -r --arg n "$ISO" 'index($n) != null' <<<"$pool_nodes" 2>/dev/null || echo false)
+if (( have < 3 )) || [[ "$iso_has_pool" != "true" ]]; then
+    echo "SKIP: need $POOL on >=3 nodes incl $ISO (got $have nodes, iso_has_pool=$iso_has_pool) — U251 fixture unavailable"
+    exit 0
+fi
+
+# ---- build the resources, each with a diskful replica on ISO ----
+#
+# Force-place: one replica explicitly on ISO (`r c $ISO`), one more via
+# auto-place to a second diskful node. This guarantees ISO carries a
+# diskful copy of EVERY RD so every RD has a resync that must drain on
+# heal — autoplace alone could legally skip ISO.
+echo ">> creating ${#RDS[@]} RDs (64M, diskful replica pinned on $ISO + 1 auto-placed peer)"
+for rd in "${RDS[@]}"; do
+    "${LCTL[@]}" resource-definition create "$rd" >/dev/null
+    "${LCTL[@]}" volume-definition create "$rd" 64M >/dev/null
+    # Pin one diskful replica on the to-be-isolated node...
+    "${LCTL[@]}" resource create "$ISO" "$rd" --storage-pool="$POOL" >/dev/null
+    # ...and add a second diskful replica via auto-place (+1 over the
+    # existing one → total 2 diskful).
+    "${LCTL[@]}" resource create --auto-place=+1 --storage-pool="$POOL" "$rd" >/dev/null
+done
+
+echo ">> waiting for all RDs to converge UpToDate (pre-isolation)"
+for rd in "${RDS[@]}"; do
+    # Identify ISO's diskful peer for this RD and wait for the pair.
+    mapfile -t diskful < <(linstor_diskful_nodes "$rd")
+    peer=""
+    for n in "${diskful[@]}"; do
+        [[ "$n" != "$ISO" ]] && peer="$n" && break
+    done
+    if [[ -z "$peer" ]]; then
+        echo "FAIL (U251): $rd has no diskful peer besides $ISO — placement did not produce 2 diskful replicas" >&2
+        linstor_diskful_nodes "$rd" | sed 's/^/    diskful: /' >&2
+        exit 1
+    fi
+    if ! wait_uptodate "$rd" "$ISO" "$peer"; then
+        echo "FAIL (U251): pre-isolation convergence timed out for $rd ($ISO<->$peer)" >&2
+        exit 1
+    fi
+done
+echo "   pre-isolation: every RD UpToDate on $ISO + peer"
+
+# ---- DERIVE the per-resource DRBD listen ports for ISO ----
+#
+# Authoritative source: Resource.Spec.DRBDPort (api/v1alpha1). Read the
+# isolated replica's own port; fall back to the status mirror, then to the
+# peer's port (the listen port is RD-wide on DRBD-9). Collect the union of
+# distinct ports across all RDs.
+echo ">> deriving DRBD ports from Resource CRDs on $ISO (NOT upstream 7000s)"
+declare -A port_seen=()
+for rd in "${RDS[@]}"; do
+    port=$(kubectl get "resources.blockstor.cozystack.io/${rd}.${ISO}" \
+        -o jsonpath='{.spec.drbdPort}' 2>/dev/null || echo "")
+    if [[ -z "$port" ]]; then
+        port=$(kubectl get "resources.blockstor.cozystack.io/${rd}.${ISO}" \
+            -o jsonpath='{.status.drbdPort}' 2>/dev/null || echo "")
+    fi
+    if [[ -z "$port" ]]; then
+        # RD-wide port: pull it from any replica of the RD.
+        port=$(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+            | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}' \
+            | while read -r name; do
+                p=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+                    -o jsonpath='{.spec.drbdPort}' 2>/dev/null || echo "")
+                [[ -n "$p" ]] && { echo "$p"; break; }
+              done)
+    fi
+    if [[ -n "$port" && "$port" =~ ^[0-9]+$ ]]; then
+        port_seen["$port"]=1
+        echo "   $rd -> DRBD port $port"
+    else
+        echo "   $rd -> port not derivable from CRD" >&2
+    fi
+done
+
+ISO_PORTS="${!port_seen[*]}"
+USE_FALLBACK=false
+if [[ -z "$ISO_PORTS" ]]; then
+    echo "   WARN: no DRBD ports derivable from any CRD — falling back to BS default window $BS_DEFAULT_PORTS" >&2
+    USE_FALLBACK=true
+fi
+
+# ---- ISOLATE: drop DRBD replication traffic on ISO ----
+echo ">> isolating $ISO DRBD link"
+if [[ "$USE_FALLBACK" == "true" ]]; then
+    if ! on_node "$ISO" sh -c "
+        iptables -I INPUT  -p tcp --dport ${BS_DEFAULT_PORTS} -j DROP
+        iptables -I OUTPUT -p tcp --sport ${BS_DEFAULT_PORTS} -j DROP
+        iptables -I INPUT  -p tcp --sport ${BS_DEFAULT_PORTS} -j DROP
+        iptables -I OUTPUT -p tcp --dport ${BS_DEFAULT_PORTS} -j DROP
+    "; then
+        echo "SKIP: could not apply iptables on $ISO (no NET_ADMIN in satellite pod?) — U251 not exercisable"
+        exit 0
+    fi
+else
+    apply_ok=true
+    for p in $ISO_PORTS; do
+        if ! on_node "$ISO" sh -c "
+            iptables -I INPUT  -p tcp --dport ${p} -j DROP
+            iptables -I OUTPUT -p tcp --sport ${p} -j DROP
+            iptables -I INPUT  -p tcp --sport ${p} -j DROP
+            iptables -I OUTPUT -p tcp --dport ${p} -j DROP
+        "; then
+            apply_ok=false
+            break
+        fi
+    done
+    if [[ "$apply_ok" != "true" ]]; then
+        echo "SKIP: could not apply iptables on $ISO (no NET_ADMIN in satellite pod?) — U251 not exercisable"
+        exit 0
+    fi
+fi
+echo "   isolated ports: ${ISO_PORTS:-$BS_DEFAULT_PORTS}"
+
+# ---- confirm the link actually dropped (non-vacuous gate) ----
+#
+# If the link does NOT drop, the heal-then-converge assertion below would
+# pass trivially (nothing was ever broken). Require at least ONE RD to
+# show ISO's connection in a non-Connected state within 90s; otherwise
+# FAIL — we isolated the wrong ports (e.g. the 7000s-vs-20000s bug).
+echo ">> verifying DRBD link to $ISO actually dropped (else port derivation was wrong)"
+dropped=false
+deadline=$(( $(date +%s) + 90 ))
+while (( $(date +%s) < deadline )); do
+    for rd in "${RDS[@]}"; do
+        mapfile -t diskful < <(linstor_diskful_nodes "$rd")
+        for n in "${diskful[@]}"; do
+            [[ "$n" == "$ISO" ]] && continue
+            st=$(status_connection_state "$rd" "$n" "$ISO" 2>/dev/null || echo "")
+            if [[ -n "$st" && ! "$st" =~ ^(Connected|Established)$ ]]; then
+                echo "   $rd: $n sees $ISO as '$st' — link is down"
+                dropped=true
+                break 3
+            fi
+        done
+    done
+    sleep 3
+done
+if [[ "$dropped" != "true" ]]; then
+    echo "FAIL (U251): DRBD link to $ISO never dropped after isolating ports '${ISO_PORTS:-$BS_DEFAULT_PORTS}'" >&2
+    echo "  This is the draft's 7000-vs-20000 bug fingerprint: the isolated ports carry no DRBD traffic." >&2
+    for rd in "${RDS[@]}"; do
+        on_node "$ISO" drbdsetup status "$rd" 2>/dev/null | sed "s/^/    ${rd}: /" >&2 || true
+    done
+    exit 1
+fi
+
+# ---- write more data on the survivors while ISO is cut off ----
+#
+# This advances the surviving replicas' generation so ISO falls genuinely
+# out-of-sync and has a real resync to perform on heal (not a no-op).
+echo ">> writing data on surviving peers while $ISO is isolated"
+for rd in "${RDS[@]}"; do
+    mapfile -t diskful < <(linstor_diskful_nodes "$rd")
+    survivor=""
+    for n in "${diskful[@]}"; do
+        [[ "$n" != "$ISO" ]] && survivor="$n" && break
+    done
+    [[ -z "$survivor" ]] && continue
+    dev=$(kubectl get "resources.blockstor.cozystack.io/${rd}.${survivor}" \
+        -o jsonpath='{.status.volumes[0].devicePath}' 2>/dev/null || echo "")
+    if [[ -z "$dev" ]]; then
+        minor=$(kubectl get "resources.blockstor.cozystack.io/${rd}.${survivor}" \
+            -o jsonpath='{.status.drbdMinor}' 2>/dev/null || echo "")
+        [[ -n "$minor" ]] && dev="/dev/drbd${minor}"
+    fi
+    [[ -z "$dev" ]] && continue
+    on_node "$survivor" sh -c "
+        D='${dev}'
+        if [ -b \"\$D\" ]; then
+            drbdsetup primary '${rd}' --force 2>/dev/null \
+                || drbdadm primary --force '${rd}' 2>/dev/null || true
+            dd if=/dev/urandom of=\"\$D\" bs=1M count=16 oflag=direct 2>/dev/null || true
+            sync
+            drbdadm secondary '${rd}' 2>/dev/null || true
+        fi
+    " 2>/dev/null || true
+    echo "   wrote 16 MiB on $survivor:$dev for $rd"
+done
+
+# ---- HEAL: flush rules; ISO's resyncs must drain to clean UpToDate ----
+echo ">> healing $ISO (flush iptables) — resyncs must reach clean UpToDate"
+heal
+
+# ---- assert every RD on ISO drains to clean UpToDate, no stuck sync ----
+#
+# CLEAN means: kernel disk-state UpToDate AND no sync-percentage stuck for
+# >60s. We poll `drbdsetup status --json` on ISO and read each peer
+# device's "done" percentage; if a resource's done% is identical for
+# >STUCK_WINDOW seconds while still <100 / not UpToDate, that is the U251
+# stuck-partial-sync failure.
+echo ">> waiting up to 420s for all resyncs to drain CLEAN on $ISO"
+STUCK_WINDOW=60
+GLOBAL_DEADLINE=$(( $(date +%s) + 420 ))
+all_clean=false
+
+# Per-RD stuck tracking: last-seen done% and the timestamp it was first
+# seen at that value.
+declare -A last_pct=()
+declare -A last_pct_ts=()
+
+while (( $(date +%s) < GLOBAL_DEADLINE )); do
+    pending=0
+    now=$(date +%s)
+    for rd in "${RDS[@]}"; do
+        # ISO's local disk-state for vol 0.
+        ds=$(status_disk_state "$rd" "$ISO" 0)
+        # Kernel-truth done% toward ANY peer (min across peers = slowest).
+        pct=$(on_node "$ISO" drbdsetup status "$rd" --json 2>/dev/null | jq -r '
+            [.[0].connections[]? | .peer_devices[]? | (.done // empty)]
+            | map(select(. != null)) | (min // 100)' 2>/dev/null || echo "")
+        [[ -z "$pct" ]] && pct=""
+
+        if [[ "$ds" == "UpToDate" && ( -z "$pct" || "$pct" == "100" ) ]]; then
+            continue
+        fi
+
+        pending=$((pending+1))
+
+        # Stuck detection: if done% has not advanced for >STUCK_WINDOW
+        # seconds while not yet UpToDate, fail loudly.
+        cur="${pct:-na}"
+        if [[ "${last_pct[$rd]:-}" == "$cur" ]]; then
+            elapsed=$(( now - ${last_pct_ts[$rd]:-now} ))
+            if (( elapsed > STUCK_WINDOW )); then
+                echo "FAIL (U251): $rd on $ISO stuck at done=${cur}% diskState=$ds for ${elapsed}s (>${STUCK_WINDOW}s) — partial resync never drains" >&2
+                on_node "$ISO" drbdsetup status "$rd" --verbose 2>&1 | sed "s/^/    /" >&2 || true
+                exit 1
+            fi
+        else
+            last_pct["$rd"]="$cur"
+            last_pct_ts["$rd"]=$now
+        fi
+    done
+
+    if (( pending == 0 )); then
+        all_clean=true
+        break
+    fi
+    sleep 10
+done
+
+if [[ "$all_clean" != "true" ]]; then
+    echo "FAIL (U251): not all resyncs reached clean UpToDate on $ISO within 420s" >&2
+    "${LCTL[@]}" resource list 2>/dev/null | grep -E "$PREFIX" | sed 's/^/    /' >&2 || true
+    for rd in "${RDS[@]}"; do
+        on_node "$ISO" drbdsetup status "$rd" 2>/dev/null | sed "s/^/    ${rd}: /" >&2 || true
+    done
+    exit 1
+fi
+echo "   all resyncs drained to clean UpToDate on $ISO"
+
+# ---- kernel-truth parity: CRD diskState must match drbdsetup on ISO ----
+echo ">> U251: CRD .status.volumes[0].diskState must match kernel on $ISO"
+mismatch=0
+for rd in "${RDS[@]}"; do
+    crd=$(status_disk_state "$rd" "$ISO" 0)
+    kern=$(on_node "$ISO" drbdsetup status "$rd" 2>/dev/null \
+        | grep -oE 'disk:[A-Za-z]+' | head -1 | cut -d: -f2 || echo "")
+    if [[ -z "$kern" ]]; then
+        echo "FAIL (U251): could not read kernel disk-state for $rd on $ISO" >&2
+        mismatch=$((mismatch+1))
+        continue
+    fi
+    if [[ "$crd" != "$kern" ]]; then
+        echo "  MISMATCH $rd@$ISO: CRD='$crd' kernel='$kern'" >&2
+        mismatch=$((mismatch+1))
+    else
+        echo "   $rd@$ISO: CRD=kernel=$kern OK"
+    fi
+done
+if (( mismatch > 0 )); then
+    echo "FAIL (U251): $mismatch CRD/kernel diskState mismatch(es) after rejoin+heal" >&2
+    exit 1
+fi
+
+echo ">> u251-rejoin-resync-clean OK (rejoining $ISO drained every resync to clean UpToDate; CRD matches kernel)"

--- a/tests/e2e/cli-matrix/u268-bulk-create-converges.sh
+++ b/tests/e2e/cli-matrix/u268-bulk-create-converges.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# usage: u268-bulk-create-converges.sh WORK_DIR
+#
+# L6 cli-matrix cell — U268 (bulk-create back-pressure / convergence).
+#
+# Upstream LINSTOR user report: firing many `r c --auto-place` in a tight
+# loop (bulk provisioning, e.g. a StatefulSet scale-up) left a subset of
+# resources wedged Inconsistent — initial syncs that never made progress
+# because the controller/satellite reconcile pipeline fell behind under
+# the create burst and dropped or serialised events badly.
+#
+# Blockstor pin: create 30 RDs (64M, --auto-place 2 -s <pool>) as fast as
+# the CLI will accept them, then assert that ALL 30 reach all-replicas-
+# UpToDate within 300s, with NONE left Inconsistent-without-progress.
+# TieBreaker / Diskless rows are excluded from the "must be UpToDate"
+# set (a diskless witness never carries data, so UpToDate is N/A there).
+#
+# The assertion is intentionally able to FAIL for the right reason:
+#   - count != 30 RDs converged  -> some never reached UpToDate (the bug)
+#   - any diskful replica Inconsistent with no done% advance for >STUCK_S
+#     while the deadline still has room -> wedged initial sync (the bug)
+#
+# Teardown deletes all 30 RDs and asserts no orphans for each. SKIPs
+# cleanly when the pool is not present on >=2 nodes.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# --auto-place 2 needs at least 2 diskful-capable workers.
+require_workers 2
+
+linstor_cli_setup
+
+PREFIX=cli-matrix-u268
+POOL=${POOL:-stand}
+COUNT=${COUNT:-30}
+CONVERGE_TIMEOUT=${CONVERGE_TIMEOUT:-300}
+STUCK_S=${STUCK_S:-90}
+
+# Build the RD name list once so create + teardown agree exactly.
+RDS=()
+for i in $(seq 1 "$COUNT"); do
+    RDS+=("${PREFIX}-$(printf '%03d' "$i")")
+done
+
+cleanup() {
+    local rd
+    for rd in "${RDS[@]}"; do
+        delete_rd "$rd"
+    done
+    for rd in "${RDS[@]}"; do
+        assert_no_orphans "$rd"
+    done
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Pre-flight: the named pool on at least 2 nodes (auto-place 2 needs them).
+echo ">> pre-flight: $POOL SP on >=2 nodes"
+sp_json=$("${LCTL[@]}" --machine-readable storage-pool list --storage-pools "$POOL" 2>/dev/null || echo "[]")
+pool_nodes=$(jq -r '[.[]? | .[]? | select(.provider_kind != null) | .node_name] | unique | length' <<<"$sp_json" 2>/dev/null || echo 0)
+if (( pool_nodes < 2 )); then
+    echo "SKIP: $POOL SP not on >=2 nodes (got $pool_nodes) — U268 fixture unavailable"
+    exit 0
+fi
+
+# ---- BULK CREATE: fire all RDs in a tight loop (the back-pressure) ----
+echo ">> bulk-creating $COUNT RDs (64M, --auto-place 2 -s $POOL) in a tight loop"
+created=0
+for rd in "${RDS[@]}"; do
+    # Each RD is rd c + vd c + r c --auto-place 2. We don't wait between
+    # iterations — the burst is the whole point of U268.
+    if ! "${LCTL[@]}" resource-definition create "$rd" >/dev/null 2>&1; then
+        echo "FAIL (U268): rd c $rd rejected during bulk burst" >&2
+        exit 1
+    fi
+    if ! "${LCTL[@]}" volume-definition create "$rd" 64M >/dev/null 2>&1; then
+        echo "FAIL (U268): vd c $rd rejected during bulk burst" >&2
+        exit 1
+    fi
+    if ! "${LCTL[@]}" resource create --auto-place 2 --storage-pool="$POOL" "$rd" >/dev/null 2>&1; then
+        echo "FAIL (U268): r c --auto-place 2 $rd rejected during bulk burst" >&2
+        exit 1
+    fi
+    created=$((created+1))
+done
+echo "   accepted $created/$COUNT RD creates"
+if (( created != COUNT )); then
+    echo "FAIL (U268): only $created/$COUNT RD creates accepted" >&2
+    exit 1
+fi
+
+# ---- CONVERGENCE: every RD's diskful replicas reach UpToDate ----
+#
+# converged_rd <rd> -> prints "yes" iff EVERY diskful (non-DISKLESS,
+# non-TIE_BREAKER) replica of <rd> reports diskState UpToDate, AND there
+# is at least 2 diskful replicas (auto-place 2 must have landed both).
+converged_rd() {
+    local rd=$1
+    local name flags ds diskful=0 up=0
+    while read -r name; do
+        [[ -z "$name" ]] && continue
+        flags=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+            -o jsonpath='{.spec.flags}' 2>/dev/null || echo "")
+        # Skip diskless witnesses / tiebreakers.
+        if [[ "$flags" == *"DISKLESS"* || "$flags" == *"TIE_BREAKER"* ]]; then
+            continue
+        fi
+        diskful=$((diskful+1))
+        ds=$(kubectl get "resources.blockstor.cozystack.io/${name}" \
+            -o jsonpath='{.status.volumes[0].diskState}' 2>/dev/null || echo "")
+        [[ "$ds" == "UpToDate" ]] && up=$((up+1))
+    done < <(kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+        | awk -v rd="${rd}." '$1 ~ "^"rd {print $1}')
+    if (( diskful >= 2 && up == diskful )); then
+        echo "yes"
+    else
+        echo "no"
+    fi
+}
+
+# inconsistent_no_progress <rd> -> prints "stuck" if any diskful replica
+# of <rd> is Inconsistent AND its kernel resync done% has not advanced
+# since last sample (tracked by the caller via the assoc arrays). Here we
+# just report the current min done% across replicas + whether any is
+# Inconsistent so the caller can decide.
+rd_min_done_and_inconsistent() {
+    local rd=$1 node pct any_incons="no" min=100
+    while read -r node; do
+        [[ -z "$node" ]] && continue
+        local ds
+        ds=$(status_disk_state "$rd" "$node" 0)
+        [[ "$ds" == "Inconsistent" ]] && any_incons="yes"
+        pct=$(on_node "$node" drbdsetup status "$rd" --json 2>/dev/null | jq -r '
+            [.[0].connections[]? | .peer_devices[]? | (.done // empty)]
+            | map(select(. != null)) | (min // 100)' 2>/dev/null || echo 100)
+        [[ -z "$pct" ]] && pct=100
+        (( pct < min )) && min=$pct
+    done < <(linstor_diskful_nodes "$rd")
+    echo "${any_incons}:${min}"
+}
+
+echo ">> waiting up to ${CONVERGE_TIMEOUT}s for all $COUNT RDs to reach all-replicas-UpToDate"
+deadline=$(( $(date +%s) + CONVERGE_TIMEOUT ))
+
+# Per-RD stuck tracking for Inconsistent-without-progress.
+declare -A last_min=()
+declare -A last_min_ts=()
+
+all_done=false
+while (( $(date +%s) < deadline )); do
+    pending=()
+    now=$(date +%s)
+    for rd in "${RDS[@]}"; do
+        if [[ "$(converged_rd "$rd")" == "yes" ]]; then
+            continue
+        fi
+        pending+=("$rd")
+
+        # Stuck check: if a diskful replica is Inconsistent and the min
+        # resync done% has not advanced for >STUCK_S, it's wedged.
+        info=$(rd_min_done_and_inconsistent "$rd")
+        incons=${info%%:*}
+        minpct=${info##*:}
+        if [[ "$incons" == "yes" ]]; then
+            if [[ "${last_min[$rd]:-}" == "$minpct" ]]; then
+                elapsed=$(( now - ${last_min_ts[$rd]:-now} ))
+                if (( elapsed > STUCK_S )); then
+                    echo "FAIL (U268): $rd has an Inconsistent diskful replica stuck at done=${minpct}% for ${elapsed}s (>${STUCK_S}s) — wedged initial sync under bulk burst" >&2
+                    kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+                        | awk -v rd="${rd}." '$1 ~ "^"rd' | sed 's/^/    /' >&2 || true
+                    for node in $(linstor_diskful_nodes "$rd"); do
+                        on_node "$node" drbdsetup status "$rd" 2>/dev/null | sed "s/^/    ${node}: /" >&2 || true
+                    done
+                    exit 1
+                fi
+            else
+                last_min["$rd"]="$minpct"
+                last_min_ts["$rd"]=$now
+            fi
+        else
+            # Progressing or not-yet-Inconsistent — reset the stuck clock.
+            unset 'last_min[$rd]'
+            unset 'last_min_ts[$rd]'
+        fi
+    done
+
+    if (( ${#pending[@]} == 0 )); then
+        all_done=true
+        break
+    fi
+    echo "   ${#pending[@]}/$COUNT RDs still converging..."
+    sleep 10
+done
+
+if [[ "$all_done" != "true" ]]; then
+    echo "FAIL (U268): not all $COUNT RDs reached all-replicas-UpToDate within ${CONVERGE_TIMEOUT}s" >&2
+    echo "   still-pending RDs:" >&2
+    for rd in "${RDS[@]}"; do
+        if [[ "$(converged_rd "$rd")" != "yes" ]]; then
+            echo "    $rd:" >&2
+            kubectl get resources.blockstor.cozystack.io --no-headers 2>/dev/null \
+                | awk -v rd="${rd}." '$1 ~ "^"rd' | sed 's/^/      /' >&2 || true
+        fi
+    done
+    exit 1
+fi
+
+# Final independent recount — converged_rd already proved per-RD UpToDate,
+# but recompute the converged total so the success line is honest and a
+# logic slip in the loop above can't claim a vacuous pass.
+converged_total=0
+for rd in "${RDS[@]}"; do
+    [[ "$(converged_rd "$rd")" == "yes" ]] && converged_total=$((converged_total+1))
+done
+if (( converged_total != COUNT )); then
+    echo "FAIL (U268): final recount $converged_total/$COUNT converged — convergence loop disagreed with recount" >&2
+    exit 1
+fi
+
+echo ">> u268-bulk-create-converges OK (all $COUNT bulk-created RDs reached all-replicas-UpToDate, none wedged Inconsistent)"

--- a/tests/operator-harness/replay/u145-add-replica-over-data-syncs.yaml
+++ b/tests/operator-harness/replay/u145-add-replica-over-data-syncs.yaml
@@ -1,0 +1,82 @@
+name: u145-add-replica-over-data-syncs
+description: |
+  U145 (P0, DATA INTEGRITY) operator-CLI replay. Upstream LINSTOR user
+  report: adding a diskful replica to a resource that already holds data
+  brought the new replica up UpToDate IMMEDIATELY without syncing — a
+  silent empty copy presenting as good, promotable on failover → data
+  loss.
+
+  For blockstor this is the critical interaction with the skip-init-sync
+  design: a replica added to an RD that has already been written (RD.Spec.
+  Initialized latched true) MUST be stamped SkipInitialSync=false by the
+  controller and come up Inconsistent → SyncTarget, converging to a clean
+  UpToDate with no stuck (NN%) — never instant-UpToDate-empty.
+
+  This replay pins the operator-CLI convergence half: build a 2-replica
+  RD, let it reach UpToDate (the lowest-id winner has minted a real
+  past-day0 generation — proxy for "data exists"), then add a 3rd diskful
+  replica and assert it converges to clean UpToDate (sync_clean) on every
+  replica without breaking the existing two.
+
+  The data-write + NEGATIVE (never instant-UpToDate) + md5 content-
+  correctness half — which needs a PVC/pod and kernel-state polling — is
+  delegated to the L6 cli-matrix cell u145-write-then-add-replica-syncs.sh
+  (same division of labour as the vd-resize lifecycle, whose pod md5
+  anchor lives in its L6 cell). The L1 seed-decision pins are
+  internal/controller TestSkipInitSyncDataBearingPeerLatchesAndNewReplica
+  Syncs and pkg/satellite TestResolveVolumeSeedReadsSkipInitialSyncSpec
+  Flag.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: lvm-thin
+
+vars:
+  sp: lvm-thin
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "1G"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-2r-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  # Add the 3rd diskful replica AFTER the initial set has converged. The
+  # RD is Initialized, so this replica must SyncTarget from a data-bearing
+  # peer — not skip-seed to instant-UpToDate.
+  - name: r-c-node3-over-data
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 3
+      timeout_s: 60
+  # The new replica must reach a CLEAN UpToDate (no stuck (NN%)) on every
+  # replica — proving the SyncTarget seed completed, not an instant skip.
+  - name: wait-3r-sync-clean
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: sync_clean
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans

--- a/tests/operator-harness/replay/u216-add-peer-mesh-no-standalone.yaml
+++ b/tests/operator-harness/replay/u216-add-peer-mesh-no-standalone.yaml
@@ -1,0 +1,78 @@
+name: u216-add-peer-mesh-no-standalone
+description: |
+  U216 (P1) operator-CLI replay. Upstream LINSTOR user report:
+  autoplace-EXTENDING an existing resource produced a StandAlone replica
+  because the EXISTING replicas' .res was never regenerated to include
+  the newly-added peer (no `on <newnode>` block / no connection path), so
+  the fresh replica's handshake found no peer and wedged StandAlone.
+
+  blockstor regenerates the desired peer set for EVERY replica each
+  reconcile from the live RD's full replica set, so adding a peer
+  rewrites every existing replica's .res with the new on-block + a full
+  connection mesh. This replay pins the operator-CLI convergence: extend
+  a 2-replica RD to 3 and assert the new replica reaches a clean UpToDate
+  on every replica (a StandAlone replica never converges → all_uptodate /
+  sync_clean would time out, catching the regression).
+
+  The .res-content + kernel "no StandAlone" + drbdsetup-connection-listing
+  assertions live in the L6 cli-matrix cell u216-add-peer-mesh.sh; the
+  dispatcher root-cause guard is the L1 pkg/dispatcher
+  TestU216AddPeerRegeneratesExistingReplicaMesh.
+
+prerequisites:
+  min_nodes: 3
+  storage_pool: stand
+
+vars:
+  sp: stand
+
+steps:
+  - name: create-rd
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd
+    cmd: ["volume-definition", "create", "{{rd}}", "32M"]
+    expect_exit: 0
+  - name: r-c-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-2r-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: r-c-node3-extend
+    cmd: ["resource", "create", "{{node3}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 3
+      timeout_s: 60
+  # If the new replica StandAlones (U216), it never reaches UpToDate and
+  # this assertion times out — the regression catcher.
+  - name: wait-3r-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+  - name: wait-3r-sync-clean
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: sync_clean
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## What

Test-only PR — campaign-2 package U2 (sync correctness), pinning the upstream-LINSTOR user-reported sync-integrity corner cases against blockstor's skip-init-sync design:

- **U145 (P0, data integrity)** — upstream report: adding a diskful replica to a resource that already holds written data brought the new replica up UpToDate WITHOUT syncing (silent empty copy, promotable on failover). For blockstor this is THE critical interaction with the day0 GI seed-skip: once `RD.Spec.Initialized` latches, an added replica must be stamped `SkipInitialSync=false` and come up Inconsistent → SyncTarget. Pinned at L6 (kernel `received` byte counter + md5 content anchor through a writer pod, with a CSI-independent fallback) and L7 (`u145-add-replica-over-data-syncs.yaml`).
- **U216** — upstream report: adding a peer did not regenerate the connection mesh on existing replicas (new peer stuck StandAlone). Pinned at L1 (dispatcher add-peer mesh test), L6 (`u216-add-peer-mesh.sh`: 3rd replica joins with all connections Connected, no StandAlone) and L7 (`u216-add-peer-mesh-no-standalone.yaml`).
- **U203** — an Inconsistent replica with no sync source must not be classified SyncTarget in status (L1 store/status classification test).
- **U251** — upstream report: after a node rejoins, resyncs stick at 97–98% with stale status. Pinned at L6 (`u251-rejoin-resync-clean.sh`): one worker's DRBD ports are isolated via iptables (ports DERIVED from the Resource CRDs — blockstor allocates 20000-20999, not upstream's 7000s; an earlier draft isolating 7000:7999 was vacuous and is replaced), data is written on the survivors, the link heals, and every resource on the rejoined node must drain to UpToDate with no stuck done-% and CRD diskState matching kernel truth. Non-vacuous gate: the cell FAILs if the isolation never drops a connection.
- **U268** — upstream report: bulk create (~50 resources) leaves a few stuck Inconsistent. Pinned at L6 (`u268-bulk-create-converges.sh`): 30 RDs created in a tight loop must all converge to UpToDate within the budget, with stuck-done-% detection rather than a bare timeout.

## Testing

- L1: `go test ./...` green (new dispatcher + store classification tests).
- Stand (main image incl. #121): `u145-write-then-add-replica-syncs.sh`, `u216-add-peer-mesh.sh`, `u251-rejoin-resync-clean.sh`, `u268-bulk-create-converges.sh`, both L7 replays, and the mandatory `r-full-lifecycle.sh` gate — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit and integration tests validating peer mesh regeneration when adding replicas to resources
  * Added end-to-end tests for replica addition with data integrity checks, bulk resource creation convergence, and rejoin/resync workflows
  * Enhanced test coverage with operator-harness replay test cases for replica management scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->