### PR TITLE
fix(store): sync ControllerProps with the ControllerConfig CRD (BUG-022)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,14 @@ rules:
 - apiGroups:
   - blockstor.cozystack.io
   resources:
+  - controllerconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - blockstor.cozystack.io
+  resources:
   - nodes
   - resourcedefinitions
   - resourcegroups

--- a/internal/controller/auto_diskful_controller.go
+++ b/internal/controller/auto_diskful_controller.go
@@ -530,6 +530,24 @@ func parsePositiveMinutes(s string) (int, bool) {
 	return n, true
 }
 
+// parseNonNegativeMinutes is the zero-permitting sibling of
+// parsePositiveMinutes for knobs where 0 is a legal explicit value —
+// upstream LINSTOR accepts `BalanceResourcesGracePeriod 0` as "no
+// grace window". Negative values and garbage still return
+// (0, false) so the resolver falls back to the default.
+func parseNonNegativeMinutes(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+
+	return n, true
+}
+
 // readDeadline pulls the stamped wall-clock deadline off the RD's
 // annotations. Bad / unparseable values are treated as "not set" so
 // a hand-edited annotation can't permanently disarm or wedge the

--- a/internal/controller/parse_minutes_internal_test.go
+++ b/internal/controller/parse_minutes_internal_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+// TestParseMinutesVariants pins the boundary between the two minute
+// parsers (BUG-022 secondary fix): parsePositiveMinutes keeps
+// rejecting 0 (an Interval of 0 is not a meaningful cadence), while
+// parseNonNegativeMinutes accepts it (GracePeriod 0 = "no grace
+// window" is a legal upstream value). Both reject negatives, empty
+// strings and garbage so the resolver falls back to defaults.
+func TestParseMinutesVariants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in          string
+		wantPos     int
+		wantPosOK   bool
+		wantNonNeg  int
+		wantNNegOK  bool
+		description string
+	}{
+		{"", 0, false, 0, false, "empty means unset"},
+		{"0", 0, false, 0, true, "zero: rejected as positive, legal as non-negative"},
+		{"1", 1, true, 1, true, "smallest positive"},
+		{"60", 60, true, 60, true, "typical grace"},
+		{"-1", 0, false, 0, false, "negatives are garbage in both"},
+		{"abc", 0, false, 0, false, "non-numeric is garbage in both"},
+		{"1.5", 0, false, 0, false, "fractions are not upstream shape"},
+		{" 1", 0, false, 0, false, "whitespace is not trimmed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			gotPos, okPos := parsePositiveMinutes(tc.in)
+			if gotPos != tc.wantPos || okPos != tc.wantPosOK {
+				t.Errorf("parsePositiveMinutes(%q) = (%d, %v), want (%d, %v)",
+					tc.in, gotPos, okPos, tc.wantPos, tc.wantPosOK)
+			}
+
+			gotNNeg, okNNeg := parseNonNegativeMinutes(tc.in)
+			if gotNNeg != tc.wantNonNeg || okNNeg != tc.wantNNegOK {
+				t.Errorf("parseNonNegativeMinutes(%q) = (%d, %v), want (%d, %v)",
+					tc.in, gotNNeg, okNNeg, tc.wantNonNeg, tc.wantNNegOK)
+			}
+		})
+	}
+}

