### PR TITLE
feat(stand): add POOL override for burn-in storage pool

### DIFF
--- a/stand/Makefile
+++ b/stand/Makefile
@@ -49,8 +49,8 @@ smoke: ## run piraeus-stack smoke (PVC + linstor-csi) (NAME=<n>)
 smoke-blockstor: ## blockstor end-to-end smoke (RD → 2 replicas → bytes-perfect failover) (NAME=<n>)
 	@./tests/smoke-blockstor.sh "$(WORK_DIR)"
 
-burnin-blockstor: ## continuous PVC churn for DURATION seconds (default 86400 = 24h) (NAME=<n>, DURATION=<sec>)
-	@./tests/burnin-blockstor.sh "$(WORK_DIR)" "$${DURATION:-86400}"
+burnin-blockstor: ## continuous PVC churn for DURATION seconds (default 86400 = 24h) (NAME=<n>, DURATION=<sec>, POOL=<storage-pool, default stand>)
+	@./tests/burnin-blockstor.sh "$(WORK_DIR)" "$${DURATION:-86400}" "$${POOL:-stand}"
 
 e2e: ## run a single e2e scenario (NAME=<cluster>, SCENARIO=<basename without .sh>)
 	@test -n "$${SCENARIO}" || (echo "usage: make e2e NAME=<cluster> SCENARIO=<name>"; exit 2)

--- a/tests/burnin-blockstor.sh
+++ b/tests/burnin-blockstor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# usage: burnin-blockstor.sh WORK_DIR [DURATION_SEC]
+# usage: burnin-blockstor.sh WORK_DIR [DURATION_SEC] [POOL]
 #
 # Continuous PVC churn against the deployed blockstor stack. Each
 # iteration:
@@ -14,6 +14,12 @@
 # Default DURATION_SEC = 86400 (24h). The "stand running for
 # 24h continuous PVC churn" item points at this script.
 #
+# POOL selects the storage pool every churn resource is placed on
+# (StorPoolName prop on both Resources). Settable as the third
+# positional arg or via the POOL env var; defaults to "stand" so
+# existing flows are unchanged. The release gate's ZFS thick burn-in
+# runs with e.g. POOL=zfs-thick.
+#
 # Reports a summary every 60 iterations: pass/fail counts + recent
 # convergence timings.
 
@@ -21,8 +27,15 @@ set -euo pipefail
 
 WORK_DIR=${1:?work_dir required}
 DURATION=${2:-86400}
+POOL=${3:-${POOL:-stand}}
 
 export KUBECONFIG="$WORK_DIR/kubeconfig"
+
+# Self-identifying startup banner: the 24h burn-in log must record
+# which pool was exercised and which commit was running.
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+GIT_SHA=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo "sha-unavailable")
+echo "[$(date -u +%FT%TZ)] burnin: pool=$POOL git=$GIT_SHA duration=${DURATION}s"
 
 # PRIMARY / PEER auto-discover when not pinned: pick two worker nodes
 # (those WITHOUT the control-plane role label). Falls back to first two
@@ -93,12 +106,12 @@ spec:
 apiVersion: blockstor.cozystack.io/v1alpha1
 kind: Resource
 metadata: {name: ${RD}.${PRIMARY}}
-spec: {resourceDefinitionName: ${RD}, nodeName: ${PRIMARY}, props: {StorPoolName: stand}}
+spec: {resourceDefinitionName: ${RD}, nodeName: ${PRIMARY}, props: {StorPoolName: ${POOL}}}
 ---
 apiVersion: blockstor.cozystack.io/v1alpha1
 kind: Resource
 metadata: {name: ${RD}.${PEER}}
-spec: {resourceDefinitionName: ${RD}, nodeName: ${PEER}, props: {StorPoolName: stand}}
+spec: {resourceDefinitionName: ${RD}, nodeName: ${PEER}, props: {StorPoolName: ${POOL}}}
 EOF
 
     # Wait for UpToDate convergence — bail out fast if it doesn't


### PR DESCRIPTION
## What

Adds a `POOL` override to the burn-in churn so it can target a non-default storage pool, e.g. `make burnin-blockstor NAME=<n> DURATION=86400 POOL=zfs-thick` (or via the `POOL` env var / third positional arg of `tests/burnin-blockstor.sh`).

## Why

The release gate requires a 24h burn-in on a ZFS thick pool, but the script hardcoded `StorPoolName: stand` on both churn Resources, so the burn-in could only exercise the default pool.

## Details

- The default remains `stand`, so existing flows are untouched.
- The override is wired Makefile -> script -> the `StorPoolName` prop on both Resource CRs, so all churn resources land on the selected pool (the script creates RD/Resource objects directly; no StorageClass/PVC is involved).
- The script now logs a startup banner with the resolved pool name, the repo's `git rev-parse HEAD`, and a UTC timestamp, making burn-in logs self-identifying for the gate.

## Validation

- `bash -n` and `shellcheck` (0.11.0) pass clean.
- No hardcoded `stand` remains in the churn path; it survives only as the parameter default and in comments.
- Startup banner verified locally for both the make-arg and env-var forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable storage pool selection for burn-in testing. Users can now specify which storage pool to use via a new parameter (defaults to 'stand'). Test output now records the selected pool and git commit information for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->