### PR TITLE
fix(controller): rebalance-pending annotation strip never reached the CRD

### DIFF
--- a/internal/controller/rg_rebalance_controller.go
+++ b/internal/controller/rg_rebalance_controller.go
@@ -367,10 +367,15 @@ func (r *RGRebalanceReconciler) stripShortfallAnnotation(ctx context.Context, rd
 
 	delete(rd.Annotations, apiv1.RDSpawnShortfallAnnotation)
 
-	if len(rd.Annotations) == 0 {
-		rd.Annotations = nil
-	}
-
+	// Keep the now-empty map NON-nil. The store Update contract
+	// (pinned by storetest's UpdateAnnotationContract) reads a nil
+	// wire map as "annotations untouched" — the k8s backend's
+	// mergeUserAnnotationsInto early-returns on nil — so nil-ing it
+	// here would turn the strip into a silent no-op on the CRD and
+	// the marker would survive forever (Bug-021). An EMPTY map means
+	// "replace the user-annotation set with nothing", which is the
+	// strip semantic. Wire-JSON shape is unaffected: the
+	// `annotations,omitempty` tag elides empty and nil alike.
 	return r.Store.ResourceDefinitions().Update(ctx, rd)
 }
 
@@ -385,13 +390,17 @@ func (r *RGRebalanceReconciler) stripRebalanceAnnotation(ctx context.Context, rg
 
 	delete(rg.Annotations, apiv1.AnnotationRGRebalancePending)
 
-	// Nil-out an empty map so the wire envelope round-trips as the
-	// pre-Bug-60 shape — round-trip stability matters for the JSON
-	// goldens that pin the RG payload.
-	if len(rg.Annotations) == 0 {
-		rg.Annotations = nil
-	}
-
+	// Keep the now-empty map NON-nil (Bug-021). An earlier revision
+	// nil-ed it "for wire-envelope round-trip stability", but the
+	// store Update contract reads a nil wire map as "annotations
+	// untouched" (the k8s backend's mergeUserAnnotationsInto
+	// early-returns on nil to protect reconciler-stamped keys), so
+	// the deletion never reached the CRD when the marker was the
+	// only annotation — and the rebalance pass re-fired on every
+	// event. An EMPTY map means "replace the user-annotation set
+	// with nothing", which is exactly the strip semantic. The JSON
+	// goldens are unaffected: `annotations,omitempty` elides empty
+	// and nil alike.
 	return r.Store.ResourceGroups().Update(ctx, rg)
 }
 