--- a/internal/controller/rg_rebalance_controller.go
+++ b/internal/controller/rg_rebalance_controller.go
@@ -97,6 +97,7 @@ type RGRebalanceReconciler struct {
 // +kubebuilder:rbac:groups=blockstor.cozystack.io,resources=resourcedefinitions,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=blockstor.cozystack.io,resources=resources,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=blockstor.cozystack.io,resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=blockstor.cozystack.io,resources=controllerconfigs,verbs=get;list;watch
 
 // Reconcile is the explicit + periodic rebalance pass. See the type
 // comment for the five-step lifecycle. Returns `RequeueAfter =
@@ -414,7 +415,10 @@ func (r *RGRebalanceReconciler) resolveTuning(ctx context.Context) (time.Duratio
 		interval = time.Duration(m) * time.Minute
 	}
 
-	if m, ok := parsePositiveMinutes(props[apiv1.PropBalanceResourcesGracePeriod]); ok {
+	// GracePeriod permits an explicit 0 ("no grace window") — a legal
+	// upstream value parsePositiveMinutes used to reject, silently
+	// pinning the default instead.
+	if m, ok := parseNonNegativeMinutes(props[apiv1.PropBalanceResourcesGracePeriod]); ok {
 		grace = time.Duration(m) * time.Minute
 	}
 

--- a/internal/controller/rg_rebalance_interval_test.go
+++ b/internal/controller/rg_rebalance_interval_test.go
@@ -263,6 +263,62 @@ func TestRebalanceGracePeriod(t *testing.T) {
 	}
 }
 
+// TestRebalanceGracePeriodZero pins the BUG-022 secondary fix: an
+// explicit `BalanceResourcesGracePeriod 0` is a legal upstream value
+// meaning "no grace window" — the scheduled pass must fire even while
+// a node is freshly OFFLINE. Pre-fix the positive-only parser
+// rejected "0" and silently fell back to the 60-minute default, so an
+// operator who explicitly disabled the grace window kept waiting an
+// hour anyway.
+func TestRebalanceGracePeriodZero(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := newScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	st := store.NewInMemory()
+
+	// Deficit of 2 (only n1 carries a replica) so the pass has an
+	// ONLINE node (n2) to land on while n3 is offline.
+	rg := seedIntervalFixture(t, ctx, st, 3, []string{"n1"})
+
+	if err := st.ControllerProps().Set(ctx, map[string]string{
+		apiv1.PropBalanceResourcesInterval:    "5",
+		apiv1.PropBalanceResourcesGracePeriod: "0",
+	}); err != nil {
+		t.Fatalf("set BalanceResources props: %v", err)
+	}
+
+	// n3 goes OFFLINE just before the tick. With grace=0 there is no
+	// suppression window; with the (wrongly applied) 60-minute default
+	// the whole pass would be gated.
+	if err := st.Nodes().SetConnectionStatus(ctx, "n3", apiv1.NodeTypeOffline); err != nil {
+		t.Fatalf("set n3 offline: %v", err)
+	}
+
+	t0 := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+
+	rec := &controllerpkg.RGRebalanceReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+		Now:    func() time.Time { return t0 },
+	}
+
+	if _, err := rec.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rg.Name}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	got, err := st.Resources().ListByDefinition(ctx, "pvc-interval")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(got) < 2 {
+		t.Fatalf("GracePeriod=0 must not gate the pass: got %d replicas, want >= 2 (entries=%v)", len(got), got)
+	}
+}
+
 // TestRebalanceHonoursDisabled pins the wave2 2.W02 contract: the
 // controller-scope `BalanceResourcesEnabled=false` kill-switch wins
 // over the new scheduled-tick path. Even at a scheduled tick (no

--- a/pkg/store/inmemory_test.go
+++ b/pkg/store/inmemory_test.go
@@ -86,6 +86,14 @@ func TestInMemorySnapshotStore(t *testing.T) {
 	})
 }
 
+func TestInMemoryControllerPropsStore(t *testing.T) {
+	storetest.RunControllerPropsStore(t, func(t *testing.T) store.Store {
+		t.Helper()
+
+		return store.NewInMemory()
+	})
+}
+
 // TestInMemoryNodeStoreConcurrentAccess: in-memory specific (CRD store has
 // optimistic-concurrency semantics; this guarantee belongs only to the
 // RAM map).

