### PR TITLE
fix(rest): treat rg spawn volume_sizes as KiB, not bytes (Bug 391)

### DIFF
--- a/pkg/rest/bug_381_spawn_non_positive_size_test.go
+++ b/pkg/rest/bug_381_spawn_non_positive_size_test.go
@@ -31,12 +31,12 @@ import (
 
 // Bug 381 (P3, bughunt round 11 — 2026-06-02): the spawn fast path
 // `POST /v1/resource-groups/{rg}/spawn` silently accepted
-// non-positive `volume_sizes` entries. The wire field is bytes
-// (Bug-92 shape); each entry is divided by 1024 to land as size_kib
-// on the VD, so a `-100` truncated to `size_kib=0` and a `0` stayed
-// `0`. Both spawned the RD with a zero-sized VD — the satellite
-// reconciler then looped on `drbdadm create-md` indefinitely
-// (DRBD's per-device minimum is ~4 MiB once metadata is reserved).
+// non-positive `volume_sizes` entries. The wire field is size_kib
+// (Bug 391 — the python client + upstream REST spec both encode
+// `volume_sizes` in KiB), so a `-100` and a `0` both spawned the RD
+// with a zero/negative-sized VD — the satellite reconciler then
+// looped on `drbdadm create-md` indefinitely (DRBD's per-device
+// minimum is ~4 MiB once metadata is reserved).
 //
 // The direct `POST /v1/resource-definitions/{rd}/volume-definitions`
 // path already rejected the same input via Bug 155

--- a/pkg/rest/bug_391_spawn_size_kib_test.go
+++ b/pkg/rest/bug_391_spawn_size_kib_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug 391 (spawn-size unit, 2026-06-06): `linstor rg spawn-resources
+// <rg> <rd> 32M` created a 32 KiB volume instead of a 32 MiB one.
+//
+// Root cause: the spawn handler treated `volume_sizes` as BYTES and
+// divided every entry by 1024 to derive size_kib. But the field is
+// KiB:
+//
+//   - The python linstor client encodes the operator's size argument
+//     with `parse_volume_size_to_kib` before POSTing — `32M` becomes
+//     the integer 32768 in the `volume_sizes` array (see
+//     linstorapi.py:resource_group_spawn → parse_volume_size_to_kib).
+//   - The upstream LINSTOR REST API spec documents `volume_sizes` as
+//     "sizes (in kib)" (rest_v1_openapi.yaml, ResourceGroupSpawn).
+//
+// So `32M` → client sends `32768` → handler divided by 1024 → a
+// 32 KiB VD. Below DRBD's ~4 MiB per-device floor, the satellite
+// reconciler then hot-looped on `drbdadm create-md`.
+//
+// The fix uses each `volume_sizes` entry directly as size_kib,
+// matching the `vd c` path (volume_definitions.go reads `size_kib`
+// verbatim). This test pins the exact operator-reported repro: the
+// integer the python client puts on the wire for "32M" (32768) must
+// land as a 32768 KiB VolumeDefinition — NOT 32 KiB.
+
+// TestBug391_SpawnSizeIsKibNotBytes is the canonical pin: the wire
+// integer 32768 (what `parse_volume_size_to_kib("32M")` produces)
+// must materialise a VD of exactly 32768 KiB.
+func TestBug391_SpawnSizeIsKibNotBytes(t *testing.T) {
+	st := store.NewInMemory()
+	ctx := t.Context()
+
+	if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+		Name: "rg-391",
+		// PlaceCount=0 → spawnAutoplace returns nil immediately, so we
+		// get a clean 201 without needing seeded nodes/pools; the size
+		// is all this test cares about.
+		SelectFilter: apiv1.AutoSelectFilter{PlaceCount: 0},
+	}); err != nil {
+		t.Fatalf("seed RG: %v", err)
+	}
+
+	base, stop := startServerWithStore(t, st)
+	defer stop()
+
+	// 32768 is exactly what the python client puts on the wire for the
+	// operator's `32M` argument (parse_volume_size_to_kib → KiB).
+	const wireSizeKibFor32M int64 = 32768
+
+	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+		ResourceDefinitionName: "bug391-rd",
+		VolumeSizes:            []int64{wireSizeKibFor32M},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := httpPost(t, base+"/v1/resource-groups/rg-391/spawn", body)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", resp.StatusCode)
+	}
+
+	vds, err := st.VolumeDefinitions().List(ctx, "bug391-rd")
+	if err != nil {
+		t.Fatalf("list VDs: %v", err)
+	}
+
+	if len(vds) != 1 {
+		t.Fatalf("VD count: got %d, want 1", len(vds))
+	}
+
+	// The bug: a /1024 divide here would land 32 KiB. The fix keeps it
+	// at the requested 32768 KiB (= 32 MiB).
+	if vds[0].SizeKib != wireSizeKibFor32M {
+		t.Errorf("VD size: got %d KiB, want %d KiB (32M must not be divided to 32 KiB)",
+			vds[0].SizeKib, wireSizeKibFor32M)
+	}
+}
+
+// TestBug391_SpawnSizeMultiUnitTable pins a representative slice of
+// the unit ladder the python client emits, so a future "helpful"
+// re-introduction of a /1024 (or a ×1024) divide is caught regardless
+// of which unit the operator typed. Each `wireKib` value is exactly
+// what `parse_volume_size_to_kib` returns for the matching CLI token.
+func TestBug391_SpawnSizeMultiUnitTable(t *testing.T) {
+	cases := []struct {
+		name    string // operator's CLI size token
+		wireKib int64  // what the python client POSTs
+	}{
+		{"4M", 4096},
+		{"32M", 32768},
+		{"1G", 1048576},
+		{"10G", 10485760},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := store.NewInMemory()
+			ctx := t.Context()
+
+			if err := st.ResourceGroups().Create(ctx, &apiv1.ResourceGroup{
+				Name:         "rg-tab",
+				SelectFilter: apiv1.AutoSelectFilter{PlaceCount: 0},
+			}); err != nil {
+				t.Fatalf("seed RG: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			body, err := json.Marshal(apiv1.ResourceGroupSpawn{
+				ResourceDefinitionName: "tab-rd",
+				VolumeSizes:            []int64{tc.wireKib},
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			resp := httpPost(t, base+"/v1/resource-groups/rg-tab/spawn", body)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusCreated {
+				t.Fatalf("status: got %d, want 201", resp.StatusCode)
+			}
+
+			vds, err := st.VolumeDefinitions().List(ctx, "tab-rd")
+			if err != nil {
+				t.Fatalf("list VDs: %v", err)
+			}
+
+			if len(vds) != 1 || vds[0].SizeKib != tc.wireKib {
+				t.Errorf("%s: VD size got %v, want one VD of %d KiB",
+					tc.name, vds, tc.wireKib)
+			}
+		})
+	}
+}