--- a/internal/controller/rg_rebalance_strip_bug021_test.go
+++ b/internal/controller/rg_rebalance_strip_bug021_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	storek8s "github.com/cozystack/blockstor/pkg/store/k8s"
+)
+
+// Bug-021 (release-gate, P1) — the `blockstor.io/rebalance-pending`
+// RG annotation could never be removed in production. The strip
+// helpers nil-ed the wire annotation map once it became empty, but
+// the k8s store's mergeUserAnnotationsInto treats a NIL wire map as
+// "annotations untouched" (deliberately, to protect reconciler-
+// stamped keys), so the deletion never reached the CRD and the
+// rebalance pass re-fired on every event — observed as the
+// annotation persisting >90s with constant placer churn. The
+// InMemory store replaced rows wholesale, which is why every unit
+// test stayed green.
+//
+// These specs run the REAL strip paths against the REAL k8s store
+// over envtest (the exact production wiring: reconciler → wire
+// strip → Store.Update → mergeUserAnnotationsInto → apiserver) and
+// assert the marker is gone FROM THE CRD. Pre-fix, both specs fail
+// with the marker still present.
+var _ = Describe("RGRebalance annotation strip through the k8s store (Bug-021)", func() {
+	ctx := context.Background()
+
+	newRebalanceReconciler := func() *RGRebalanceReconciler {
+		return &RGRebalanceReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Store:  storek8s.New(k8sClient),
+		}
+	}
+
+	It("removes a lone rebalance-pending annotation from the RG CRD via Reconcile", func() {
+		const rgName = "rg-bug021-strip-lone"
+
+		rg := &blockstoriov1alpha1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rgName,
+				// The bug shape: the marker is the ONLY annotation, so
+				// the strip leaves an EMPTY map behind. Pre-fix the
+				// helper nil-ed it and the Update became a silent no-op.
+				Annotations: map[string]string{
+					apiv1.AnnotationRGRebalancePending: "2026-06-12T00:00:00Z",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, rg)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, rg)
+		})
+
+		_, err := newRebalanceReconciler().Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rgName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var got blockstoriov1alpha1.ResourceGroup
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rgName}, &got)).To(Succeed())
+		Expect(got.Annotations).NotTo(HaveKey(apiv1.AnnotationRGRebalancePending),
+			"rebalance-pending must be stripped from the CRD after the pass (Bug-021)")
+	})
+
+	It("strips only the rebalance-pending key and keeps sibling annotations", func() {
+		const rgName = "rg-bug021-strip-sibling"
+
+		rg := &blockstoriov1alpha1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rgName,
+				Annotations: map[string]string{
+					apiv1.AnnotationRGRebalancePending: "2026-06-12T00:00:00Z",
+					"aux/operator-note":                "keep-me",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, rg)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, rg)
+		})
+
+		_, err := newRebalanceReconciler().Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rgName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var got blockstoriov1alpha1.ResourceGroup
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rgName}, &got)).To(Succeed())
+		Expect(got.Annotations).NotTo(HaveKey(apiv1.AnnotationRGRebalancePending))
+		Expect(got.Annotations).To(HaveKeyWithValue("aux/operator-note", "keep-me"),
+			"the strip must not clobber unrelated user annotations")
+	})
+
+	It("removes a lone spawn-shortfall annotation from the RD CRD", func() {
+		const rdName = "rd-bug021-strip-shortfall"
+
+		rd := &blockstoriov1alpha1.ResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rdName,
+				Annotations: map[string]string{
+					apiv1.RDSpawnShortfallAnnotation: "2026-06-12T00:00:00Z",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, rd)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, rd)
+		})
+
+		rec := newRebalanceReconciler()
+
+		// Same strip-then-Update shape replaySpawnShortfalls drives
+		// after a successful placer top-up: fetch the wire RD, strip
+		// the marker, persist through the store.
+		wire, err := rec.Store.ResourceDefinitions().Get(ctx, rdName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec.stripShortfallAnnotation(ctx, &wire)).To(Succeed())
+
+		var got blockstoriov1alpha1.ResourceDefinition
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rdName}, &got)).To(Succeed())
+		Expect(got.Annotations).NotTo(HaveKey(apiv1.RDSpawnShortfallAnnotation),
+			"spawn-shortfall must be stripped from the CRD (Bug-021, same class)")
+	})
+})

--- a/pkg/store/inmemory.go
+++ b/pkg/store/inmemory.go
@@ -60,6 +60,25 @@ func NewInMemory() *InMemory {
 	}
 }
 
+// carryAnnotationsOnNil implements the store-wide Update/Patch
+// annotation contract (Bug-021, pinned by storetest's
+// UpdateAnnotationContract suites): a nil wire-side annotation map
+// means "leave the stored annotations untouched", while a non-nil
+// (including empty) map means "replace the user-annotation set with
+// exactly this". The k8s backend gets this behaviour from
+// mergeUserAnnotationsInto's early-return on nil; the in-memory
+// store replaces rows wholesale, so the carry-over has to be
+// explicit or the two backends diverge — which is how the
+// rebalance-pending strip silently no-op'd in production while
+// every InMemory-backed unit test stayed green.
+func carryAnnotationsOnNil(next, prev map[string]string) map[string]string {
+	if next == nil {
+		return prev
+	}
+
+	return next
+}
+
 // Nodes returns the NodeStore view of this store.
 func (s *InMemory) Nodes() NodeStore { return s.nodes }
 

