### PR TITLE
fix(controller): ghost tiebreaker witness re-created on a just-deleted node

### DIFF
--- a/internal/controller/ensure_tiebreaker_ghost_bug024_test.go
+++ b/internal/controller/ensure_tiebreaker_ghost_bug024_test.go
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	controllerpkg "github.com/cozystack/blockstor/internal/controller"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store"
+)
+
+// Bug-024 (release-gate, deadlock-class) — after `n lost` cascades a
+// 3-diskful RD down to 2 diskful, ensureTiebreaker re-created the
+// witness `<rd>.<lost-node>` `[DISKLESS TIE_BREAKER]` ON THE JUST-
+// DELETED NODE: the witness placement picked candidates from the
+// manager's lagging informer cache, and nothing ever reaped the
+// ghost (the node row is gone — no DeletionTimestamp event, no
+// finalizer pass). Deterministic on a warm process; observed >30s.
+//
+// The fix has two legs, both pinned here:
+//
+//  1. Placement guard: re-validate the chosen witness node against
+//     the authoritative reader right before the Create (the
+//     controller-side mirror of REST's Bug 174 node-deleted-race
+//     guard) and defer to the next reconcile on a miss.
+//  2. Repair leg: a witness Resource referencing a node that no
+//     longer exists is reaped by the reconciler — which also covers
+//     ghosts created before the fix.
+
+// staleListStore wraps an inner store and, while `stale` is true,
+// appends a phantom node to Nodes().List — modelling the lagging
+// informer cache that still serves a node `n lost` already deleted.
+// Get / every other call passes through to the inner (authoritative)
+// store, which is exactly the split the fix exploits.
+type staleListStore struct {
+	store.Store
+
+	stale *bool
+	ghost apiv1.Node
+}
+
+func (s *staleListStore) Nodes() store.NodeStore {
+	return &staleNodeLister{NodeStore: s.Store.Nodes(), stale: s.stale, ghost: s.ghost}
+}
+
+type staleNodeLister struct {
+	store.NodeStore
+
+	stale *bool
+	ghost apiv1.Node
+}
+
+func (l *staleNodeLister) List(ctx context.Context) ([]apiv1.Node, error) {
+	nodes, err := l.NodeStore.List(ctx)
+	if err != nil || !*l.stale {
+		return nodes, err
+	}
+
+	return append(nodes, l.ghost), nil
+}
+
+// TestBug024WitnessNeverCreatedOnDeletedNode pins the placement
+// guard. Topology: diskful on n1 + n2, one real spare (n3), and the
+// cached node list still serving the just-deleted "a-lost" (lex-
+// first, so the deterministic picker selects it). Pre-fix the
+// reconciler stamped the `[DISKLESS TIE_BREAKER]` ghost on a-lost;
+// post-fix the authoritative probe reports the node gone, the create
+// is deferred, and the next reconcile (fresh list) lands the witness
+// on the real spare.
+func TestBug024WitnessNeverCreatedOnDeletedNode(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	inner := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n2", "n3"} {
+		if err := inner.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := inner.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug024-guard", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	stale := true
+	st := &staleListStore{
+		Store: inner,
+		stale: &stale,
+		// "a-lost" sorts before "n3", so the picker WILL choose it
+		// off the stale list — the guard is the only thing standing
+		// between the pick and the ghost create.
+		ghost: apiv1.Node{Name: "a-lost", Type: apiv1.NodeTypeSatellite},
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug024-guard"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	// Pass 1: stale cache. The witness create must be DEFERRED, not
+	// land on the deleted node.
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker (stale pass): %v", err)
+	}
+
+	if _, err := inner.Resources().Get(ctx, "pvc-bug024-guard", "a-lost"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("Bug-024 regression: witness ghost created on deleted node a-lost (err=%v)", err)
+	}
+
+	// Pass 2: cache caught up. The witness converges onto the real
+	// spare — the deferral is a delay, not a permanent skip.
+	stale = false
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker (fresh pass): %v", err)
+	}
+
+	got, err := inner.Resources().Get(ctx, "pvc-bug024-guard", "n3")
+	if err != nil {
+		t.Fatalf("witness not created on healthy spare n3 after fresh list: %v", err)
+	}
+
+	if !slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("n3 replica must carry TIE_BREAKER; got %v", got.Flags)
+	}
+}
+
+// TestBug024GhostWitnessOnMissingNodeIsReaped pins the repair leg:
+// a pre-existing `[DISKLESS TIE_BREAKER]` row referencing a node
+// with no Node object (the exact artifact pre-fix processes left
+// behind, or a crash between `n lost`'s node delete and the
+// cascade) must be reaped, and the fresh witness must land on a
+// healthy spare. The diskful pair must never be touched.
+func TestBug024GhostWitnessOnMissingNodeIsReaped(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	// n1, n2 host diskful; n3 is the healthy spare. NOTE: no node
+	// row exists for "w-gone" — the witness below is a ghost.
+	for _, n := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	for _, n := range []string{"n1", "n2"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug024-reap", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	if err := st.Resources().Create(ctx, &apiv1.Resource{
+		Name: "pvc-bug024-reap", NodeName: "w-gone",
+		Flags: []string{apiv1.ResourceFlagDiskless, apiv1.ResourceFlagTieBreaker},
+	}); err != nil {
+		t.Fatalf("seed ghost witness: %v", err)
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug024-reap"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// 1. The ghost is reaped.
+	if _, err := st.Resources().Get(ctx, "pvc-bug024-reap", "w-gone"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("ghost witness on missing node w-gone must be reaped (err=%v)", err)
+	}
+
+	// 2. A fresh witness lands on the healthy spare (diskful==2, so
+	// the witness invariant still wants one).
+	got, err := st.Resources().Get(ctx, "pvc-bug024-reap", "n3")
+	if err != nil {
+		t.Fatalf("fresh witness not created on n3: %v", err)
+	}
+
+	if !slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("n3 replica must carry TIE_BREAKER; got %v", got.Flags)
+	}
+
+	// 3. The diskful pair is untouched — a healthy replica is never
+	// demoted or deleted by the repair leg.
+	for _, n := range []string{"n1", "n2"} {
+		diskful, err := st.Resources().Get(ctx, "pvc-bug024-reap", n)
+		if err != nil {
+			t.Fatalf("diskful %s vanished: %v", n, err)
+		}
+
+		if slices.Contains(diskful.Flags, apiv1.ResourceFlagDiskless) {
+			t.Errorf("diskful %s demoted: %v", n, diskful.Flags)
+		}
+	}
+}
+
+// TestBug024GhostDiskfulExcludedFromCountButNotDeleted pins the
+// boundary of the repair leg: a DISKFUL replica on a missing node
+// (mid-flight `n lost` cascade) is excluded from the voting count —
+// so a 3-diskful RD that lost a node behaves as 2-diskful and grows
+// a witness on the spare — but the row itself is NOT deleted here;
+// the cascade owns diskful teardown.
+func TestBug024GhostDiskfulExcludedFromCountButNotDeleted(t *testing.T) {
+	t.Parallel()
+
+	scheme := newScheme(t)
+	st := store.NewInMemory()
+	ctx := context.Background()
+
+	for _, n := range []string{"n1", "n2", "n3"} {
+		if err := st.Nodes().Create(ctx, &apiv1.Node{
+			Name: n, Type: apiv1.NodeTypeSatellite,
+		}); err != nil {
+			t.Fatalf("seed node %s: %v", n, err)
+		}
+	}
+
+	// 3 diskful, but "lost-n"'s node row is already gone.
+	for _, n := range []string{"n1", "n2", "lost-n"} {
+		if err := st.Resources().Create(ctx, &apiv1.Resource{
+			Name: "pvc-bug024-diskful", NodeName: n,
+		}); err != nil {
+			t.Fatalf("seed diskful %s: %v", n, err)
+		}
+	}
+
+	rd := &blockstoriov1alpha1.ResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-bug024-diskful"},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rd).Build()
+
+	rec := &controllerpkg.ResourceDefinitionReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Store:  st,
+	}
+
+	if err := rec.EnsureTiebreaker(ctx, rd); err != nil {
+		t.Fatalf("EnsureTiebreaker: %v", err)
+	}
+
+	// The stranded diskful survives — its teardown belongs to the
+	// `n lost` cascade, not the witness invariant.
+	if _, err := st.Resources().Get(ctx, "pvc-bug024-diskful", "lost-n"); err != nil {
+		t.Errorf("stranded diskful must NOT be reaped by the witness pass: %v", err)
+	}
+
+	// Voting count is 2 → the invariant grows a witness on n3.
+	got, err := st.Resources().Get(ctx, "pvc-bug024-diskful", "n3")
+	if err != nil {
+		t.Fatalf("witness not created on n3 (ghost diskful still counted as live?): %v", err)
+	}
+
+	if !slices.Contains(got.Flags, apiv1.ResourceFlagTieBreaker) {
+		t.Errorf("n3 replica must carry TIE_BREAKER; got %v", got.Flags)
+	}
+}