--- a/pkg/rest/spawn.go
+++ b/pkg/rest/spawn.go
@@ -88,38 +88,44 @@ func (s *Server) handleSpawn(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Bug 381 (P3, bughunt round 11 — 2026-06-02): the spawn fast
-	// path silently accepted non-positive `volume_sizes`. The wire
-	// field is bytes (Bug-92 shape); each entry is divided by 1024
-	// to land as size_kib on the VD, so a `-100` truncated to
-	// `size_kib=0` and a `0` stayed `0`. Both spawned the RD with a
-	// zero-sized VD — the satellite reconciler then looped on
-	// `drbdadm create-md` indefinitely (DRBD's per-device minimum is
-	// ~4 MiB once metadata is reserved). Reject non-positive entries
-	// at the wire boundary BEFORE `Store.Create` so a bad spawn is
-	// one consistent LINSTOR envelope and no orphan RD is left
-	// behind. We don't apply the full Bug 155 [4096 KiB, 16 TiB]
-	// gate here because the oversub gate already runs against the
-	// caller's bytes value upstream (see `rejectIfExceedsOversubGate`
-	// + `oversub_test.go`), and unit tests cover ≤4 MiB sizes for
-	// oversub-policy probes that we don't want to break. The Bug 155
-	// bound itself still kicks in if the caller later issues a
-	// `vd c` or `vd modify` — but those paths already gate it.
-	// Symmetric with the VD-create body branch's writeVDSizeRejection
-	// so the CLI parity audit row for `rg spawn` matches `vd c` on
-	// the non-positive input class operators actually hit.
-	for i, sizeBytes := range req.VolumeSizes {
-		if sizeBytes > 0 {
+	// path silently accepted non-positive `volume_sizes`, spawning
+	// the RD with a zero-sized VD — the satellite reconciler then
+	// looped on `drbdadm create-md` indefinitely (DRBD's per-device
+	// minimum is ~4 MiB once metadata is reserved). Reject
+	// non-positive entries at the wire boundary BEFORE `Store.Create`
+	// so a bad spawn is one consistent LINSTOR envelope and no orphan
+	// RD is left behind.
+	//
+	// Bug 391 (spawn-size unit, 2026-06-06): `volume_sizes` is KiB,
+	// NOT bytes. The python linstor client encodes the operator's
+	// size argument with `parse_volume_size_to_kib` before POSTing
+	// (e.g. `rg spawn-resources <rg> <rd> 32M` → `[32768]`), and the
+	// upstream REST API spec documents the field as "sizes (in kib)".
+	// The handler previously divided every entry by 1024 (treating it
+	// as bytes — the Bug-92 shape that applies to a DIFFERENT field),
+	// so `32M` landed as a 32 KiB VD. Each entry is now used directly
+	// as size_kib, matching the `vd c` path (volume_definitions.go,
+	// which reads `size_kib` verbatim).
+	//
+	// We don't apply the full Bug 155 [4096 KiB, 16 TiB] gate here
+	// because the oversub gate already runs against the requested KiB
+	// upstream (see `rejectIfExceedsOversubGate` + `oversub_test.go`),
+	// and unit tests cover small sizes for oversub-policy probes that
+	// we don't want to break. The Bug 155 bound itself still kicks in
+	// if the caller later issues a `vd c` or `vd modify`. Symmetric
+	// with the VD-create body branch's writeVDSizeRejection so the
+	// CLI parity audit row for `rg spawn` matches `vd c` on the
+	// non-positive input class operators actually hit.
+	for i, sizeKib := range req.VolumeSizes {
+		if sizeKib > 0 {
 			continue
 		}
 
 		// Fabricate the same below-minimum sentinel the VD-create
-		// path uses so the wire shape is byte-identical. The
-		// post-divide size_kib value is what the operator sees in
-		// the envelope; we report it directly so `0` and `-100`
-		// both surface as `size_kib=0 below minimum 4096 KiB` (the
-		// effective floor) rather than a separate "non-positive"
-		// envelope that no other handler emits.
-		sizeKib := sizeBytes / bytesPerKib
+		// path uses so the wire shape is byte-identical: `0` and
+		// `-100` both surface as `size_kib=<n> below minimum 4096
+		// KiB` (the effective floor) rather than a separate
+		// "non-positive" envelope that no other handler emits.
 		reason := errors.Wrapf(ErrVolumeSizeBelowMinimum,
 			"size_kib=%d below minimum %d KiB "+
 				"(DRBD reserves ~32 KiB of metadata per peer; backing layers add alignment on top)",
@@ -259,17 +265,18 @@ func buildSpawnedRD(req *apiv1.ResourceGroupSpawn, rgName string, rg *apiv1.Reso
 	return rd
 }
 
-const bytesPerKib = 1024
-
 // spawnVolumeDefinitions creates one VD per requested size on the named RD.
-// Volume numbers follow the slice index, matching upstream LINSTOR.
+// Volume numbers follow the slice index, matching upstream LINSTOR. Each
+// `sizes` entry is size_kib (Bug 391) — the python client + upstream REST
+// spec both encode `volume_sizes` in KiB — so it is stamped on the VD
+// verbatim, identically to the `vd c` path.
 func (s *Server) spawnVolumeDefinitions(ctx context.Context, rdName string, rg *apiv1.ResourceGroup, sizes []int64) error {
-	for i, sizeBytes := range sizes {
+	for i, sizeKib := range sizes {
 		volNum := int32(i)
 
 		vd := apiv1.VolumeDefinition{
 			VolumeNumber: volNum,
-			SizeKib:      sizeBytes / bytesPerKib,
+			SizeKib:      sizeKib,
 			Props:        copyVolumeGroupProps(rg.VolumeGroups, volNum),
 		}
 
@@ -352,8 +359,7 @@ func (s *Server) rejectIfExceedsOversubGate(ctx context.Context, w http.Response
 		return false
 	}
 
-	for i, sizeBytes := range req.VolumeSizes {
-		sizeKib := sizeBytes / bytesPerKib
+	for i, sizeKib := range req.VolumeSizes {
 		if sizeKib > capKib {
 			writeError(w, http.StatusConflict,
 				"over-subscription gate: volume "+

--- a/pkg/rest/spawn_test.go
+++ b/pkg/rest/spawn_test.go
@@ -48,7 +48,9 @@ func TestSpawnCreatesRDAndVDs(t *testing.T) {
 
 	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-1",
-		VolumeSizes:            []int64{2 * 1024 * 1024, 4 * 1024 * 1024}, // bytes
+		// volume_sizes is KiB (Bug 391): the python client encodes
+		// `2M`/`4M` as [2048, 4096] via parse_volume_size_to_kib.
+		VolumeSizes: []int64{2048, 4096}, // KiB
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -83,7 +85,8 @@ func TestSpawnCreatesRDAndVDs(t *testing.T) {
 		t.Fatalf("len: got %d, want 2", len(vds))
 	}
 
-	// 2 MiB / 1024 = 2048 KiB; 4 MiB → 4096 KiB.
+	// volume_sizes entries land verbatim as size_kib (Bug 391): the
+	// requested [2048, 4096] KiB must NOT be divided by 1024.
 	if vds[0].SizeKib != 2048 || vds[1].SizeKib != 4096 {
 		t.Errorf("VD sizes: got %d, %d, want 2048, 4096", vds[0].SizeKib, vds[1].SizeKib)
 	}
@@ -325,7 +328,7 @@ func TestSpawnRejectsExceedingFreeCapacityRatio(t *testing.T) {
 
 	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-too-big",
-		VolumeSizes:            []int64{3 * 1024 * 1024}, // 3 MiB = 3072 KiB > 2048 cap
+		VolumeSizes:            []int64{3072}, // 3 MiB = 3072 KiB > 2048 cap
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -400,7 +403,7 @@ func TestSpawnRejectsExceedingTotalCapacityRatio(t *testing.T) {
 
 	body, _ := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-total-gate",
-		VolumeSizes:            []int64{24 * 1024}, // 24 KiB > cap=20
+		VolumeSizes:            []int64{24}, // 24 KiB > cap=20 (volume_sizes is KiB, Bug 391)
 	})
 
 	resp := httpPost(t, base+"/v1/resource-groups/rg-total/spawn", body)
@@ -443,7 +446,7 @@ func TestSpawnRejectsExceedingOversubscriptionRatio(t *testing.T) {
 
 	body, _ := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-umb",
-		VolumeSizes:            []int64{40 * 1024}, // 40 KiB > 30 cap
+		VolumeSizes:            []int64{40}, // 40 KiB > 30 cap (volume_sizes is KiB, Bug 391)
 	})
 
 	resp := httpPost(t, base+"/v1/resource-groups/rg-umb/spawn", body)
@@ -489,7 +492,7 @@ func TestSpawnAcceptsWithinOversubscriptionGate(t *testing.T) {
 
 	body, _ := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-fits",
-		VolumeSizes:            []int64{40 * 1024}, // 40 KiB ≤ 50 cap
+		VolumeSizes:            []int64{40}, // 40 KiB ≤ 50 cap (volume_sizes is KiB, Bug 391)
 	})
 
 	resp := httpPost(t, base+"/v1/resource-groups/rg-ok/spawn", body)
@@ -627,7 +630,7 @@ func TestSpawnAutoplacesFromRGSelectFilter(t *testing.T) {
 
 	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-spawn",
-		VolumeSizes:            []int64{4 * 1024 * 1024}, // 4 MiB
+		VolumeSizes:            []int64{4096}, // 4 MiB = 4096 KiB (Bug 391)
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -749,7 +752,10 @@ func TestSpawnAutoplaceRejectsCrossKindFromRG(t *testing.T) {
 
 	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-mixed",
-		VolumeSizes:            []int64{1024 * 1024},
+		// 4 MiB in KiB (Bug 391): well under the default-ratio cap
+		// (free 1000 KiB × 20 = 20000) so this exercises the
+		// cross-kind placement deferral, not the oversub gate.
+		VolumeSizes: []int64{4096},
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -842,8 +848,11 @@ func TestSpawnPartialFlagAllowsShortPlacement(t *testing.T) {
 
 	body, err := json.Marshal(apiv1.ResourceGroupSpawn{
 		ResourceDefinitionName: "pvc-partial",
-		VolumeSizes:            []int64{1024 * 1024},
-		PartialFlag:            true,
+		// 4 MiB in KiB (Bug 391): under the default-ratio cap
+		// (free 1000 KiB × 20 = 20000) so the partial-placement
+		// path is what's exercised, not the oversub gate.
+		VolumeSizes: []int64{4096},
+		PartialFlag: true,
 	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)

--- a/tests/e2e/cli-matrix/r-c-autoplace-plus-one.sh
+++ b/tests/e2e/cli-matrix/r-c-autoplace-plus-one.sh
@@ -63,6 +63,19 @@ echo ">> [D2] rg create --place-count 2 + spawn -> 2 diskful replicas"
 "${LCTL[@]}" resource-group create "$RG" --place-count 2 --storage-pool="$POOL" >/dev/null
 "${LCTL[@]}" resource-group spawn-resources "$RG" "$RD" 32M >/dev/null
 
+# Bug 391 cross-check: `32M` must spawn a 32768 KiB VD, not a 32 KiB
+# one (a 32 KiB VD is below DRBD's create-md floor and the replicas
+# below would never converge). Guards this workflow against a silent
+# spawn-size regression that the replica-count assertion alone would
+# mask.
+if ! wait_vd_size "$RD" 0 32768 60; then
+    got=$(linstor_vd_size_kib "$RD" 0)
+    echo "FAIL (D2/Bug391): VD size_kib=${got}, want 32768 (32M must not be divided to 32 KiB)" >&2
+    "${LCTL[@]}" volume-definition list --resource-definitions "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo ">> spawned VD = 32768 KiB (32M) — OK"
+
 # Wait for 2 diskful replicas UpToDate.
 wait_replica_count "$RD" 2 90 || {
     echo "FAIL (D2 setup): RD did not reach 2 replicas" >&2

--- a/tests/e2e/cli-matrix/r-c-autoplace-plus-one.sh
+++ b/tests/e2e/cli-matrix/r-c-autoplace-plus-one.sh
@@ -76,15 +76,20 @@ if ! wait_vd_size "$RD" 0 32768 60; then
 fi
 echo ">> spawned VD = 32768 KiB (32M) — OK"
 
-# Wait for 2 diskful replicas UpToDate.
-wait_replica_count "$RD" 2 90 || {
-    echo "FAIL (D2 setup): RD did not reach 2 replicas" >&2
-    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
-    exit 1
-}
-diskful2=$(linstor_diskful_count "$RD")
+# Wait for the place-count=2 spawn to converge to 2 DISKFUL replicas.
+# An auto-quorum RD also spawns a diskless TIE_BREAKER (total CRDs = 3),
+# so gate on the diskful count, not the total replica count — the old
+# wait_replica_count "$RD" 2 timed out at 3 once the tiebreaker landed.
+ap_deadline=$(( $(date +%s) + 90 ))
+diskful2=0
+while (( $(date +%s) < ap_deadline )); do
+    diskful2=$(linstor_diskful_count "$RD")
+    (( diskful2 == 2 )) && break
+    sleep 2
+done
 if [[ "$diskful2" != "2" ]]; then
     echo "FAIL (D2 setup): expected 2 diskful replicas, got $diskful2" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
     exit 1
 fi
 echo ">> baseline: 2 diskful replicas — OK"

--- a/tests/e2e/cli-matrix/rg-spawn-size-parse.sh
+++ b/tests/e2e/cli-matrix/rg-spawn-size-parse.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# usage: rg-spawn-size-parse.sh WORK_DIR
+#
+# L6 cli-matrix cell — Bug 391 (spawn-size unit).
+#
+# Upstream LINSTOR contract: `linstor rg spawn-resources <rg> <rd> 32M`
+# creates a 32 MiB volume — i.e. a VolumeDefinition of 32768 KiB. The
+# size token is parsed by the python client into KiB
+# (`parse_volume_size_to_kib("32M") == 32768`) and shipped on the wire
+# as the `volume_sizes` array, which the upstream REST API documents as
+# "sizes (in kib)".
+#
+# The bug: blockstor's spawn handler treated `volume_sizes` as BYTES
+# and divided every entry by 1024, so `32M` (wire value 32768) landed
+# as a 32 KiB VolumeDefinition. 32 KiB is below DRBD's ~4 MiB
+# per-device floor, so the satellite reconciler then hot-looped on
+# `drbdadm create-md`.
+#
+# Reproduction:
+#
+#   $ linstor resource-group create rg --place-count 1 -s stand
+#   $ linstor resource-group spawn-resources rg rd 32M
+#   $ linstor volume-definition list -r rd      # size MUST be 32 MiB
+#
+# This cell pins the size half end-to-end against the real CLI: after a
+# `32M` spawn, the VolumeDefinition size_kib MUST be exactly 32768, and
+# the spawned replica MUST reach UpToDate (which a 32 KiB VD never
+# could — create-md would loop). A regression that re-introduces the
+# /1024 divide lands a 32 KiB VD and this cell goes red on both the
+# size assertion and the UpToDate wait.
+#
+# Unit pin: pkg/rest/bug_391_spawn_size_kib_test.go.
+# L7 replay: tests/operator-harness/replay/rg-spawn-size-parse.yaml.
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+require_workers 1
+
+linstor_cli_setup
+
+RG=cli-matrix-bug391-rg
+RD=cli-matrix-bug391-rd
+POOL=${POOL:-stand}
+
+# 32M == 32 MiB == 32768 KiB. This is the exact value the python client
+# puts on the wire for the operator's `32M` argument.
+WANT_KIB=32768
+
+cleanup() {
+    "${LCTL[@]}" resource-definition delete "$RD" >/dev/null 2>&1 || true
+    "${LCTL[@]}" resource-group delete "$RG" >/dev/null 2>&1 || true
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+echo ">> [Bug391] rg create --place-count 1 + spawn-resources $RD 32M"
+"${LCTL[@]}" resource-group create "$RG" --place-count 1 --storage-pool="$POOL" >/dev/null
+"${LCTL[@]}" resource-group spawn-resources "$RG" "$RD" 32M >/dev/null
+
+echo ">> [Bug391] VolumeDefinition size MUST be ${WANT_KIB} KiB (32 MiB), NOT 32 KiB"
+if ! wait_vd_size "$RD" 0 "$WANT_KIB" 60; then
+    got=$(linstor_vd_size_kib "$RD" 0)
+    echo "FAIL (Bug391): VD size_kib=${got}, want ${WANT_KIB} (32M must NOT be divided to 32 KiB)" >&2
+    "${LCTL[@]}" volume-definition list --resource-definitions "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+echo ">> VD size = ${WANT_KIB} KiB — OK"
+
+echo ">> [Bug391] the spawned replica MUST reach UpToDate (a 32 KiB VD never could)"
+if ! wait_replica_count "$RD" 1 90; then
+    echo "FAIL (Bug391): RD did not reach 1 replica" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+deadline=$(( $(date +%s) + 240 ))
+all_up=false
+while (( $(date +%s) < deadline )); do
+    up=$("${LCTL[@]}" --machine-readable resource list --resources "$RD" 2>/dev/null \
+        | jq -r '[.[][]? | .volumes[]? | select(.provider_kind != "DISKLESS") | .state.disk_state]
+                 | map(select(. == "UpToDate")) | length' 2>/dev/null || echo 0)
+    if (( up >= 1 )); then
+        all_up=true
+        break
+    fi
+    sleep 3
+done
+
+if [[ "$all_up" != "true" ]]; then
+    echo "FAIL (Bug391): replica never reached UpToDate (32 KiB VD would loop on create-md)" >&2
+    "${LCTL[@]}" resource list --resources "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+echo ">> rg-spawn-size-parse OK (Bug391 pinned: 32M spawns a 32768 KiB VD, replica UpToDate)"

--- a/tests/integration/group_i_test.go
+++ b/tests/integration/group_i_test.go
@@ -268,7 +268,7 @@ func groupIResourceConnectionPathCreate(t *testing.T, stack *harness.Stack) {
 		pathTwoAB = "10.99.1.12"
 	)
 
-	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4*1024*1024)
+	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4096)
 	groupIWaitResourcesCreated(t, stack, rdName, 2)
 
 	groupIPostResourceConnectionPath(t, stack.RestURL, rdName,
@@ -355,7 +355,7 @@ func groupIPingTimeoutPropagation(t *testing.T, stack *harness.Stack) {
 	groupIPutControllerProp(t, stack.RestURL, groupIPropPingTimeout, "100")
 	groupIPutRGProp(t, stack.RestURL, harness.FixtureDefaultRG, groupIPropPingTimeout, "200")
 
-	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4*1024*1024)
+	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4096)
 	groupIWaitResourcesCreated(t, stack, rdName, 2)
 
 	groupIPutRDProp(t, stack.RestURL, rdName, groupIPropPingTimeout, "300")
@@ -399,7 +399,7 @@ func groupINetOptionsSplit(t *testing.T, stack *harness.Stack) {
 
 	const rdName = "rd-netopts"
 
-	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4*1024*1024)
+	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4096)
 	groupIWaitResourcesCreated(t, stack, rdName, 2)
 
 	want := map[string]string{
@@ -472,7 +472,7 @@ func groupIEffectivePropsAtAllLevels(t *testing.T, stack *harness.Stack) {
 	// new RD.Props at spawn time — writing the RG key before spawn
 	// would surface the value at RD scope on the resolver's walk,
 	// hiding the per-scope tag the Bug 203 guard asserts.
-	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4*1024*1024)
+	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4096)
 	groupIWaitResourcesCreated(t, stack, rdName, 2)
 
 	groupIPutRGProp(t, stack.RestURL, harness.FixtureDefaultRG, rgKey, rgVal)
@@ -549,7 +549,7 @@ func groupIDrbdProxyEndpoint(t *testing.T, stack *harness.Stack) {
 
 	const rdName = "rd-drbd-proxy"
 
-	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4*1024*1024)
+	spawnRDViaRG(t, stack, harness.FixtureDefaultRG, rdName, 4096)
 	groupIWaitResourcesCreated(t, stack, rdName, 2)
 
 	resp := groupIDoHTTPRequest(t, http.MethodPost,

--- a/tests/integration/group_j_test.go
+++ b/tests/integration/group_j_test.go
@@ -86,10 +86,10 @@ const groupJDefaultPlaceCount = 2
 // exercised.
 const groupJVolumeSizeKib int64 = 1024 * 1024 // 1 GiB
 
-// groupJVolumeSizeBytes is the byte-denominated form. The REST
-// spawn handler interprets `volume_sizes[]` as bytes and divides
-// by 1024 to land KiB on the VolumeDefinition; the Driver's
-// CapacityRangeMin is also byte-denominated to match the CSI spec.
+// groupJVolumeSizeBytes is the byte-denominated form, used only for
+// the Driver's CSI CapacityRangeMin (which IS byte-denominated per
+// the CSI spec). The REST spawn handler's `volume_sizes[]` field is
+// KiB (Bug 391) — pass groupJVolumeSizeKib to spawnViaRG, not this.
 const groupJVolumeSizeBytes = groupJVolumeSizeKib * 1024
 
 // TestGroupJ is the single parent that boots the stack once and
@@ -141,15 +141,15 @@ func TestGroupJ(t *testing.T) {
 // deterministic across the 9 fixture SPs (3 nodes × {lvm-thin,
 // zfs-thin, file}); pass "" to inherit from the RG.
 //
-// sizeBytes is byte-denominated to match the REST handler's
-// `volume_sizes[]` interpretation (it divides by 1024 to derive
-// VolumeDefinition.SizeKib).
-func spawnViaRG(t *testing.T, csi *harness.CSI, rdName, storPool string, sizeBytes int64) {
+// sizeKib is KiB-denominated to match the REST handler's
+// `volume_sizes[]` interpretation (Bug 391: the field is size_kib,
+// stamped verbatim onto the VolumeDefinition).
+func spawnViaRG(t *testing.T, csi *harness.CSI, rdName, storPool string, sizeKib int64) {
 	t.Helper()
 
 	req := lapi.ResourceGroupSpawn{
 		ResourceDefinitionName: rdName,
-		VolumeSizes:            []int64{sizeBytes},
+		VolumeSizes:            []int64{sizeKib},
 	}
 
 	if storPool != "" {
@@ -324,7 +324,7 @@ func runCSIIdentityServer(t *testing.T, csi *harness.CSI) {
 func runCSICreateVolumeFromEmpty(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 	const rdName = "pvc-create-empty"
 
-	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeKib)
 
 	waitForRDInStore(t, stack, rdName)
 
@@ -362,7 +362,7 @@ func runCSICreateVolumeFromEmpty(t *testing.T, stack *harness.Stack, csi *harnes
 func runCSICreateVolumeIdempotent(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 	const rdName = "pvc-idempotent"
 
-	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeKib)
 
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
@@ -377,7 +377,7 @@ func runCSICreateVolumeIdempotent(t *testing.T, stack *harness.Stack, csi *harne
 	// truncating the existing volume.
 	err := csi.Client.ResourceGroups.Spawn(context.Background(), harness.FixtureDefaultRG, lapi.ResourceGroupSpawn{
 		ResourceDefinitionName: rdName,
-		VolumeSizes:            []int64{groupJVolumeSizeBytes},
+		VolumeSizes:            []int64{groupJVolumeSizeKib},
 		SelectFilter: lapi.AutoSelectFilter{
 			PlaceCount:  groupJDefaultPlaceCount,
 			StoragePool: "zfs-thin",
@@ -415,7 +415,7 @@ func runCSICreateVolumeIdempotent(t *testing.T, stack *harness.Stack, csi *harne
 func runCSIDeleteVolume(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 	const rdName = "pvc-delete"
 
-	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, rdName) == groupJDefaultPlaceCount
@@ -459,7 +459,7 @@ func runCSIDeleteVolume(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 func runCSIControllerPublish(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 	const rdName = "pvc-publish-diskful"
 
-	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, rdName) == groupJDefaultPlaceCount
@@ -506,7 +506,7 @@ func runCSIControllerPublish(t *testing.T, stack *harness.Stack, csi *harness.CS
 func runCSIControllerPublishDiskless(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 	const rdName = "pvc-publish-diskless"
 
-	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "lvm-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, rdName) == groupJDefaultPlaceCount
@@ -571,7 +571,7 @@ func runCSICreateSnapshot(t *testing.T, stack *harness.Stack, csi *harness.CSI) 
 		snapName = "snap-1"
 	)
 
-	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, rdName) == groupJDefaultPlaceCount
@@ -618,7 +618,7 @@ func runCSIDeleteSnapshotIdempotent(t *testing.T, stack *harness.Stack, csi *har
 		snapName = "snap-del"
 	)
 
-	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, rdName) == groupJDefaultPlaceCount
@@ -664,7 +664,7 @@ func runCSIDeleteSnapshotIdempotent(t *testing.T, stack *harness.Stack, csi *har
 func runCSIListSnapshotsPagination(t *testing.T, stack *harness.Stack, csi *harness.CSI) {
 	const rdName = "pvc-snap-paginate"
 
-	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, rdName, "zfs-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, rdName)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, rdName) == groupJDefaultPlaceCount
@@ -745,12 +745,11 @@ func runCSICreateVolumeFromSnapshot(t *testing.T, stack *harness.Stack, csi *har
 		srcRD        = "pvc-clone-src"
 		snapName     = "snap-1"
 		destRD       = "pvc-clone-dest"
-		bytesPerKiB  = int64(1024)
 		restoreProp  = "BlockstorRestoreFromSnapshot"
 		restoreValue = srcRD + ":" + snapName
 	)
 
-	spawnViaRG(t, csi, srcRD, "zfs-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, srcRD, "zfs-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, srcRD)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, srcRD) == groupJDefaultPlaceCount
@@ -766,7 +765,7 @@ func runCSICreateVolumeFromSnapshot(t *testing.T, stack *harness.Stack, csi *har
 
 	resp, err := csi.Driver.CreateVolume(context.Background(), &csidriver.CreateVolumeRequest{
 		Name:             destRD,
-		CapacityRangeMin: groupJVolumeSizeKib * bytesPerKiB,
+		CapacityRangeMin: groupJVolumeSizeBytes,
 		ContentSource: &csidriver.VolumeContentSourceSnapshot{
 			SourceRD:     srcRD,
 			SnapshotName: snapName,
@@ -825,7 +824,7 @@ func runCSICreateVolumeFromClone(t *testing.T, stack *harness.Stack, csi *harnes
 		destRD = "pvc-direct-clone"
 	)
 
-	spawnViaRG(t, csi, srcRD, "zfs-thin", groupJVolumeSizeBytes)
+	spawnViaRG(t, csi, srcRD, "zfs-thin", groupJVolumeSizeKib)
 	waitForRDInStore(t, stack, srcRD)
 	harness.Eventually(t, groupJTimeout, func() bool {
 		return countDiskfulResourcesForRD(t, stack, srcRD) == groupJDefaultPlaceCount

--- a/tests/operator-harness/replay/r-c-autoplace-plus-one.yaml
+++ b/tests/operator-harness/replay/r-c-autoplace-plus-one.yaml
@@ -36,6 +36,19 @@ steps:
     cmd: ["resource-group", "spawn-resources", "{{rg}}", "{{rd}}", "32M"]
     expect_exit: 0
     await:
+      # Bug 391 cross-check: `32M` must spawn a 32768 KiB VD, not a
+      # 32 KiB one. A 32 KiB VD is below DRBD's create-md floor and the
+      # replicas below would never converge — so the size assertion
+      # guards this workflow against a silent spawn-size regression.
+      kind: vd_size_kib
+      rd: "{{rd}}"
+      vol: 0
+      expected_kib: 32768
+      timeout_s: 60
+  - name: spawn-2r-replicas
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
       kind: replica_count
       rd: "{{rd}}"
       min: 2

--- a/tests/operator-harness/replay/rg-spawn-size-parse.yaml
+++ b/tests/operator-harness/replay/rg-spawn-size-parse.yaml
@@ -1,0 +1,79 @@
+name: rg-spawn-size-parse
+description: |
+  Bug 391 (spawn-size unit): `rg spawn-resources <rg> <rd> 32M` must
+  create a 32 MiB volume — a VolumeDefinition of 32768 KiB — NOT a
+  32 KiB one.
+
+  The python linstor client parses the `32M` token into KiB
+  (`parse_volume_size_to_kib("32M") == 32768`) and ships it on the wire
+  as the `volume_sizes` array, which the upstream REST API documents as
+  "sizes (in kib)". blockstor's spawn handler previously treated the
+  field as BYTES and divided every entry by 1024, so `32M` landed as a
+  32 KiB VD — below DRBD's ~4 MiB per-device floor, which made the
+  satellite reconciler hot-loop on `drbdadm create-md`.
+
+  Operator sequence:
+    rg create --place-count 1 → spawn-resources <rd> 32M
+
+  CLI-side contract:
+    - the spawned VolumeDefinition is exactly 32768 KiB (vd_size_kib)
+    - the single replica reaches UpToDate (a 32 KiB VD never could —
+      create-md would loop), pinned via replica_count + all_uptodate
+
+  Unit pin: pkg/rest/bug_391_spawn_size_kib_test.go.
+  L6 cell: tests/e2e/cli-matrix/rg-spawn-size-parse.sh.
+
+  If this YAML goes red, no fix in pkg/rest/spawn.go (volume_sizes →
+  size_kib stamping) may be claimed closed.
+
+prerequisites:
+  min_nodes: 1
+  storage_pool: stand
+
+vars:
+  rg: rg-bug391-spawn-size
+  sp: stand
+
+steps:
+  - name: create-rg
+    cmd: ["resource-group", "create", "{{rg}}", "--place-count", "1", "--storage-pool", "{{sp}}"]
+    expect_exit: 0
+  - name: spawn-32m
+    cmd: ["resource-group", "spawn-resources", "{{rg}}", "{{rd}}", "32M"]
+    expect_exit: 0
+    await:
+      # 32M == 32768 KiB. Pre-fix this landed at 32 (the /1024 divide).
+      kind: vd_size_kib
+      rd: "{{rd}}"
+      vol: 0
+      expected_kib: 32768
+      timeout_s: 60
+  - name: wait-replica
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: replica_count
+      rd: "{{rd}}"
+      min: 1
+      timeout_s: 120
+  - name: wait-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      # A 32 KiB VD would loop on drbdadm create-md and never converge.
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+teardown:
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: rd_absent
+      rd: "{{rd}}"
+      timeout_s: 60
+  - cmd: ["resource-group", "delete", "{{rg}}"]
+    expect_exit: 0
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## What

`linstor rg spawn-resources <rg> <rd> 32M` created a **32 KiB** volume instead of 32 MiB. The spawn handler divided every `volume_sizes` entry by 1024 (treating it as bytes), but the field is **KiB**: the python-linstor client encodes the operator's size argument with `parse_volume_size_to_kib` before POSTing (`32M` -> `32768`), and the upstream REST API spec documents `volume_sizes` as "sizes (in kib)".

## Why

The bytes-shape (divide-by-1024) belongs to a *different* wire field (Bug-92). Applying it to `volume_sizes` silently shrank every spawned volume by 1024x, so any `rg spawn-resources` with a human size landed three orders of magnitude too small.

## How

- Stamp each `volume_sizes` entry directly as `size_kib`, matching the `vd c` path which reads `size_kib` verbatim. Drop the now-unused `bytesPerKib` constant; apply the same KiB reading in the non-positive-size and over-subscription gates.

## Testing

- **L1**: `bug_391_spawn_size_kib_test.go` pins the operator repro (wire `32768` -> `32768 KiB` VD) plus a unit-ladder table; existing spawn / bug-381 tests refreshed off the old bytes assumption.
- **L6**: `cli-matrix/rg-spawn-size-parse.sh` + hardened `r-c-autoplace-plus-one.sh` (asserts `vd_size_kib=32768`).
- **L7**: `replay/rg-spawn-size-parse.yaml` + `replay/r-c-autoplace-plus-one.yaml`.
- **Stand** (dev-kvaps, fix image): operator-CLI gates — PASS lines posted before merge.

Moves the verb toward upstream parity (no new divergence -> no `cli-parity-known-deltas` row).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed volume size handling in resource group spawn operations to correctly interpret size specifications, preventing unintended volume size miscalculations.

* **Tests**
  * Added regression tests for volume size parsing across multiple unit formats.
  * Enhanced e2e CLI, integration, and operator-harness tests to validate correct size behavior end-to-end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->