--- a/pkg/store/k8s/controller_props_bug022_test.go
+++ b/pkg/store/k8s/controller_props_bug022_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s_test
+
+import (
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store/k8s"
+)
+
+// TestControllerPropsSeeCRDWritesWithoutRestart pins BUG-022: the
+// CRD-backed store's ControllerProps() view used to be a
+// process-local map populated once at construction and never synced
+// from the ControllerConfig CRD again. `linstor controller
+// set-property` persisted into Spec.ExtraProps via the REST shim, but
+// every reconciler / placer read through Store.ControllerProps() —
+// so controller-scope knobs (BalanceResourcesInterval / GracePeriod /
+// Enabled, Autoplacer/Weights/*, AllowMixingStoragePoolDriver) were
+// silent no-ops until a controller restart.
+//
+// The test reproduces the operator-day split exactly: construct the
+// store FIRST (the long-running controller process), then drive the
+// REST write path (PatchControllerExtraProps is what
+// handleControllerPropsModify calls), then assert the SAME store
+// instance observes the fresh value — no reconstruction, no restart.
+func TestControllerPropsSeeCRDWritesWithoutRestart(t *testing.T) {
+	if fixture == nil {
+		t.Skip("envtest assets not installed; run `make setup-envtest` to enable")
+	}
+
+	t.Cleanup(func() { wipeAll(t, fixture.client) })
+
+	ctx := t.Context()
+
+	// 1) The controller process boots: store constructed while the
+	// ControllerConfig CRD does not exist yet.
+	st := k8s.New(fixture.client)
+
+	props, err := st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get before any write: %v", err)
+	}
+
+	if len(props) != 0 {
+		t.Fatalf("fresh cluster must read an empty props bag, got %v", props)
+	}
+
+	// 2) Operator runs `linstor controller set-property
+	// BalanceResourcesInterval 1` — the REST handler lands it on
+	// ControllerConfig.Spec.ExtraProps through this exact helper.
+	err = k8s.PatchControllerExtraProps(ctx, fixture.client, func(m map[string]string) error {
+		m[apiv1.PropBalanceResourcesInterval] = "1"
+		m[apiv1.PropBalanceResourcesGracePeriod] = "0"
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("simulate REST set-property: %v", err)
+	}
+
+	// 3) The running reconcilers' next ControllerProps().Get() MUST
+	// observe the write. Pre-fix this returned the stale boot-time map
+	// (empty) and the scheduled rebalance kept firing at the 5-minute
+	// default.
+	props, err = st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after set-property: %v", err)
+	}
+
+	if got := props[apiv1.PropBalanceResourcesInterval]; got != "1" {
+		t.Errorf("BalanceResourcesInterval after CLI write: got %q, want %q (stale process-local map?)", got, "1")
+	}
+
+	if got := props[apiv1.PropBalanceResourcesGracePeriod]; got != "0" {
+		t.Errorf("BalanceResourcesGracePeriod after CLI write: got %q, want %q", got, "0")
+	}
+
+	// 4) Drop-property is the symmetric half: deletion must also be
+	// visible live.
+	err = k8s.PatchControllerExtraProps(ctx, fixture.client, func(m map[string]string) error {
+		delete(m, apiv1.PropBalanceResourcesInterval)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("simulate REST drop-property: %v", err)
+	}
+
+	props, err = st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after drop-property: %v", err)
+	}
+
+	if _, stale := props[apiv1.PropBalanceResourcesInterval]; stale {
+		t.Errorf("BalanceResourcesInterval still visible after drop-property: %v", props)
+	}
+}

--- a/pkg/store/k8s/k8s.go
+++ b/pkg/store/k8s/k8s.go
@@ -30,8 +30,10 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	crdv1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
 	"github.com/cozystack/blockstor/pkg/store"
 )
 
@@ -70,47 +72,65 @@ func New(c ctrlclient.Client) *Store {
 	s.volumeDefinitions = &volumeDefinitions{c: c}
 	s.snapshots = &snapshots{c: c}
 	s.physicalDevices = &physicalDevices{c: c}
-	s.controllerProps = &controllerProps{props: map[string]string{}}
+	s.controllerProps = &controllerProps{c: c}
 	s.storagePoolDefinitions = &storagePoolDefinitions{m: map[string]store.StoragePoolDefinition{}}
 
 	return s
 }
 
