### PR TITLE
fix(storage): add mutex-guarded FakeExec.CallsSnapshot for concurrent readers

### DIFF
--- a/pkg/satellite/controllers/physicaldevice_discovery_uevent_bug341_test.go
+++ b/pkg/satellite/controllers/physicaldevice_discovery_uevent_bug341_test.go
@@ -50,9 +50,13 @@ func (f *fakeUeventNotifier) Emit(event uevent.Event) { f.events <- event }
 // countLsblkCalls counts how many times the FakeExec saw an `lsblk`
 // invocation. FakeExec records every Run as a FakeCall with the
 // program name; one scanOnce always shells out to lsblk first, so
-// the count is a 1:1 proxy for "scanOnce ran".
+// the count is a 1:1 proxy for "scanOnce ran". The discovery
+// runnable is still appending to the call log from its own
+// goroutine while we poll, so the read MUST go through the
+// mutex-guarded CallsSnapshot — a direct fx.Calls read here is a
+// data race.
 func countLsblkCalls(fx *storage.FakeExec) int {
-	calls := fx.Calls
+	calls := fx.CallsSnapshot()
 
 	n := 0
 

--- a/pkg/storage/exec.go
+++ b/pkg/storage/exec.go
@@ -119,6 +119,10 @@ type FakeExec struct {
 	mu sync.Mutex
 
 	// Calls records every Run / RunWithStdin invocation in order.
+	// Direct reads are only safe once no goroutine can still be
+	// executing commands against this FakeExec; tests that inspect
+	// the log while a product goroutine is live MUST use
+	// CallsSnapshot instead.
 	Calls []FakeCall
 
 	// Stdins parallels Calls: Stdins[i] is the string read from the
@@ -207,6 +211,20 @@ func (f *FakeExec) StdinFor(i int) string {
 	}
 
 	return f.Stdins[i]
+}
+
+// CallsSnapshot returns a mutex-guarded copy of the recorded calls.
+// Use it instead of reading Calls directly whenever the FakeExec may
+// still be receiving commands from a live goroutine (e.g. a started
+// Runnable) — direct reads in that situation are a data race.
+func (f *FakeExec) CallsSnapshot() []FakeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]FakeCall, len(f.Calls))
+	copy(out, f.Calls)
+
+	return out
 }
 
 // Expect registers a canned response. Match is exact on the command line.


### PR DESCRIPTION
## What

`go test -race ./pkg/satellite/controllers/` failed deterministically with 9 DATA RACE reports (and ~25 collateral package failures): the Bug 341 uevent discovery tests poll the FakeExec call log while the discovery runnable's goroutine is still appending to it under the fake's mutex, so the lock-free `fx.Calls` read in the test helper raced with the writer.

## Why

The race detector poisons the whole package run, blocking the release gate's `-race` acceptance.

## How it is fixed

- Add `FakeExec.CallsSnapshot()`, a mutex-guarded copy accessor, and document on the `Calls` field when direct reads are safe.
- Route the polling test helper through the snapshot accessor.

All other direct `.Calls` readers in the repo were audited: they inspect the log only after synchronous calls return (no live goroutine), so they are left as-is. No test assertions were changed.

## Validation

- `go test -race -count=3 ./pkg/satellite/... ./pkg/rest/...` green
- `go test -race -count=1 ./internal/controller/...` green (Ginkgo suite rejects `-count` > 1)
- `go test ./...` green
- `golangci-lint run` clean