### PR TITLE
fix(rest): populate resource create_timestamp (CreatedOn) from CRD creationTimestamp

### DIFF
--- a/pkg/api/v1/resource.go
+++ b/pkg/api/v1/resource.go
@@ -85,6 +85,17 @@ type Resource struct {
 	// Drives the `(R)` inherited-property marker in
 	// `linstor r lp <rd> <node>`.
 	EffectiveProps EffectiveProperties `json:"effective_props,omitempty"`
+
+	// CreateTimestamp is the replica creation time in unix
+	// milliseconds, sourced from the backing Resource CRD's
+	// metadata.creationTimestamp. Upstream LINSTOR populates the same
+	// `create_timestamp` field — the Python CLI renders it as the
+	// `CreatedOn` column (dividing by 1000) on `linstor r list`.
+	// blockstor previously left it unset, so CreatedOn was empty.
+	// Per-replica: each node's Resource CRD carries its own creation
+	// time, matching upstream's per-resource timestamp. Set only on
+	// the read path (crdToWireResource); ignored on writes.
+	CreateTimestamp int64 `json:"create_timestamp,omitempty"`
 }
 
 // ResourceState is the runtime state surface of a Resource.

--- a/pkg/store/k8s/resource_create_timestamp_internal_test.go
+++ b/pkg/store/k8s/resource_create_timestamp_internal_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crdv1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+)
+
+// TestCrdToWireResourceStampsCreateTimestamp pins the parity fix:
+// upstream LINSTOR populates the `create_timestamp` wire field (the
+// Python CLI's `CreatedOn` column, in unix milliseconds). blockstor
+// sources it, persistence-free, from the backing Resource CRD's
+// metadata.creationTimestamp — per replica.
+func TestCrdToWireResourceStampsCreateTimestamp(t *testing.T) {
+	t.Parallel()
+
+	// A fixed instant; metav1.Time has second granularity on the wire,
+	// so truncate to seconds to make the millisecond expectation exact.
+	created := metav1.NewTime(time.Unix(1_780_000_000, 0).UTC())
+	crd := &crdv1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "orc-tb.dev-worker-1",
+			CreationTimestamp: created,
+		},
+		Spec: crdv1alpha1.ResourceSpec{
+			ResourceDefinitionName: "orc-tb",
+			NodeName:               "dev-worker-1",
+		},
+	}
+
+	wire := crdToWireResource(crd)
+	want := created.UnixMilli()
+	if wire.CreateTimestamp != want {
+		t.Fatalf("CreateTimestamp: got %d, want %d (creationTimestamp in unix ms)",
+			wire.CreateTimestamp, want)
+	}
+}
+
+// TestCrdToWireResourceZeroCreateTimestamp: an unset creationTimestamp
+// (e.g. a hand-built CRD) maps to 0 so `omitempty` drops the field
+// rather than emitting a 1970 epoch CreatedOn.
+func TestCrdToWireResourceZeroCreateTimestamp(t *testing.T) {
+	t.Parallel()
+
+	crd := &crdv1alpha1.Resource{
+		Spec: crdv1alpha1.ResourceSpec{
+			ResourceDefinitionName: "no-ts",
+			NodeName:               "dev-worker-1",
+		},
+	}
+
+	if got := crdToWireResource(crd).CreateTimestamp; got != 0 {
+		t.Fatalf("CreateTimestamp on a zero-creationTimestamp CRD: got %d, want 0", got)
+	}
+}

--- a/pkg/store/k8s/resources.go
+++ b/pkg/store/k8s/resources.go
@@ -531,7 +531,24 @@ func crdToWireResource(crd *crdv1alpha1.Resource) apiv1.Resource {
 		),
 		UUID:        string(crd.UID),
 		Annotations: cloneAnnotations(crd.Annotations),
+		// Upstream LINSTOR populates `create_timestamp` (the Python
+		// CLI's `CreatedOn` column). The Resource CRD's
+		// metadata.creationTimestamp is the per-replica creation time
+		// and the natural, persistence-free source for it.
+		CreateTimestamp: crdCreateTimestampMs(crd),
 	}
+}
+
+// crdCreateTimestampMs translates a Resource CRD's
+// metadata.creationTimestamp into the upstream `create_timestamp`
+// wire field (unix milliseconds). Returns 0 (dropped by omitempty)
+// when the timestamp is unset, e.g. a hand-built CRD in a unit test.
+func crdCreateTimestampMs(crd *crdv1alpha1.Resource) int64 {
+	if crd.CreationTimestamp.IsZero() {
+		return 0
+	}
+
+	return crd.CreationTimestamp.UnixMilli()
 }
 
 // volumesFromStatus projects the CRD `Status.Volumes` onto wire