--- a/pkg/store/inmemory_resource.go
+++ b/pkg/store/inmemory_resource.go
@@ -116,12 +116,18 @@ func (s *inMemoryResources) Update(_ context.Context, r *apiv1.Resource) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	k := rKey{r.Name, r.NodeName}
-	if _, exists := s.m[k]; !exists {
+	key := rKey{r.Name, r.NodeName}
+
+	prev, exists := s.m[key]
+	if !exists {
 		return errors.Wrapf(ErrNotFound, "resource %q on node %q", r.Name, r.NodeName)
 	}
 
-	s.m[k] = *r
+	next := *r
+	// Bug-021: nil wire annotations = "untouched"; empty = "clear".
+	// Mirrors the k8s store's mergeUserAnnotationsInto contract.
+	next.Annotations = carryAnnotationsOnNil(next.Annotations, prev.Annotations)
+	s.m[key] = next
 
 	return nil
 }
@@ -145,11 +151,16 @@ func (s *inMemoryResources) PatchResourceSpec(_ context.Context, rdName, node st
 		return errors.Wrapf(ErrNotFound, "resource %q on node %q", rdName, node)
 	}
 
+	prevAnnotations := r.Annotations
+
 	err := mutate(&r)
 	if err != nil {
 		return errors.Wrapf(err, "patch resource %q on node %q", rdName, node)
 	}
 
+	// Bug-021: same annotation contract as Update — a closure that
+	// nils the map means "untouched", not "clear".
+	r.Annotations = carryAnnotationsOnNil(r.Annotations, prevAnnotations)
 	s.m[key] = r
 
 	return nil