--- a/internal/controller/resourcedefinition_controller.go
+++ b/internal/controller/resourcedefinition_controller.go
@@ -234,14 +234,9 @@ func (r *ResourceDefinitionReconciler) ensureTiebreaker(ctx context.Context, rd 
 	// only. Stranded witnesses are reaped explicitly below so a fresh one
 	// can land on a healthy spare (or quorum falls to off when none
 	// remains) — never by demoting a healthy diskful to TIE_BREAKER.
-	disabled, err := r.disabledNodeSet(ctx)
-	if err != nil {
-		return err
-	}
-
-	live, stranded := splitByDisabledNode(replicas, disabled)
-
-	err = r.removeStrandedWitnesses(ctx, rd.Name, stranded)
+	// Bug-024 extends the same treatment to replicas whose node row is
+	// gone entirely (ghost witnesses left behind by `n lost`).
+	live, err := r.dropStrandedReplicas(ctx, rd.Name, replicas)
 	if err != nil {
 		return err
 	}
@@ -795,6 +790,29 @@ func (r *ResourceDefinitionReconciler) createWitness(ctx context.Context, rd *bl
 		return nil
 	}
 
+	// Bug-024 placement guard: the candidate list above comes from
+	// Store.Nodes().List, which in production reads the manager's
+	// informer cache — after `n lost` deletes a node, the lagging
+	// cache re-offers it for tens to hundreds of ms and the Create
+	// below would stamp a `[DISKLESS TIE_BREAKER]` ghost on the
+	// just-deleted node (nothing reaps it: no DeletionTimestamp
+	// event, no finalizer). Re-validate the pick against the
+	// authoritative reader right before the write — the same shape
+	// as the REST layer's Bug 174 node-deleted-race guard. On a miss
+	// (or a freshly-stamped drain flag) skip this pass; the standing
+	// rdReconcileRequeue retries with a fresh candidate list.
+	probe, err := r.probeNodeDirect(ctx, tiebreakerNode)
+	if err != nil {
+		return err
+	}
+
+	if !probe.found || probe.drained {
+		logf.FromContext(ctx).Info("witness candidate vanished or drained; deferring witness create",
+			"rd", rd.Name, "node", tiebreakerNode, "found", probe.found)
+
+		return nil
+	}
+
 	newWitness := apiv1.Resource{
 		Name:     rd.Name,
 		NodeName: tiebreakerNode,
@@ -808,7 +826,29 @@ func (r *ResourceDefinitionReconciler) createWitness(ctx context.Context, rd *bl
 
 	r.rollbackWitnessIfRDGone(ctx, rd.Name, tiebreakerNode)
 
+	// Bug-024, post-write half (mirrors Bug 174's two-sided close):
+	// the node can vanish between the pre-write probe and the Create.
+	// Re-probe and roll the witness back if the node is gone — the
+	// next reconcile re-picks from a fresh list. Best-effort like
+	// rollbackWitnessIfRDGone: a failed rollback is caught by the
+	// repair leg (dropStrandedReplicas) on the next pass.
+	r.rollbackWitnessIfNodeGone(ctx, rd.Name, tiebreakerNode)
+
 	return nil
+}
+
+// rollbackWitnessIfNodeGone deletes the just-created witness when its
+// host node no longer exists per the authoritative reader. Swallows
+// every error: the witness Create already succeeded, and the ghost-
+// repair leg in dropStrandedReplicas reaps whatever slips through on
+// the next reconcile.
+func (r *ResourceDefinitionReconciler) rollbackWitnessIfNodeGone(ctx context.Context, rdName, witnessNode string) {
+	probe, err := r.probeNodeDirect(ctx, witnessNode)
+	if err != nil || probe.found {
+		return
+	}
+
+	_ = r.Store.Resources().Delete(ctx, rdName, witnessNode)
 }
 
 // rollbackWitnessIfRDGone probes the parent RD via the APIReader
@@ -1227,27 +1267,199 @@ func isDisabledNode(node *apiv1.Node) bool {
 	return false
 }
 
-// disabledNodeSet returns the set of node names flagged EVICTED / LOST.
-// Bug 385: the RD-level witness / quorum decision must treat replicas on
-// these nodes as draining placements, not live ones — mirroring the
-// placer's `disabledNodes` semantic. Re-probed from the store on every
-// reconcile so a freshly-stamped EVICTED flag takes effect on the next
-// witness pass.
-func (r *ResourceDefinitionReconciler) disabledNodeSet(ctx context.Context) (map[string]struct{}, error) {
-	nodes, err := r.Store.Nodes().List(ctx)
+// dropStrandedReplicas reduces the RD's replica snapshot to the live
+// voting set and reaps stranded witnesses along the way. Two classes
+// of replica are excluded:
+//
+//   - Bug 385: replicas hosted on EVICTED / LOST nodes — draining
+//     placements, not live voters.
+//   - Bug-024: replicas whose Node row no longer exists at all (e.g.
+//     a TIE_BREAKER ghost stamped on a node that `n lost` just
+//     deleted — nothing else ever reaps it: the node object is gone,
+//     so there is no DeletionTimestamp event and no finalizer pass).
+//     Absence is confirmed against the authoritative reader (direct
+//     read, not the informer cache) so a momentarily-lagging cache
+//     can't trigger a wrongful reap.
+//
+// TIE_BREAKER rows in either class are deleted via
+// removeStrandedWitnesses so a fresh witness can land on a healthy
+// spare; stranded diskful replicas are left alone (relocating those
+// is the NodeReconciler's job) but still excluded from the count.
+func (r *ResourceDefinitionReconciler) dropStrandedReplicas(
+	ctx context.Context,
+	rdName string,
+	replicas []apiv1.Resource,
+) ([]apiv1.Resource, error) {
+	disabled, known, err := r.nodeSets(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	live, stranded := splitByDisabledNode(replicas, disabled)
+
+	live, ghosts, err := r.confirmGhostReplicas(ctx, live, known)
+	if err != nil {
+		return nil, err
+	}
+
+	stranded = append(stranded, ghosts...)
+
+	err = r.removeStrandedWitnesses(ctx, rdName, stranded)
+	if err != nil {
+		return nil, err
+	}
+
+	return live, nil
+}
+
+// nodeSets returns (disabled, known): the set of node names flagged
+// EVICTED / LOST and the set of ALL node names the store currently
+// lists. Bug 385: the RD-level witness / quorum decision must treat
+// replicas on disabled nodes as draining placements, not live ones —
+// mirroring the placer's `disabledNodes` semantic. Bug-024 extends
+// the same idea to nodes that are gone entirely: a replica whose
+// node is absent from `known` is a ghost candidate (confirmed
+// against the authoritative reader in confirmGhostReplicas before
+// any reap). Re-probed from the store on every reconcile so a
+// freshly-stamped flag — or a freshly-deleted node — takes effect on
+// the next witness pass.
+func (r *ResourceDefinitionReconciler) nodeSets(ctx context.Context) (map[string]struct{}, map[string]struct{}, error) {
+	nodes, err := r.Store.Nodes().List(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	disabled := make(map[string]struct{})
+	known := make(map[string]struct{}, len(nodes))
 
 	for i := range nodes {
+		known[nodes[i].Name] = struct{}{}
+
 		if isDisabledNode(&nodes[i]) {
 			disabled[nodes[i].Name] = struct{}{}
 		}
 	}
 
-	return disabled, nil
+	return disabled, known, nil
+}
+
+// confirmGhostReplicas partitions `replicas` into (live, ghosts):
+// a ghost is a replica whose node is missing from the cached `known`
+// set AND confirmed absent by the authoritative reader. The double
+// check matters in both directions — the informer cache can lag the
+// apiserver, so `known` alone could briefly miss a real node (which
+// must NOT get its witness reaped), while the cache can also still
+// serve a node `n lost` already deleted (the Bug-024 ghost-create
+// source, handled separately in createWitness).
+func (r *ResourceDefinitionReconciler) confirmGhostReplicas(
+	ctx context.Context,
+	replicas []apiv1.Resource,
+	known map[string]struct{},
+) ([]apiv1.Resource, []apiv1.Resource, error) {
+	var live, ghosts []apiv1.Resource
+
+	for i := range replicas {
+		if _, ok := known[replicas[i].NodeName]; ok {
+			live = append(live, replicas[i])
+
+			continue
+		}
+
+		probe, err := r.probeNodeDirect(ctx, replicas[i].NodeName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if probe.found {
+			// Cached list lagged a just-created node; the replica is
+			// real. Never reap on a stale negative.
+			live = append(live, replicas[i])
+
+			continue
+		}
+
+		ghosts = append(ghosts, replicas[i])
+	}
+
+	return live, ghosts, nil
+}
+
+// linstorNameAnnotation mirrors pkg/store/k8s.AnnotationLinstorName.
+// The literal is duplicated (same pattern as snapshotGroupIDLabel in
+// snapshot_controller.go) to avoid a controller→store/k8s dependency.
+// Node CRDs whose LINSTOR name needed slugifying carry the original
+// wire name here; probeNodeDirect matches against both spellings.
+const linstorNameAnnotation = "blockstor.io/linstor-name"
+
+// nodeProbe is the answer probeNodeDirect returns about a node's
+// authoritative state.
+type nodeProbe struct {
+	// found reports the node row exists.
+	found bool
+	// drained reports an EVICTED / LOST drain flag on the found node.
+	drained bool
+}
+
+// probeNodeDirect answers "does this node exist right NOW, and is it
+// usable as a witness host?" against the authoritative source rather
+// than the manager's informer cache. Bug-024: the witness-placement
+// candidate list comes from Store.Nodes().List, which in production
+// is backed by the cached client and trails the apiserver — after
+// `n lost` deletes a node, the lagging cache happily re-offers it
+// and the controller would stamp a `[DISKLESS TIE_BREAKER]` ghost on
+// the just-deleted node. Mirrors the REST layer's Bug 174 node-
+// deleted-race guard (pkg/rest/autoplace.go::
+// refuseResourceCreateOnNodeDeletedRace), which re-validates the
+// pinned node against the store right after the write.
+//
+// Production path: APIReader (direct apiserver reads, no cache).
+// LINSTOR node names are matched case-insensitively against both the
+// CRD name and the preserved original-name annotation, the same
+// resolution pkg/store/k8s applies. Unit tests construct the
+// reconciler without APIReader — the Store fallback is authoritative
+// there (InMemory has no cache to lag).
+func (r *ResourceDefinitionReconciler) probeNodeDirect(ctx context.Context, wireName string) (nodeProbe, error) {
+	if r.APIReader == nil {
+		node, err := r.Store.Nodes().Get(ctx, wireName)
+		if stderrors.Is(err, store.ErrNotFound) {
+			return nodeProbe{}, nil
+		}
+
+		if err != nil {
+			return nodeProbe{}, err
+		}
+
+		return nodeProbe{found: true, drained: isDisabledNode(&node)}, nil
+	}
+
+	var list blockstoriov1alpha1.NodeList
+	if err := r.APIReader.List(ctx, &list); err != nil {
+		return nodeProbe{}, err
+	}
+
+	for i := range list.Items {
+		if !nodeCRDMatchesWireName(&list.Items[i], wireName) {
+			continue
+		}
+
+		return nodeProbe{found: true, drained: nodeHasDrainFlag(&list.Items[i])}, nil
+	}
+
+	return nodeProbe{}, nil
+}
+
+// nodeCRDMatchesWireName reports whether a Node CRD addresses the
+// given LINSTOR wire name: either directly via metadata.name or via
+// the preserved original-name annotation (slugified names). LINSTOR
+// identifiers are case-insensitive, so both comparisons fold case.
+func nodeCRDMatchesWireName(node *blockstoriov1alpha1.Node, wireName string) bool {
+	if strings.EqualFold(node.Name, wireName) {
+		return true
+	}
+
+	original, ok := node.Annotations[linstorNameAnnotation]
+
+	return ok && strings.EqualFold(original, wireName)
 }
 
 // splitByDisabledNode partitions replicas into (live, stranded) by the
@@ -1506,7 +1718,14 @@ func nodeDrainFlagChanged() predicate.Predicate {
 
 			return nodeHasDrainFlag(oldNode) != nodeHasDrainFlag(newNode)
 		},
-		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		// Bug-024: a node DELETE is the strongest drain signal there
+		// is — `n lost` removes the Node row outright. Re-running the
+		// witness invariant on it lets the ghost-repair leg
+		// (dropStrandedReplicas) reap a TIE_BREAKER stranded on the
+		// deleted node as soon as the event lands instead of waiting
+		// for the periodic requeue. Node deletion is rare, so the
+		// all-RD fan-out stays cheap.
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}
 }


### PR DESCRIPTION
## Problem

After `node lost` cascades a 3-diskful RD down to 2 diskful, `ensureTiebreaker` re-created the witness `<rd>.<lost-node>` `[DISKLESS TIE_BREAKER]` on the node that was just deleted: the witness placement picks candidates from the manager's lagging informer cache, which still serves the deleted node for a short window. Nothing ever reaped the ghost — the node object is gone, so there is no DeletionTimestamp event and no finalizer pass. Deterministic on a warm process; deadlock-class.

The REST layer already guards the equivalent race on `r c` (the Bug 174 node-deleted post-write re-check); the controller-side witness create lacked it.

## Fix

Both legs, mirroring the REST guard's shape on the controller side:

- **Placement guard**: the chosen witness node is re-validated against the authoritative reader (direct apiserver read, not the cache) right before the Create, and re-checked right after it. On a miss (or a freshly-stamped drain flag) the create is deferred to the next reconcile, which re-picks from a fresh list; a witness whose node vanished mid-write is rolled back.
- **Repair leg**: replicas whose node row no longer exists are treated like EVICTED/LOST placements — excluded from the diskful/diskless voting count, and TIE_BREAKER rows are reaped so a fresh witness lands on a healthy spare. This also cleans up ghosts created before the fix. Absence is confirmed authoritatively before any reap, so a lagging cache can never trigger a wrongful one. Stranded diskful replicas are excluded from the count but never deleted here — their teardown belongs to the lost-node cascade.

Node deletions now also re-enqueue the witness invariant through the existing node watch, so the repair runs event-driven instead of waiting for the periodic requeue.

## Tests

L1 regression tests pin both legs and the boundary: a stale cached list offering a deleted node never produces a ghost (and the witness converges on the healthy spare once the list is fresh); a pre-existing ghost witness on a missing node is reaped and replaced; a stranded diskful on a missing node is excluded from the count but not deleted. All three fail without the fix. The full `ensure_tiebreaker` suite (witness-iff-diskful==2 and friends) stays green.

Verified locally: `go test ./...`, `go test -race ./internal/controller/...` and `golangci-lint run` are clean; the operator-level integration pin `TestGroupKWFNodeLostCascade` (PR #137 branch) goes red on main and green with this fix.