### PR TITLE
fix(e2e): resolve DRBD device via drbdadm sh-dev in snap-restore cell

### DIFF
--- a/tests/e2e/cli-matrix/lib.sh
+++ b/tests/e2e/cli-matrix/lib.sh
@@ -658,26 +658,39 @@ expandable_linstor_csi_sc() {
 # and aborts with "bad magic number in super-block". We pre-format
 # through the satellite so the subsequent CSI mount sees a valid fs.
 #
+# resolve_drbd_device <node> <rd> [vol=0] — print the RD's local
+# /dev/drbdN path on NODE. drbdadm sh-dev prints the volume's
+# /dev/drbdN path directly. The /dev/drbd/by-res/<rd>/<vol> symlink
+# is not reliably present in the satellite mount namespace, and
+# 'drbdsetup status' (no --json, jq absent) does not print the minor
+# — so sh-dev is the one portable resolver here. Falls back to the
+# bare-RD spelling for drbd-utils that reject '<rd>/<vol>'. Returns
+# non-zero when the device cannot be resolved.
+resolve_drbd_device() {
+    local node=$1 rd=$2 vol=${3:-0}
+    on_node "$node" sh -c "
+        dev=\$(drbdadm sh-dev '${rd}/${vol}' 2>/dev/null) \
+            || dev=\$(drbdadm sh-dev '${rd}' 2>/dev/null) || dev=''
+        [ -n \"\$dev\" ] || exit 1
+        printf '%s\n' \"\$dev\"
+    "
+}
+
 # DRBD only permits writes while Primary, so we promote --force,
 # mkfs, then demote back to Secondary (same primary/secondary dance the
 # snap-*-lifecycle cells use to write anchor data). Idempotent: a second
 # call just rewrites the fs.
 format_drbd_device() {
     local rd=$1 node=$2 fstype=${3:-ext4} vol=${4:-0}
+    local dev
+    dev=$(resolve_drbd_device "$node" "$rd" "$vol") \
+        || { echo 'format_drbd_device: cannot resolve drbd device' >&2; return 1; }
     on_node "$node" sh -c "
         set -e
-        # drbdadm sh-dev prints the volume's /dev/drbdN path directly.
-        # The /dev/drbd/by-res/<rd>/<vol> symlink is not reliably present
-        # in the satellite mount namespace, and 'drbdsetup status' (no
-        # --json, jq absent) does not print the minor — so sh-dev is the
-        # one portable resolver here.
-        dev=\$(drbdadm sh-dev '${rd}/${vol}' 2>/dev/null) \
-            || dev=\$(drbdadm sh-dev '${rd}' 2>/dev/null) || dev=''
-        [ -n \"\$dev\" ] || { echo 'format_drbd_device: cannot resolve drbd device' >&2; exit 1; }
         drbdadm primary --force '${rd}'
         # Settle the role change before mkfs opens the device.
         sleep 1
-        mkfs.${fstype} -F -q \"\$dev\"
+        mkfs.${fstype} -F -q '${dev}'
         sync
         drbdadm secondary '${rd}'
     "

--- a/tests/e2e/cli-matrix/snap-restore-snapshotless-node-rejected.sh
+++ b/tests/e2e/cli-matrix/snap-restore-snapshotless-node-rejected.sh
@@ -82,15 +82,15 @@ wait_uptodate "$SRC" "$N1" "$N2"
 
 echo ">> seed deterministic marker on $N1 $SRC"
 on_node "$N1" drbdadm primary --force "$SRC" 2>/dev/null || true
-on_node "$N1" bash -c "
-    dev=\$(readlink -f /dev/drbd/by-res/$SRC/0 2>/dev/null || true)
-    if [ -n \"\$dev\" ]; then
-        printf '$MARKER' | dd of=\"\$dev\" bs=1 count=${#MARKER} conv=fsync status=none
-    else
-        echo 'ABORT: could not resolve /dev/drbd for $SRC on $N1' >&2
-        exit 2
-    fi
-"
+# Resolve via `drbdadm sh-dev` (lib.sh resolve_drbd_device): the
+# /dev/drbd/by-res symlink is not reliably present in the satellite
+# mount namespace, so readlink-based resolution aborts on the stand.
+dev=$(resolve_drbd_device "$N1" "$SRC" 0) || {
+    echo "ABORT: could not resolve /dev/drbd for $SRC on $N1" >&2
+    exit 2
+}
+on_node "$N1" bash -c \
+    "printf '$MARKER' | dd of='$dev' bs=1 count=${#MARKER} conv=fsync status=none"
 wait_uptodate "$SRC" "$N1" "$N2"
 
 echo ">> snap c $SRC $SNAP"
@@ -203,11 +203,15 @@ for node in "${placed_nodes[0]}" "${placed_nodes[1]}"; do
         on_node "$other" drbdadm secondary "$TGT_OK" 2>/dev/null || true
     done
 
+    # Same portable resolver as the seeding step: by-res symlinks are
+    # not reliably present in the satellite mount namespace. An
+    # unresolved device leaves marker_read empty and fails the
+    # data-integrity assertion below, exactly like before.
+    dev=$(resolve_drbd_device "$node" "$TGT_OK" 0 2>/dev/null) || dev=""
     marker_read=$(on_node "$node" bash -c "
         drbdadm primary --force $TGT_OK 2>/dev/null || true
-        dev=\$(readlink -f /dev/drbd/by-res/$TGT_OK/0 2>/dev/null || true)
-        if [ -n \"\$dev\" ]; then
-            head -c ${#MARKER} \"\$dev\" 2>/dev/null
+        if [ -n '$dev' ]; then
+            head -c ${#MARKER} '$dev' 2>/dev/null
         fi
     " 2>/dev/null || echo "")
 


### PR DESCRIPTION
## What

The L6 cli-matrix cell `snap-restore-snapshotless-node-rejected.sh` (Bug 397, P0 data integrity) aborted deterministically on the stand with `ABORT: could not resolve /dev/drbd for <rd> on <node>` before reaching its assertions.

## Why

The cell resolved the DRBD device via `readlink -f /dev/drbd/by-res/...`, but the by-res symlink is not reliably present in the satellite mount namespace — `tests/e2e/cli-matrix/lib.sh` already documents `drbdadm sh-dev` as the one portable resolver there.

## How it is fixed

- Factor the `sh-dev` resolver out of `format_drbd_device` into a shared `resolve_drbd_device` helper in `lib.sh` (behavior-preserving for existing callers).
- Use the helper in the cell for both the marker seeding and the per-replica marker read.

The cell's actual assertions (the silently-empty-replica guards) are unchanged: an unresolved device still leaves the marker read empty and fails the data-integrity check, exactly as before.

## Validation

- `bash -n` clean on both scripts
- `shellcheck`: only pre-existing info-level findings (SC1091/SC2295) on untouched lines, consistent with sibling cells