### PR TITLE
fix(e2e): make rwx-ganesha dump_diag actually capture the failure surface

### DIFF
--- a/tests/e2e/rwx-ganesha.sh
+++ b/tests/e2e/rwx-ganesha.sh
@@ -78,12 +78,52 @@ dump_diag() {
     echo "----- diag ($label): linstor-csi-controller log tail -----" >&2
     kubectl -n piraeus-datastore logs deploy/linstor-csi-controller \
         -c linstor-csi --tail=80 2>&1 >&2 || true
-    echo "----- diag ($label): linstor-csi-node logs (per worker) -----" >&2
-    kubectl -n piraeus-datastore logs ds/linstor-csi-node \
-        -c linstor-csi --tail=80 --prefix=true 2>&1 >&2 || true
-    echo "----- diag ($label): linstor r l (via blockstor controller) -----" >&2
-    kubectl -n blockstor-system exec deploy/blockstor-controller -- \
-        linstor r l 2>&1 >&2 || true
+    # `kubectl logs ds/...` follows only ONE pod ("Found 3 pods, using
+    # pod/..."), hiding the workers that actually hit the failure. Loop
+    # over every pod explicitly, all containers.
+    echo "----- diag ($label): linstor-csi-node logs (every pod, all containers) -----" >&2
+    for pod in $(kubectl -n piraeus-datastore get pods \
+            -l app.kubernetes.io/component=linstor-csi-node \
+            -o name 2>/dev/null); do
+        echo "--- $pod ---" >&2
+        kubectl -n piraeus-datastore logs "$pod" --all-containers \
+            --prefix --tail=80 2>&1 >&2 || true
+    done
+    # The NFS-Ganesha export pods and their in-pod drbd-reactor promoter
+    # are the usual suspects when consumers see `mount.nfs: Connection
+    # refused`: if the promoter never promotes the backing DRBD resource,
+    # ganesha never starts listening on any of them.
+    echo "----- diag ($label): linstor-csi-nfs-server logs (every pod, all containers) -----" >&2
+    for pod in $(kubectl -n piraeus-datastore get pods \
+            -l app.kubernetes.io/component=linstor-csi-nfs-server \
+            -o name 2>/dev/null); do
+        echo "--- $pod ---" >&2
+        kubectl -n piraeus-datastore logs "$pod" --all-containers \
+            --prefix --tail=120 2>&1 >&2 || true
+    done
+    echo "----- diag ($label): drbd-reactor promoter ConfigMap -----" >&2
+    kubectl -n piraeus-datastore get cm linstor-csi-nfs-server-reactor-config \
+        -o yaml 2>&1 >&2 || true
+    echo "----- diag ($label): EndpointSlices for svc linstor-csi-nfs -----" >&2
+    kubectl -n piraeus-datastore get endpointslices \
+        -l kubernetes.io/service-name=linstor-csi-nfs -o yaml 2>&1 >&2 || true
+    # blockstor-side view of the volume. The previous shape exec'd
+    # `linstor r l` inside the blockstor-controller image, which ships no
+    # `linstor` binary — that dump always died with "executable file not
+    # found in \$PATH". The blockstor CRDs carry the same RD/Resource
+    # state without needing any in-pod binary or a port-forward.
+    echo "----- diag ($label): blockstor RD + Resource CRDs -----" >&2
+    kubectl get resourcedefinitions.blockstor.cozystack.io 2>&1 >&2 || true
+    if [[ -n "${PV:-}" ]]; then
+        kubectl get "resourcedefinitions.blockstor.cozystack.io/$PV" \
+            -o yaml 2>&1 >&2 || true
+        for res in $(kubectl get resources.blockstor.cozystack.io \
+                -o name 2>/dev/null | grep -F "$PV" || true); do
+            kubectl get "$res" -o yaml 2>&1 >&2 || true
+        done
+    else
+        kubectl get resources.blockstor.cozystack.io 2>&1 >&2 || true
+    fi
 }
 
 cleanup() {


### PR DESCRIPTION
## What

Hardens the `dump_diag` helper in the `rwx-ganesha` e2e scenario so a failing run captures the state needed for triage on the first attempt. Diagnostics only — no timeout or assertion changes.

## Why

During triage of the intermittent rwx-ganesha CI failures the existing diagnostics had three blind spots:

- The blockstor-side dump ran `linstor r l` via `kubectl exec` inside the blockstor-controller image, which ships no `linstor` binary, so that section always failed with `executable file not found in $PATH`. It now reads the blockstor ResourceDefinition / Resource CRDs instead — same state, no in-pod binary or port-forward needed.
- `kubectl logs ds/linstor-csi-node` prints only one pod of the DaemonSet ("Found 3 pods, using pod/..."), hiding the workers that actually hit the failure. The dump now loops over every linstor-csi-node pod, all containers.
- The NFS-Ganesha publish side was invisible. The dump now includes every linstor-csi-nfs-server pod log (all containers), the drbd-reactor promoter ConfigMap, and the EndpointSlices of the `linstor-csi-nfs` Service — the pieces that show whether the promoter ever promoted the backing DRBD resource and whether the Service had a ready backend.

For the volume under test the dump also prints the full RD and per-node Resource CRDs, so the DRBD-side placement and state are visible without re-running the scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced diagnostic logging in end-to-end tests for improved troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->