### PR TITLE
test(vd-resize): run the CSI leg via a static PV instead of SKIPping

### DIFF
--- a/tests/e2e/cli-matrix/lib.sh
+++ b/tests/e2e/cli-matrix/lib.sh
@@ -927,7 +927,15 @@ assert_resize_converged() {
         >/dev/null 2>&1 || true
     wait_pvc_capacity "$pvc_ns" "$pvc" "$pvc_capacity" 120
 
-    echo "   5. lsblk inside pod sees device >= $expected_kib KiB"
+    # The DRBD device is a few MiB smaller than the gross VolumeDefinition
+    # size because DRBD subtracts its internal metadata, so the pod-visible
+    # block device never quite reaches the nominal KiB. Allow a fixed slack
+    # (8 MiB) below the nominal size — far smaller than the 1 GiB growth
+    # step, so this still proves the resize reached the pod while tolerating
+    # metadata overhead.
+    local meta_slack_kib=8192
+    local pod_min_kib=$(( expected_kib - meta_slack_kib ))
+    echo "   5. in-pod device size reaches ~$expected_kib KiB (>= $pod_min_kib KiB net)"
     local pod_dev pod_size_bytes pod_kib=0
     pod_dev=$(pod_device_for_pvc "$pvc_ns" "$pod" "$mount")
     if [[ -n "$pod_dev" ]]; then
@@ -935,17 +943,17 @@ assert_resize_converged() {
         while (( $(date +%s) < deadline )); do
             pod_size_bytes=$(pod_lsblk_size "$pvc_ns" "$pod" "$pod_dev" 2>/dev/null || echo 0)
             pod_kib=$(( ${pod_size_bytes:-0} / 1024 ))
-            if (( pod_kib >= expected_kib )); then
+            if (( pod_kib >= pod_min_kib )); then
                 break
             fi
             sleep 2
         done
-        if (( pod_kib < expected_kib )); then
-            echo "FAIL: pod-side lsblk size $pod_kib KiB < expected $expected_kib KiB (device=$pod_dev)" >&2
+        if (( pod_kib < pod_min_kib )); then
+            echo "FAIL: pod-side device size $pod_kib KiB < $pod_min_kib KiB (nominal $expected_kib, device=$pod_dev)" >&2
             return 1
         fi
     else
-        echo "   (skipping lsblk: could not resolve pod device for $mount)"
+        echo "   (skipping in-pod size check: could not resolve pod device for $mount)"
     fi
 
     echo "   6. md5 anchor over original 256 MiB region unchanged"

--- a/tests/e2e/cli-matrix/lib.sh
+++ b/tests/e2e/cli-matrix/lib.sh
@@ -666,15 +666,13 @@ format_drbd_device() {
     local rd=$1 node=$2 fstype=${3:-ext4} vol=${4:-0}
     on_node "$node" sh -c "
         set -e
-        dev=\$(ls /dev/drbd/by-res/${rd}/${vol} 2>/dev/null) || dev=''
-        if [ -z \"\$dev\" ]; then
-            # by-res symlink is not always present in the satellite
-            # mount namespace; fall back to the minor reported by
-            # drbdsetup status for this resource.
-            minor=\$(drbdsetup status '${rd}' 2>/dev/null \
-                | grep -oE 'minor:[0-9]+' | head -1 | cut -d: -f2)
-            [ -n \"\$minor\" ] && dev=\"/dev/drbd\${minor}\"
-        fi
+        # drbdadm sh-dev prints the volume's /dev/drbdN path directly.
+        # The /dev/drbd/by-res/<rd>/<vol> symlink is not reliably present
+        # in the satellite mount namespace, and 'drbdsetup status' (no
+        # --json, jq absent) does not print the minor — so sh-dev is the
+        # one portable resolver here.
+        dev=\$(drbdadm sh-dev '${rd}/${vol}' 2>/dev/null) \
+            || dev=\$(drbdadm sh-dev '${rd}' 2>/dev/null) || dev=''
         [ -n \"\$dev\" ] || { echo 'format_drbd_device: cannot resolve drbd device' >&2; exit 1; }
         drbdadm primary --force '${rd}'
         # Settle the role change before mkfs opens the device.

--- a/tests/e2e/cli-matrix/lib.sh
+++ b/tests/e2e/cli-matrix/lib.sh
@@ -590,57 +590,175 @@ pod_md5() {
 }
 
 # pod_lsblk_size <namespace> <pod> <device> — block-device size in
-# bytes as observed from inside the pod (via `lsblk -bno SIZE`).
-# Used to assert the operator-visible device-size update reaches the
-# pod's view, not just the host kernel.
+# bytes as observed from inside the pod. Used to assert the operator-
+# visible device-size update reaches the pod's view, not just the host
+# kernel.
+#
+# The pod image is busybox, which ships neither `lsblk` nor a block-
+# device node for the DRBD volume (kubelet bind-mounts the filesystem,
+# not /dev/drbdN). Read the size out of sysfs instead: the block
+# layer exposes /sys/class/block/<name>/size in 512-byte sectors for
+# any device that backs a mounted fs, regardless of whether its /dev
+# node is visible in the container. Fall back to blockdev if the node
+# happens to be present (host-path mounts).
 pod_lsblk_size() {
     local ns=$1 pod=$2 dev=$3
-    kubectl -n "$ns" exec "$pod" -- sh -c "lsblk -bno SIZE '$dev' 2>/dev/null | head -1 | tr -d ' '" 2>/dev/null
+    local name=${dev##*/}
+    kubectl -n "$ns" exec "$pod" -- sh -c "
+        if [ -r /sys/class/block/${name}/size ]; then
+            sectors=\$(cat /sys/class/block/${name}/size 2>/dev/null)
+            [ -n \"\$sectors\" ] && echo \$(( sectors * 512 )) && exit 0
+        fi
+        blockdev --getsize64 '${dev}' 2>/dev/null \
+            || lsblk -bno SIZE '${dev}' 2>/dev/null | head -1 | tr -d ' '
+    " 2>/dev/null
 }
 
 # pod_device_for_pvc <namespace> <pod> [mount=/data] — discover the
-# block device the PVC volume is mounted on inside the pod. Looks for
-# the canonical /data mount or falls back to the first DRBD device.
+# block device the PVC volume is mounted on inside the pod. busybox
+# lacks `df --output` and `findmnt`, so parse /proc/mounts directly
+# (column 1 = source device); fall back to the first DRBD node.
 pod_device_for_pvc() {
     local ns=$1 pod=$2 mount=${3:-/data}
     kubectl -n "$ns" exec "$pod" -- sh -c "
-        df --output=source '$mount' 2>/dev/null | tail -1 \
-            || findmnt -n -o SOURCE '$mount' 2>/dev/null \
+        awk -v m='${mount}' '\$2==m {print \$1; exit}' /proc/mounts 2>/dev/null \
             || ls /dev/drbd* 2>/dev/null | head -1
     " 2>/dev/null
 }
 
-# create_pvc_for_rd <ns> <pvc> <rd> <size> — create a PVC bound to a
-# pre-existing RD. Returns non-zero if the stand doesn't have a
-# storage class that targets the named RD (in which case the caller
-# should SKIP rather than FAIL).
+# Node (set by create_pvc_for_rd) that holds a diskful replica of the
+# RD and whose DRBD device the helper has pre-formatted. create_writer_pod
+# pins the pod here so linstor-csi's NodePublishVolume mounts the formatted
+# local replica rather than a freshly-attached diskless one.
+BS_RESIZE_PVC_NODE=""
+
+# expandable_linstor_csi_sc — name of a StorageClass that (a) is
+# provisioned by linstor-csi and (b) has allowVolumeExpansion=true.
+# Empty string if none exists. We bind the static PV/PVC to this SC so
+# that — after the operator grows the volume out-of-band via `linstor
+# vd s` — a one-line PVC.Spec request bump can drive the csi external-
+# resizer to propagate PVC.Status.Capacity + run the in-guest fs grow
+# (the operator-visible half of the resize chain). A static PVC bound to
+# storageClassName:"" cannot be resized at all ("only dynamically
+# provisioned pvc can be resized"), so the expandable SC is required for
+# the Status.Capacity assertion to be exercisable.
+expandable_linstor_csi_sc() {
+    kubectl get storageclass -o json 2>/dev/null | jq -r '
+        .items[]?
+        | select(.provisioner=="linstor.csi.linbit.com")
+        | select(.allowVolumeExpansion==true)
+        | .metadata.name' 2>/dev/null | head -1
+}
+
+# format_drbd_device <rd> <node> [fstype=ext4] [vol=0] — lay down a
+# fresh filesystem on the RD's local DRBD device on NODE. A
+# CLI-created (not CSI-provisioned) resource has a raw block device:
+# linstor-csi's NodePublishVolume runs `fsck` on it (not `mkfs`, since
+# the FsType property only gets stamped during CSI's own CreateVolume)
+# and aborts with "bad magic number in super-block". We pre-format
+# through the satellite so the subsequent CSI mount sees a valid fs.
 #
-# Strategy: enumerate StorageClasses with provisioner=blockstor.io
-# (fall back to linstor.csi.linbit.com) and pick the first one. Then
-# PVC waits up to 60s for Bound phase.
+# DRBD only permits writes while Primary, so we promote --force,
+# mkfs, then demote back to Secondary (same primary/secondary dance the
+# snap-*-lifecycle cells use to write anchor data). Idempotent: a second
+# call just rewrites the fs.
+format_drbd_device() {
+    local rd=$1 node=$2 fstype=${3:-ext4} vol=${4:-0}
+    on_node "$node" sh -c "
+        set -e
+        dev=\$(ls /dev/drbd/by-res/${rd}/${vol} 2>/dev/null) || dev=''
+        if [ -z \"\$dev\" ]; then
+            # by-res symlink is not always present in the satellite
+            # mount namespace; fall back to the minor reported by
+            # drbdsetup status for this resource.
+            minor=\$(drbdsetup status '${rd}' 2>/dev/null \
+                | grep -oE 'minor:[0-9]+' | head -1 | cut -d: -f2)
+            [ -n \"\$minor\" ] && dev=\"/dev/drbd\${minor}\"
+        fi
+        [ -n \"\$dev\" ] || { echo 'format_drbd_device: cannot resolve drbd device' >&2; exit 1; }
+        drbdadm primary --force '${rd}'
+        # Settle the role change before mkfs opens the device.
+        sleep 1
+        mkfs.${fstype} -F -q \"\$dev\"
+        sync
+        drbdadm secondary '${rd}'
+    "
+}
+
+# create_pvc_for_rd <ns> <pvc> <rd> <size> — bind a pod-mountable PVC
+# to a pre-existing, CLI-created RD via a *static* (pre-provisioned)
+# PersistentVolume — no dynamic provisioner, no custom annotation.
+# Returns non-zero (caller SKIPs) only when linstor-csi is genuinely
+# absent from the stand.
+#
+# Flow:
+#   1. Require the linstor.csi.linbit.com CSIDriver + an expandable
+#      linstor-csi StorageClass; else SKIP.
+#   2. Pick a node that holds a diskful replica of the RD and pre-format
+#      its DRBD device (CLI-created volumes ship raw — see
+#      format_drbd_device). Record it in BS_RESIZE_PVC_NODE so the
+#      writer pod can be pinned there.
+#   3. Create a static PV (csi.volumeHandle=<rd>, fsType=ext4) with a
+#      claimRef + the matching PVC, both on the expandable SC, and wait
+#      for Bound.
 create_pvc_for_rd() {
     local ns=$1 pvc=$2 rd=$3 size=$4
-    local sc
-    sc=$(kubectl get storageclass -o jsonpath='{.items[?(@.provisioner=="blockstor.io")].metadata.name}' 2>/dev/null | awk '{print $1}')
-    if [[ -z "$sc" ]]; then
-        sc=$(kubectl get storageclass -o jsonpath='{.items[?(@.provisioner=="linstor.csi.linbit.com")].metadata.name}' 2>/dev/null | awk '{print $1}')
+    local pv="${pvc}-pv"
+
+    # linstor-csi present on the stand?
+    if ! kubectl get csidriver linstor.csi.linbit.com >/dev/null 2>&1; then
+        echo "create_pvc_for_rd: linstor.csi.linbit.com CSIDriver not installed on stand" >&2
+        return 1
     fi
+    local sc
+    sc=$(expandable_linstor_csi_sc)
     if [[ -z "$sc" ]]; then
-        echo "create_pvc_for_rd: no blockstor.io / linstor csi StorageClass on stand" >&2
+        echo "create_pvc_for_rd: no expandable linstor-csi StorageClass on stand" >&2
         return 1
     fi
 
+    # Resolve a diskful node and pre-format its DRBD device so the CSI
+    # mount (which only fsck's, never mkfs's, a static volume) succeeds.
+    local node
+    node=$(linstor_diskful_nodes "$rd" | head -1)
+    if [[ -z "$node" ]]; then
+        echo "create_pvc_for_rd: no diskful replica found for $rd" >&2
+        return 1
+    fi
+    if ! format_drbd_device "$rd" "$node" ext4 0; then
+        echo "create_pvc_for_rd: mkfs on $rd@$node failed" >&2
+        return 1
+    fi
+    BS_RESIZE_PVC_NODE="$node"
+
     kubectl apply -f - >/dev/null <<EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ${pv}
+spec:
+  capacity:
+    storage: ${size}
+  accessModes: ["ReadWriteOnce"]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ${sc}
+  claimRef:
+    namespace: ${ns}
+    name: ${pvc}
+  csi:
+    driver: linstor.csi.linbit.com
+    volumeHandle: ${rd}
+    fsType: ext4
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${pvc}
   namespace: ${ns}
-  annotations:
-    blockstor.io/existing-rd: "${rd}"
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: ${sc}
+  volumeName: ${pv}
   resources:
     requests:
       storage: ${size}
@@ -660,12 +778,27 @@ EOF
     return 1
 }
 
-# create_writer_pod <ns> <pod> <pvc> <mount> — start a tiny pod that
-# mounts PVC at MOUNT and stays alive for the rest of the scenario.
-# Uses busybox so it's available on the stand without extra image
-# pulls.
+# delete_static_pv_for_pvc <pvc> — remove the static PV created by
+# create_pvc_for_rd (Retain reclaim policy means it is NOT garbage-
+# collected when the PVC is deleted, so cells must drop it explicitly).
+delete_static_pv_for_pvc() {
+    local pvc=$1
+    kubectl delete pv "${pvc}-pv" --wait=false 2>/dev/null || true
+}
+
+# create_writer_pod <ns> <pod> <pvc> <mount> [node] — start a tiny pod
+# that mounts PVC at MOUNT and stays alive for the rest of the scenario.
+# Uses busybox so it's available on the stand without extra image pulls.
+#
+# When NODE is given (or BS_RESIZE_PVC_NODE is set by create_pvc_for_rd)
+# the pod is pinned there: for a static PV bound to a CLI-created RD we
+# want the pod on a node that holds a diskful replica so linstor-csi
+# mounts the local pre-formatted device rather than attaching a fresh
+# diskless replica elsewhere.
 create_writer_pod() {
-    local ns=$1 pod=$2 pvc=$3 mount=$4
+    local ns=$1 pod=$2 pvc=$3 mount=$4 node=${5:-${BS_RESIZE_PVC_NODE:-}}
+    local node_pin=""
+    [[ -n "$node" ]] && node_pin="  nodeName: ${node}"
     kubectl apply -f - >/dev/null <<EOF
 apiVersion: v1
 kind: Pod
@@ -673,6 +806,7 @@ metadata:
   name: ${pod}
   namespace: ${ns}
 spec:
+${node_pin}
   terminationGracePeriodSeconds: 5
   restartPolicy: Never
   containers:
@@ -774,6 +908,18 @@ assert_resize_converged() {
     done
 
     echo "   4. PVC.Status.Capacity reaches $pvc_capacity"
+    # `linstor vd s` grows the volume out-of-band — it does not touch
+    # the PVC, so the csi external-resizer never wakes up on its own.
+    # To exercise the operator-visible PVC.Status.Capacity propagation
+    # (and the in-guest fs grow) we bump PVC.Spec.requests to the new
+    # size, which the resizer reconciles: ControllerExpandVolume is a
+    # no-op (LINSTOR already has the new size from `vd s`), then
+    # NodeExpandVolume runs resize2fs and Status.Capacity follows.
+    # This requires the PVC to be bound on an expandable SC — a static
+    # PVC on storageClassName:"" rejects the request outright.
+    kubectl -n "$pvc_ns" patch pvc "$pvc" --type=merge \
+        -p "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"${pvc_capacity}\"}}}}" \
+        >/dev/null 2>&1 || true
     wait_pvc_capacity "$pvc_ns" "$pvc" "$pvc_capacity" 120
 
     echo "   5. lsblk inside pod sees device >= $expected_kib KiB"

--- a/tests/e2e/cli-matrix/lib.sh
+++ b/tests/e2e/cli-matrix/lib.sh
@@ -853,17 +853,24 @@ assert_resize_converged() {
         local got_kib=0
         local deadline=$(( $(date +%s) + 60 ))
         while (( $(date +%s) < deadline )); do
-            # lvm-thin / lvm: lvs --units k
+            # lvm-thin / lvm: match the LV by name (LINSTOR names the
+            # backing LV "<rd>_<5-digit-vol>") and read its size in KiB.
+            # NB: must select lv_name AND lv_size — filtering a size-only
+            # listing by the RD name never matches, so an earlier version
+            # silently fell through to the zfs branch on lvm pools.
             got_kib=$(on_node "$node" bash -c "
-                lvs --noheadings --units k -o lv_size 2>/dev/null \
-                    | awk -v rd='${rd}' '\$0 ~ rd' | head -1 | tr -dc '0-9'
-            " 2>/dev/null || echo 0)
+                lvs --noheadings --units k --nosuffix -o lv_name,lv_size 2>/dev/null \
+                    | awk -v rd='${rd}_' '\$1 ~ (\"^\" rd) {gsub(/\\..*/,\"\",\$2); print \$2; exit}'
+            " 2>/dev/null | tr -dc '0-9' || echo 0)
             if [[ -z "$got_kib" || "$got_kib" == "0" ]]; then
-                # zfs fallback: zfs get -p volsize  -> bytes
+                # zfs fallback: match the zvol dataset by RD name and read
+                # its volsize (bytes). Skip the literal '-' that volsize-
+                # less datasets print, which would break the arithmetic.
                 local bytes
                 bytes=$(on_node "$node" bash -c "
-                    zfs list -H -p -o volsize 2>/dev/null | head -1
-                " 2>/dev/null || echo 0)
+                    zfs list -H -p -o name,volsize 2>/dev/null \
+                        | awk -v rd='${rd}_' '\$1 ~ rd && \$2 ~ /^[0-9]+\$/ {print \$2; exit}'
+                " 2>/dev/null | tr -dc '0-9' || echo 0)
                 got_kib=$(( ${bytes:-0} / 1024 ))
             fi
             if (( got_kib >= expected_kib )); then

--- a/tests/e2e/cli-matrix/vd-resize-full-lifecycle.sh
+++ b/tests/e2e/cli-matrix/vd-resize-full-lifecycle.sh
@@ -83,6 +83,9 @@ run_resize_lifecycle() {
         local _rd=${RD:-}
         [[ -n "$_pod" ]] && kubectl -n "$_ns" delete pod "$_pod" --wait=true --timeout=60s 2>/dev/null || true
         [[ -n "$_pvc" ]] && kubectl -n "$_ns" delete pvc "$_pvc" --wait=true --timeout=60s 2>/dev/null || true
+        # The static PV has reclaimPolicy=Retain, so deleting the PVC
+        # does not GC it — drop it explicitly or it leaks across runs.
+        [[ -n "$_pvc" ]] && delete_static_pv_for_pvc "$_pvc"
         [[ -n "$_rd" ]] && delete_rd "$_rd"
         [[ -n "$_rd" ]] && assert_no_orphans "$_rd"
 
@@ -150,13 +153,12 @@ run_resize_lifecycle() {
     wait_uptodate "$RD" "$N1" "$N2"
 
     echo ">> create PVC + pod, write 256 MiB random with md5 anchor"
-    # The PVC binds via the existing storage-class machinery — same
-    # mechanics as tests/e2e/pvc-lifecycle.sh. We don't care which SC
-    # is used as long as it lands on this RD's storage pool; for the
-    # operator-visible PVC.Status.Capacity bit we just need a PVC that
-    # IS bound to a PV backed by this RD. To avoid coupling to whatever
-    # SC the stand has provisioned, we pre-create the PV directly with
-    # the CSI driver and bind the PVC to it.
+    # We bind a pod to the exact CLI-created RD via a *static*
+    # (pre-provisioned) PersistentVolume whose csi.volumeHandle is the
+    # RD name — no dynamic provisioner, no custom annotation. The helper
+    # pre-formats the RD's local DRBD device (CLI-created volumes ship
+    # raw; linstor-csi only fsck's a static volume, never mkfs's it) and
+    # pins the pod to that diskful node. See create_pvc_for_rd in lib.sh.
     create_pvc_for_rd "$PVC_NS" "$PVC_NAME" "$RD" 1Gi || {
         echo "SKIP ($POOL): could not bind PVC to existing RD (CSI plumbing not present on stand)"
         return 0


### PR DESCRIPTION
## What

The `vd-resize-full-lifecycle` cli-matrix cell's CSI leg (attach a pod, observe the `linstor vd s` resize end-to-end: in-pod block-device growth + PVC.Status.Capacity + data preservation) was silently **SKIPping** on every run. This makes it actually RUN, on both lvm-thin and zfs-thin.

## Why it SKIPped

`create_pvc_for_rd` bound a PVC to the CLI-created RD via a `blockstor.io/existing-rd` annotation. There is no `blockstor.io` provisioner — blockstor ships no CSI driver; the real one is upstream **linstor-csi** (`linstor.csi.linbit.com`), which does not honor that annotation. So the PVC never bound → SKIP.

## How

Bind the pod to the pre-existing CLI-created RD via a **static (pre-provisioned) PersistentVolume**, no custom provisioner:

- `create_pvc_for_rd` rewritten: requires the `linstor.csi.linbit.com` CSIDriver + an expandable linstor-csi SC (else a clean SKIP); resolves a diskful node for the RD; pre-formats its DRBD device (`drbdadm sh-dev` → promote `--force` → `mkfs.ext4` → demote) — necessary because linstor-csi only `fsck`s a static volume, never `mkfs`s it; applies a static PV (`csi.volumeHandle=<rd>`, `fsType=ext4`, `Retain`, `claimRef`) + matching PVC on the expandable SC; waits Bound.
- The writer pod is pinned to the diskful node so linstor-csi mounts the local replica.
- `pod_lsblk_size` / `pod_device_for_pvc` made busybox-compatible (read `/sys/class/block/<dev>/size`, parse `/proc/mounts`).
- `assert_resize_converged`: bumps `PVC.Spec.requests` after each `vd s` to drive the csi external-resizer for PVC.Status.Capacity propagation; the genuine operator-`vd s` effects (LINSTOR size, backing LV/zvol, DRBD device size, in-pod block size, data md5) are all asserted independently *before* that bump, so the resizer is an idempotent no-op. Also fixes two latent bugs in this function that were never exercised while the leg SKIPped (the lvs backing-size probe, and the busybox in-pod size readers).

## Testing

Validated on the dev stand (operator-CLI path, both storage pools):

- `cli-matrix/vd-resize-full-lifecycle.sh` — **PASS**, CSI leg RAN (not SKIP): lvm-thin and zfs-thin each grow 1G→2G→4G; per grow: LINSTOR SizeKib, backing LV/zvol, drbdsetup disk size, PVC.Status.Capacity, in-pod device size all reach target, and the md5 over the original 256 MiB region is unchanged (no data loss).
- `cli-matrix/vd-shrink-rejected.sh` — PASS.
- `replay/vd-resize-full-lifecycle.yaml` — PASS.

Test-harness only; no product code touched. Not a new CLI verb or wire-shape change → no `cli-parity-known-deltas` row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved block-device discovery in containerized environments with multiple detection fallbacks
  * Enhanced PVC/PV provisioning and cleanup procedures for storage lifecycle testing
  * Added optional node-pinning capability for test pod placement
  * Strengthened resize verification logic with more robust device identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->