-// controllerProps is a process-local stand-in for the singleton
-// controller-scope props bag. A future iteration will swap this for a
-// dedicated CRD (or a ConfigMap-backed shim) so the value survives
-// controller restarts; until then the autoplacer's weights revert to
-// defaults across restarts, which is acceptable because the four
-// `Autoplacer/Weights/*` knobs are pure scoring multipliers — no
-// persisted state depends on them and operators that set them today
-// can re-set after a restart with no data risk.
+// controllerProps is the CRD-backed view of the singleton
+// controller-scope props bag: `ControllerConfig.Spec.ExtraProps` on
+// the cluster-wide `default` instance — the same record the REST
+// shim mutates on `linstor controller set-property`.
+//
+// BUG-022: this used to be a process-local map populated only at
+// construction, so every controller-scope knob written via the CLI
+// (BalanceResources*, Autoplacer/Weights/*, ...) was invisible to
+// running reconcilers and the placer until a process restart. Reading
+// through the client keeps the bag fresh: in production the client is
+// the manager's informer-cached client, so Get is a cache hit kept in
+// sync by the ControllerConfig watch — the same mechanism every other
+// kind in this store relies on. Thread-safety comes from the client
+// (concurrent reconcilers call Get; the cache reader is safe for
+// concurrent use).
 type controllerProps struct {
-	mu    sync.RWMutex
-	props map[string]string
+	c ctrlclient.Client
 }
 
-// Get returns a defensive copy (never nil).
-func (s *controllerProps) Get(_ context.Context) (map[string]string, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// Get returns a defensive copy of `Spec.ExtraProps` (never nil). A
+// missing ControllerConfig CRD — fresh cluster, nothing written yet —
+// folds into an empty map, mirroring the InMemory store's "no value
+// written yet" contract.
+func (s *controllerProps) Get(ctx context.Context) (map[string]string, error) {
+	var cfg crdv1alpha1.ControllerConfig
 
-	out := make(map[string]string, len(s.props))
-	maps.Copy(out, s.props)
+	err := s.c.Get(ctx, ctrlclient.ObjectKey{Name: crdv1alpha1.ControllerConfigName}, &cfg)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return map[string]string{}, nil
+		}
+
+		return nil, errors.Wrap(err, "get ControllerConfig")
+	}
+
+	out := make(map[string]string, len(cfg.Spec.ExtraProps))
+	maps.Copy(out, cfg.Spec.ExtraProps)
 
 	return out, nil
 }
 
-// Set replaces the props map atomically.
-func (s *controllerProps) Set(_ context.Context, props map[string]string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// Set replaces `Spec.ExtraProps` atomically, routed through
+// PatchControllerExtraProps so it inherits the auto-create-on-NotFound
+// and retry-on-conflict semantics the REST write path already uses —
+// a Set racing a `linstor controller set-property` converges instead
+// of clobbering.
+func (s *controllerProps) Set(ctx context.Context, props map[string]string) error {
+	return PatchControllerExtraProps(ctx, s.c, func(m map[string]string) error {
+		clear(m)
+		maps.Copy(m, props)
 
-	next := make(map[string]string, len(props))
-	maps.Copy(next, props)
-
-	s.props = next
-
-	return nil
+		return nil
+	})
 }
 
 // Nodes returns the NodeStore view of this store.

--- a/pkg/store/k8s/k8s_test.go
+++ b/pkg/store/k8s/k8s_test.go
@@ -178,6 +178,23 @@ func TestK8sSnapshotStore(t *testing.T) {
 	})
 }
 