--- a/tests/e2e/cli-matrix/r-l-created-on.sh
+++ b/tests/e2e/cli-matrix/r-l-created-on.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# usage: r-l-created-on.sh WORK_DIR
+#
+# L6 cli-matrix cell — `linstor r list` CreatedOn parity.
+#
+# Upstream LINSTOR populates the `create_timestamp` wire field for every
+# resource; the Python CLI renders it as the `CreatedOn` column (unix
+# milliseconds / 1000). blockstor previously left it unset, so `r l`
+# showed a blank CreatedOn for every replica. The fix sources it,
+# persistence-free, from the backing Resource CRD's
+# metadata.creationTimestamp (per replica) in crdToWireResource.
+#
+# This cell pins the operator-visible result: after `r c`, both the
+# machine-readable `create_timestamp` and the human `CreatedOn` column
+# are non-empty and carry a plausibly-recent timestamp.
+#
+# Verified live against the upstream LINSTOR oracle (1.33.2), which
+# fills CreatedOn the same way (2026-06-08 A/B on the dev stand).
+
+set -euo pipefail
+
+WORK_DIR=${1:?work_dir required}
+export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+linstor_cli_setup
+
+RD=cli-matrix-createdon-rd
+POOL=${POOL:-stand}
+
+cleanup() {
+    "${LCTL[@]}" resource-definition delete "$RD" >/dev/null 2>&1 || true
+    assert_no_orphans "$RD"
+    linstor_cli_teardown
+}
+trap cleanup EXIT
+
+# Lower bound captured just before the create, with 5s of slack for
+# clock skew between this host and the apiserver node.
+before_ms=$(( $(date +%s) * 1000 - 5000 ))
+
+echo ">> rd c + vd c + r c $WORKER_1 (diskful) for $RD"
+"${LCTL[@]}" resource-definition create "$RD" >/dev/null
+"${LCTL[@]}" volume-definition create "$RD" 64M >/dev/null
+"${LCTL[@]}" resource create "$WORKER_1" "$RD" --storage-pool="$POOL" >/dev/null
+
+if ! wait_replica_count "$RD" 1 60; then
+    echo "FAIL: RD did not reach 1 replica" >&2
+    "${LCTL[@]}" resource list -r "$RD" 2>&1 | tail -20 >&2
+    exit 1
+fi
+
+echo ">> create_timestamp MUST be non-empty in machine-readable r l"
+ts=$(linstor_r_l_json "$RD" \
+    | jq -r '[.[][]? | .create_timestamp] | map(select(. != null and . > 0)) | (.[0] // 0)')
+if [[ -z "$ts" || "$ts" == "0" || "$ts" == "null" ]]; then
+    echo "FAIL: r l create_timestamp empty/zero — upstream populates it (CreatedOn column)" >&2
+    linstor_r_l_json "$RD" | jq -c '.[][]? | {node: .node_name, create_timestamp}' >&2 || true
+    exit 1
+fi
+
+now_ms=$(( $(date +%s) * 1000 + 5000 ))
+if (( ts < before_ms || ts > now_ms )); then
+    echo "FAIL: create_timestamp=$ts not in plausible window [$before_ms, $now_ms] (unix ms)" >&2
+    exit 1
+fi
+echo ">> create_timestamp=$ts (plausible, unix ms) — OK"
+
+echo ">> human r l CreatedOn column MUST render a date"
+human=$("${LCTL[@]}" resource list -r "$RD" 2>/dev/null \
+    | grep -E "$RD" \
+    | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}' | head -1)
+if [[ -z "$human" ]]; then
+    echo "FAIL: human r l CreatedOn column is blank" >&2
+    "${LCTL[@]}" resource list -r "$RD" >&2
+    exit 1
+fi
+
+echo ">> r-l-created-on OK (create_timestamp=$ts, CreatedOn=$human)"


### PR DESCRIPTION
## What

`linstor r list` showed a **blank `CreatedOn` column** for every replica. Upstream LINSTOR populates the `create_timestamp` wire field (the Python CLI renders it as `CreatedOn`, unix ms / 1000); blockstor never set it.

## Why / verification

Confirmed divergent **live against the upstream LINSTOR oracle (1.33.2)** on the dev stand: a freshly-created upstream resource carries `CreatedOn: 2026-06-08 13:00:36` (`create_timestamp=1780923…`), while blockstor's `r l` left it empty.

## How

Source it, persistence-free, from the backing Resource CRD's `metadata.creationTimestamp` — the per-replica creation time, matching upstream's per-resource timestamp:

- `pkg/api/v1.Resource` gains `CreateTimestamp int64` (json `create_timestamp,omitempty`).
- `crdToWireResource` (the single CR→wire conversion behind List/ListByDefinition/Get) sets it via `crdCreateTimestampMs` (`crd.CreationTimestamp.UnixMilli()`, 0 when unset so omitempty drops it).
- Read path only; ignored on writes. No new persistence, no satellite involvement (unlike the snapshot path, whose timestamp is the satellite's real "snapshot taken" time).

## Testing

- **L1** `pkg/store/k8s`: `crdToWireResource` stamps create_timestamp from creationTimestamp (unix ms); a zero creationTimestamp maps to 0 (omitempty).
- **L6** `cli-matrix/r-l-created-on.sh`: after `r c`, both the machine-readable `create_timestamp` and the human `CreatedOn` column are non-empty and carry a plausibly-recent unix-ms timestamp.
- **Stand** (dev-kvaps, fix image): cell PASS; the pre-existing `test` resource now renders `CreatedOn 2026-06-08 12:44:22` (== its CRD creationTimestamp) on all 3 replicas; matches the upstream-oracle shape.

Moves the field toward upstream parity (no new divergence → no `cli-parity-known-deltas` row).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resources now display creation timestamp information. Resource list output includes when each resource was created, shown in both machine-readable and human-readable formats. This provides visibility into resource provisioning times and lifecycle tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->