--- a/pkg/store/inmemory_resource_definition.go
+++ b/pkg/store/inmemory_resource_definition.go
@@ -84,11 +84,16 @@ func (s *inMemoryResourceDefinitions) Update(_ context.Context, rd *apiv1.Resour
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.m[rd.Name]; !exists {
+	prev, exists := s.m[rd.Name]
+	if !exists {
 		return errors.Wrapf(ErrNotFound, "resource definition %q", rd.Name)
 	}
 
-	s.m[rd.Name] = *rd
+	next := *rd
+	// Bug-021: nil wire annotations = "untouched"; empty = "clear".
+	// Mirrors the k8s store's mergeUserAnnotationsInto contract.
+	next.Annotations = carryAnnotationsOnNil(next.Annotations, prev.Annotations)
+	s.m[rd.Name] = next
 
 	return nil
 }
@@ -110,11 +115,16 @@ func (s *inMemoryResourceDefinitions) PatchResourceDefinitionSpec(_ context.Cont
 		return errors.Wrapf(ErrNotFound, "resource definition %q", name)
 	}
 
+	prevAnnotations := rd.Annotations
+
 	err := mutate(&rd)
 	if err != nil {
 		return errors.Wrapf(err, "patch resource definition %q", name)
 	}
 
+	// Bug-021: same annotation contract as Update — a closure that
+	// nils the map means "untouched", not "clear".
+	rd.Annotations = carryAnnotationsOnNil(rd.Annotations, prevAnnotations)
 	s.m[name] = rd
 
 	return nil

--- a/pkg/store/inmemory_resource_group.go
+++ b/pkg/store/inmemory_resource_group.go
@@ -84,11 +84,16 @@ func (s *inMemoryResourceGroups) Update(_ context.Context, rg *apiv1.ResourceGro
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.m[rg.Name]; !exists {
+	prev, exists := s.m[rg.Name]
+	if !exists {
 		return errors.Wrapf(ErrNotFound, "resource group %q", rg.Name)
 	}
 
-	s.m[rg.Name] = *rg
+	next := *rg
+	// Bug-021: nil wire annotations = "untouched"; empty = "clear".
+	// Mirrors the k8s store's mergeUserAnnotationsInto contract.
+	next.Annotations = carryAnnotationsOnNil(next.Annotations, prev.Annotations)
+	s.m[rg.Name] = next
 
 	return nil
 }
@@ -110,11 +115,16 @@ func (s *inMemoryResourceGroups) PatchResourceGroup(_ context.Context, name stri
 		return errors.Wrapf(ErrNotFound, "resource group %q", name)
 	}
 
+	prevAnnotations := rg.Annotations
+
 	err := mutate(&rg)
 	if err != nil {
 		return errors.Wrapf(err, "patch ResourceGroup %q", name)
 	}
 
+	// Bug-021: same annotation contract as Update — a closure that
+	// nils the map means "untouched", not "clear".
+	rg.Annotations = carryAnnotationsOnNil(rg.Annotations, prevAnnotations)
 	s.m[name] = rg
 
 	return nil

--- a/pkg/store/inmemory_snapshot.go
+++ b/pkg/store/inmemory_snapshot.go
@@ -113,12 +113,18 @@ func (s *inMemorySnapshots) Update(_ context.Context, snap *apiv1.Snapshot) erro
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	k := snapKey{snap.ResourceName, snap.Name}
-	if _, exists := s.m[k]; !exists {
+	key := snapKey{snap.ResourceName, snap.Name}
+
+	prev, exists := s.m[key]
+	if !exists {
 		return errors.Wrapf(ErrNotFound, "snapshot %q on resource definition %q", snap.Name, snap.ResourceName)
 	}
 
-	s.m[k] = *snap
+	next := *snap
+	// Bug-021: nil wire annotations = "untouched"; empty = "clear".
+	// Mirrors the k8s store's mergeUserAnnotationsInto contract.
+	next.Annotations = carryAnnotationsOnNil(next.Annotations, prev.Annotations)
+	s.m[key] = next
 
 	return nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -116,6 +116,16 @@ type StoragePoolStore interface {
 }
 
 // ResourceGroupStore persists ResourceGroup objects. Keyed by name.
+//
+// Annotation contract (Bug-021; shared by every annotation-carrying
+// store — RG, RD, Resource, Snapshot): on Update/Patch a NIL wire
+// `Annotations` map means "leave the stored user annotations
+// untouched", while a NON-NIL map — including an empty one — means
+// "replace the user-annotation set with exactly this set". Callers
+// that delete the last remaining annotation must therefore keep the
+// emptied map non-nil, or the deletion is silently dropped. Pinned
+// by storetest's UpdateAnnotationContract suites against both the
+// in-memory and the CRD-backed implementations.
 type ResourceGroupStore interface {
 	List(ctx context.Context) ([]apiv1.ResourceGroup, error)
 	Get(ctx context.Context, name string) (apiv1.ResourceGroup, error)
@@ -136,6 +146,8 @@ type ResourceGroupStore interface {
 }
 
 // ResourceDefinitionStore persists ResourceDefinition objects. Keyed by name.
+// Update/Patch follow the annotation contract documented on
+// ResourceGroupStore (nil = untouched, empty = clear).
 type ResourceDefinitionStore interface {
 	List(ctx context.Context) ([]apiv1.ResourceDefinition, error)
 	Get(ctx context.Context, name string) (apiv1.ResourceDefinition, error)
@@ -155,6 +167,8 @@ type ResourceDefinitionStore interface {
 
 // ResourceStore persists Resource (replica placement) objects. The
 // composite key is (resource_definition_name, node_name).
+// Update/Patch follow the annotation contract documented on
+// ResourceGroupStore (nil = untouched, empty = clear).
 type ResourceStore interface {
 	List(ctx context.Context) ([]apiv1.Resource, error)
 	ListByDefinition(ctx context.Context, rdName string) ([]apiv1.Resource, error)
@@ -230,6 +244,8 @@ type VolumeDefinitionStore interface {
 
 // SnapshotStore persists Snapshot objects. The composite key is
 // (resource definition, snapshot name).
+// Update follows the annotation contract documented on
+// ResourceGroupStore (nil = untouched, empty = clear).
 type SnapshotStore interface {
 	List(ctx context.Context) ([]apiv1.Snapshot, error)
 	ListByDefinition(ctx context.Context, rdName string) ([]apiv1.Snapshot, error)

--- a/pkg/store/storetest/annotation_contract.go
+++ b/pkg/store/storetest/annotation_contract.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storetest
+
+import (
+	"testing"
+
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+)
+
+// Bug-021 — Update annotation contract, shared by every annotation-
+// carrying store (RG, RD, Resource, Snapshot):
+//
+//   - NIL wire `Annotations` map  → stored user annotations untouched.
+//   - NON-NIL map (incl. EMPTY)   → user-annotation set replaced with
+//     exactly the wire set; an empty map clears all user annotations.
+//
+// The k8s backend implements this via mergeUserAnnotationsInto's
+// early-return on nil; pre-fix the in-memory backend replaced rows
+// wholesale, so "nil = untouched" silently diverged and the
+// production-only k8s behaviour (a stripped-to-empty map nil-ed by
+// the caller never reaching the CRD) was invisible to unit tests.
+// These subtests pin all three transitions against both backends.
+
+// annotationOps adapts one store type to the shared contract walk.
+// `update` must send a FULL wire object whose Annotations field is
+// exactly the given map (nil stays nil).
+type annotationOps struct {
+	create func(t *testing.T, annotations map[string]string)
+	update func(t *testing.T, annotations map[string]string)
+	get    func(t *testing.T) map[string]string
+}
+
+const (
+	contractMarkerKey   = "blockstor.io/rebalance-pending"
+	contractMarkerValue = "2026-06-12T00:00:00Z"
+	contractUserKey     = "aux/operator-note"
+	contractUserValue   = "keep-me"
+)
+
+// runUpdateAnnotationContract drives the three contract transitions:
+// nil-is-untouched, non-nil-replaces, empty-clears.
+func runUpdateAnnotationContract(t *testing.T, ops annotationOps) {
+	t.Helper()
+
+	ops.create(t, map[string]string{
+		contractMarkerKey: contractMarkerValue,
+		contractUserKey:   contractUserValue,
+	})
+
+	// 1) nil wire map: both annotations survive.
+	ops.update(t, nil)
+
+	got := ops.get(t)
+	if got[contractMarkerKey] != contractMarkerValue || got[contractUserKey] != contractUserValue {
+		t.Fatalf("Update(nil annotations) must leave annotations untouched; got %v", got)
+	}
+
+	// 2) non-nil map: replaces the full user set — the marker key is
+	// dropped, the listed key survives.
+	ops.update(t, map[string]string{contractUserKey: contractUserValue})
+
+	got = ops.get(t)
+	if _, still := got[contractMarkerKey]; still {
+		t.Fatalf("Update(non-nil annotations) must drop unlisted keys; %q survived: %v",
+			contractMarkerKey, got)
+	}
+
+	if got[contractUserKey] != contractUserValue {
+		t.Fatalf("Update(non-nil annotations) must keep listed keys; got %v", got)
+	}
+
+	// 3) EMPTY non-nil map: clears every user annotation. This is the
+	// Bug-021 load-bearing transition — the rebalance / shortfall
+	// strips delete the last marker and must be able to persist the
+	// now-empty set.
+	ops.update(t, map[string]string{})
+
+	got = ops.get(t)
+	if len(got) != 0 {
+		t.Fatalf("Update(empty annotations) must clear all user annotations; got %v", got)
+	}
+}
+
+func testRGUpdateAnnotationContract(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	s := newStore(t).ResourceGroups()
+	const name = "rg-ann-contract"
+
+	runUpdateAnnotationContract(t, annotationOps{
+		create: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Create(t.Context(), &apiv1.ResourceGroup{Name: name, Annotations: ann}); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+		},
+		update: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Update(t.Context(), &apiv1.ResourceGroup{Name: name, Annotations: ann}); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+		},
+		get: func(t *testing.T) map[string]string {
+			t.Helper()
+			got, err := s.Get(t.Context(), name)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+
+			return got.Annotations
+		},
+	})
+}
+
+func testRDUpdateAnnotationContract(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	s := newStore(t).ResourceDefinitions()
+	const name = "rd-ann-contract"
+
+	runUpdateAnnotationContract(t, annotationOps{
+		create: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Create(t.Context(), &apiv1.ResourceDefinition{Name: name, Annotations: ann}); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+		},
+		update: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Update(t.Context(), &apiv1.ResourceDefinition{Name: name, Annotations: ann}); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+		},
+		get: func(t *testing.T) map[string]string {
+			t.Helper()
+			got, err := s.Get(t.Context(), name)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+
+			return got.Annotations
+		},
+	})
+}
+
+func testResourceUpdateAnnotationContract(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	s := newStore(t).Resources()
+
+	const (
+		rdName = "pvc-ann-contract"
+		node   = "n1"
+	)
+
+	runUpdateAnnotationContract(t, annotationOps{
+		create: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Create(t.Context(), &apiv1.Resource{Name: rdName, NodeName: node, Annotations: ann}); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+		},
+		update: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Update(t.Context(), &apiv1.Resource{Name: rdName, NodeName: node, Annotations: ann}); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+		},
+		get: func(t *testing.T) map[string]string {
+			t.Helper()
+			got, err := s.Get(t.Context(), rdName, node)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+
+			return got.Annotations
+		},
+	})
+}
+
+func testSnapshotUpdateAnnotationContract(t *testing.T, newStore Factory) {
+	t.Helper()
+
+	s := newStore(t).Snapshots()
+
+	const (
+		rdName   = "pvc-ann-contract"
+		snapName = "snap-ann-contract"
+	)
+
+	runUpdateAnnotationContract(t, annotationOps{
+		create: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Create(t.Context(), &apiv1.Snapshot{Name: snapName, ResourceName: rdName, Annotations: ann}); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+		},
+		update: func(t *testing.T, ann map[string]string) {
+			t.Helper()
+			if err := s.Update(t.Context(), &apiv1.Snapshot{Name: snapName, ResourceName: rdName, Annotations: ann}); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+		},
+		get: func(t *testing.T) map[string]string {
+			t.Helper()
+			got, err := s.Get(t.Context(), rdName, snapName)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+
+			return got.Annotations
+		},
+	})
+}

--- a/pkg/store/storetest/storetest.go
+++ b/pkg/store/storetest/storetest.go
@@ -386,6 +386,9 @@ func RunSnapshotStore(t *testing.T, newStore Factory) {
 	// can't crash the controller process.
 	t.Run("CreateNilArg", func(t *testing.T) { testSnapshotCreateNilArg(t, newStore) })
 	t.Run("UpdateNilArg", func(t *testing.T) { testSnapshotUpdateNilArg(t, newStore) })
+	// Bug-021: nil = untouched / non-nil = replace / empty = clear.
+	// See annotation_contract.go.
+	t.Run("UpdateAnnotationContract", func(t *testing.T) { testSnapshotUpdateAnnotationContract(t, newStore) })
 	t.Run("CreateThenGet", func(t *testing.T) {
 		s := newStore(t).Snapshots()
 		ctx := t.Context()
@@ -592,6 +595,9 @@ func RunResourceStore(t *testing.T, newStore Factory) {
 	// deterministic order, every poll reorders the list and CSI
 	// pagination would skip / duplicate entries.
 	t.Run("ListSorted", func(t *testing.T) { testResourceListSorted(t, newStore) })
+	// Bug-021: nil = untouched / non-nil = replace / empty = clear.
+	// See annotation_contract.go.
+	t.Run("UpdateAnnotationContract", func(t *testing.T) { testResourceUpdateAnnotationContract(t, newStore) })
 	t.Run("CreateDuplicate", func(t *testing.T) {
 		s := newStore(t).Resources()
 		ctx := t.Context()
@@ -990,6 +996,9 @@ func RunResourceDefinitionStore(t *testing.T, newStore Factory) {
 			t.Errorf("Update(nil): want error, got nil")
 		}
 	})
+	// Bug-021: nil = untouched / non-nil = replace / empty = clear.
+	// See annotation_contract.go.
+	t.Run("UpdateAnnotationContract", func(t *testing.T) { testRDUpdateAnnotationContract(t, newStore) })
 	t.Run("UpdateChangesProps", func(t *testing.T) {
 		s := newStore(t).ResourceDefinitions()
 		ctx := t.Context()
@@ -1037,6 +1046,9 @@ func RunResourceGroupStore(t *testing.T, newStore Factory) {
 	t.Run("ListSorted", func(t *testing.T) { testRGListSorted(t, newStore) })
 	t.Run("CreateNilArg", func(t *testing.T) { testRGCreateNilArg(t, newStore) })
 	t.Run("UpdateNilArg", func(t *testing.T) { testRGUpdateNilArg(t, newStore) })
+	// Bug-021: nil = untouched / non-nil = replace / empty = clear.
+	// See annotation_contract.go.
+	t.Run("UpdateAnnotationContract", func(t *testing.T) { testRGUpdateAnnotationContract(t, newStore) })
 }
 
 func testRGCreateNilArg(t *testing.T, newStore Factory) {


### PR DESCRIPTION
## Problem

The `blockstor.io/rebalance-pending` RG annotation could never be removed in production: once the rebalance pass completed, the strip helper nil-ed the wire annotation map when it became empty, but the k8s store's annotation merge treats a nil wire map as "annotations untouched" (deliberately, to protect reconciler-stamped keys). The deletion therefore never reached the CRD and the rebalance pass re-fired on every RG event — observed as the annotation persisting indefinitely with constant placer churn. The InMemory store replaced rows wholesale, which is why unit tests never caught it. The `blockstor.io/spawn-shortfall` strip on RDs had the identical defect.

## Fix

- **Store contract made explicit and uniform**: on Update/Patch, a nil wire `Annotations` map means "leave stored annotations untouched"; a non-nil map — including an empty one — means "replace the user-annotation set with exactly this set". The k8s backend already behaved this way; the InMemory backend now carries stored annotations across nil wire maps in the RG, RD, Resource and Snapshot Update/Patch paths, so both backends are behaviourally identical. The contract is documented on the store interfaces.
- **Strip helpers fixed**: `stripRebalanceAnnotation` and `stripShortfallAnnotation` keep the emptied map non-nil so the deletion propagates. The wire JSON shape is unchanged (`annotations,omitempty` elides empty and nil alike).

## Tests

- **Store-contract pins** (`pkg/store/storetest`): `UpdateAnnotationContract` subtests cover all three transitions (nil = untouched, non-nil = replace, empty = clear) for RG, RD, Resource and Snapshot, and run against both backends. Red against the pre-fix InMemory store.
- **L1 envtest regression** (`internal/controller`): drives the real strip paths through the CRD-backed store against envtest and asserts the markers are gone from the CRD — a lone rebalance-pending annotation stripped via `Reconcile`, a multi-key strip that must keep sibling annotations, and the spawn-shortfall strip. The lone-marker specs fail without the fix.

Verified locally: `go test ./...`, `go test -race ./internal/controller/...` and `golangci-lint run` are clean; the operator-level integration pin `TestGroupKWFSpawnAndDependentReAutoplace` (PR #137 branch) goes red on main and green with this fix.