+// TestK8sControllerPropsStore runs the shared ControllerPropsStore
+// suite against the CRD-backed store (BUG-022: keeps the k8s
+// implementation behaviourally identical to InMemory — the old
+// process-local map drifted silently).
+func TestK8sControllerPropsStore(t *testing.T) {
+	if fixture == nil {
+		t.Skip("envtest assets not installed; run `make setup-envtest` to enable")
+	}
+
+	storetest.RunControllerPropsStore(t, func(t *testing.T) store.Store {
+		t.Helper()
+		t.Cleanup(func() { wipeAll(t, fixture.client) })
+
+		return k8s.New(fixture.client)
+	})
+}
+
 // envtestAvailable returns whether KUBEBUILDER_ASSETS or a known asset
 // directory exists; without binaries we cannot start envtest.
 func envtestAvailable() bool {
@@ -280,5 +297,11 @@ func wipeAll(t *testing.T, c client.Client) {
 
 	if err := c.DeleteAllOf(ctx, &crdv1alpha1.Snapshot{}); err != nil {
 		t.Logf("wipe Snapshots: %v", err)
+	}
+
+	// The ControllerConfig singleton backs ControllerProps (BUG-022);
+	// leftover ExtraProps would leak between subtests.
+	if err := c.DeleteAllOf(ctx, &crdv1alpha1.ControllerConfig{}); err != nil {
+		t.Logf("wipe ControllerConfigs: %v", err)
 	}
 }

--- a/pkg/store/storetest/controller_props.go
+++ b/pkg/store/storetest/controller_props.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storetest
+
+import (
+	"sync"
+	"testing"
+)
+
+// RunControllerPropsStore exercises the singleton controller-scope
+// props bag. Added with the BUG-022 fix: the k8s store used to back
+// this with a process-local map populated once at construction, so
+// the CRD-backed and in-memory implementations drifted — reconcilers
+// reading through the k8s store never saw `linstor controller
+// set-property` writes. The shared suite pins both implementations
+// to identical Get/Set semantics.
+func RunControllerPropsStore(t *testing.T, newStore Factory) {
+	t.Helper()
+	t.Run("GetEmpty", func(t *testing.T) { testCtrlPropsGetEmpty(t, newStore) })
+	t.Run("SetThenGet", func(t *testing.T) { testCtrlPropsSetThenGet(t, newStore) })
+	t.Run("SetReplaces", func(t *testing.T) { testCtrlPropsSetReplaces(t, newStore) })
+	t.Run("SetNilClears", func(t *testing.T) { testCtrlPropsSetNilClears(t, newStore) })
+	t.Run("GetDefensiveCopy", func(t *testing.T) { testCtrlPropsGetDefensiveCopy(t, newStore) })
+	// Reconcilers and the placer call Get concurrently while the REST
+	// shim writes — pinned under -race so an implementation that hands
+	// out its backing map (or mutates without locking) fails loudly.
+	t.Run("ConcurrentGetSet", func(t *testing.T) { testCtrlPropsConcurrentGetSet(t, newStore) })
+}
+
+// testCtrlPropsGetEmpty pins the "no value written yet" contract: an
+// empty, non-nil map so callers can do `props[key]` without nil-checks.
+func testCtrlPropsGetEmpty(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	props, err := newStore(t).ControllerProps().Get(t.Context())
+	if err != nil {
+		t.Fatalf("Get on fresh store: %v", err)
+	}
+
+	if props == nil {
+		t.Fatal("Get on fresh store: want empty non-nil map, got nil")
+	}
+
+	if len(props) != 0 {
+		t.Errorf("Get on fresh store: want empty map, got %v", props)
+	}
+}
+
+func testCtrlPropsSetThenGet(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	st := newStore(t)
+	ctx := t.Context()
+
+	want := map[string]string{
+		"BalanceResourcesInterval":        "1",
+		"Autoplacer/Weights/MaxFreeSpace": "2.0",
+	}
+
+	if err := st.ControllerProps().Set(ctx, want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("Get after Set: got %v, want %v", got, want)
+	}
+
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Get after Set: key %q = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// testCtrlPropsSetReplaces pins the replace-not-merge contract from
+// store.ControllerPropsStore: a second Set drops keys absent from the
+// new map.
+func testCtrlPropsSetReplaces(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	st := newStore(t)
+	ctx := t.Context()
+
+	if err := st.ControllerProps().Set(ctx, map[string]string{
+		"BalanceResourcesInterval": "1",
+		"BalanceResourcesEnabled":  "false",
+	}); err != nil {
+		t.Fatalf("first Set: %v", err)
+	}
+
+	if err := st.ControllerProps().Set(ctx, map[string]string{
+		"BalanceResourcesInterval": "7",
+	}); err != nil {
+		t.Fatalf("second Set: %v", err)
+	}
+
+	got, err := st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got["BalanceResourcesInterval"] != "7" {
+		t.Errorf("BalanceResourcesInterval: got %q, want %q", got["BalanceResourcesInterval"], "7")
+	}
+
+	if _, stale := got["BalanceResourcesEnabled"]; stale {
+		t.Errorf("BalanceResourcesEnabled survived a replacing Set: %v", got)
+	}
+}
+
+func testCtrlPropsSetNilClears(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	st := newStore(t)
+	ctx := t.Context()
+
+	if err := st.ControllerProps().Set(ctx, map[string]string{"A": "1"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := st.ControllerProps().Set(ctx, nil); err != nil {
+		t.Fatalf("Set(nil): %v", err)
+	}
+
+	got, err := st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if len(got) != 0 {
+		t.Errorf("Set(nil) must clear the bag; got %v", got)
+	}
+}
+
+// testCtrlPropsGetDefensiveCopy pins that mutating the returned map
+// never leaks back into the store.
+func testCtrlPropsGetDefensiveCopy(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	st := newStore(t)
+	ctx := t.Context()
+
+	if err := st.ControllerProps().Set(ctx, map[string]string{"A": "1"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	first, err := st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+
+	first["A"] = "tampered"
+	first["B"] = "injected"
+
+	second, err := st.ControllerProps().Get(ctx)
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+
+	if second["A"] != "1" {
+		t.Errorf("mutation of a returned map leaked into the store: A=%q", second["A"])
+	}
+
+	if _, leaked := second["B"]; leaked {
+		t.Errorf("insertion into a returned map leaked into the store: %v", second)
+	}
+}
+
+func testCtrlPropsConcurrentGetSet(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	st := newStore(t)
+	ctx := t.Context()
+
+	const iterations = 20
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for i := range iterations {
+			_ = st.ControllerProps().Set(ctx, map[string]string{
+				"BalanceResourcesInterval": string(rune('1' + i%9)),
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range iterations {
+			props, err := st.ControllerProps().Get(ctx)
+			if err != nil {
+				continue
+			}
+
+			_ = props["BalanceResourcesInterval"]
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

`linstor controller set-property` persists into the ControllerConfig CRD's `Spec.ExtraProps`, but reconcilers and the placer read `Store.ControllerProps()`, which in the CRD-backed store was a process-local map populated once at construction and never synced from the CRD afterwards. Every controller-scope knob set via the CLI — `BalanceResourcesInterval` / `GracePeriod` / `Enabled`, `Autoplacer/Weights/*`, `AllowMixingStoragePoolDriver` — was a silent no-op for the running process until a controller restart. Empirically: with the interval set to 1 minute via the CLI, the scheduled rebalance still fired at the 5-minute default.

Secondary: the grace-period resolver rejected an explicit `BalanceResourcesGracePeriod 0` (a legal upstream value meaning "no grace window") and silently fell back to the 60-minute default.

## Fix

- `ControllerProps()` in the k8s store now reads `Spec.ExtraProps` through the store's client — the manager's informer-cached client in production, the same freshness mechanism every other kind in the store uses. `Set` routes through `PatchControllerExtraProps`, so it converges with concurrent REST writes instead of clobbering them. As a side effect the props bag now survives controller restarts.
- `BalanceResourcesGracePeriod` is parsed with a new non-negative parser: `0` is honoured as "no grace window"; negatives and garbage still fall back to the default. `BalanceResourcesInterval` keeps the positive-only parser.
- The generated manager role gains `get`/`list`/`watch` on `controllerconfigs`, since reconcilers now read the CRD through the cached client's watch.

## Tests

- New shared `storetest.RunControllerPropsStore` suite pins the InMemory and CRD-backed implementations to identical Get/Set semantics (empty-not-nil, replace-not-merge, defensive copies, concurrent Get/Set under `-race`).
- `TestControllerPropsSeeCRDWritesWithoutRestart` (envtest) reproduces the operator-day split exactly: store constructed first, then the REST write path mutates the CRD, then the same store instance must observe the fresh value. Red on the previous implementation, green now.
- `TestRebalanceGracePeriodZero` pins that an explicit zero grace period does not gate the scheduled pass; a table test covers the parser boundary between the two minute parsers.
- The intentionally-red integration pin `TestGroupKWFBalanceResourcesTick` (#137) goes green with this fix: red pre-fix (Eventually timed out — the tick stayed at the 5-minute default), passes in ~67s post-fix with the CLI-set 1-minute tick.