### PR TITLE
fix(rest): retry on store conflict in read-modify-write handlers

### DIFF
--- a/pkg/rest/autoplace.go
+++ b/pkg/rest/autoplace.go
@@ -1556,11 +1556,18 @@ func (s *Server) createOneResource(w http.ResponseWriter, r *http.Request, rdNam
 	// Persist onto rd.LayerStack if not already set so the satellite
 	// reconciler sees the right composition.
 	if len(env.LayerList) > 0 {
-		rd, getErr := s.Store.ResourceDefinitions().Get(r.Context(), rdName)
-		if getErr == nil && len(rd.LayerStack) == 0 {
-			rd.LayerStack = append([]string(nil), env.LayerList...)
-			_ = s.Store.ResourceDefinitions().Update(r.Context(), &rd)
-		}
+		// Bug 204b shape: typed-Patch with retry-on-conflict; the
+		// "only if unset" guard re-runs against the live RD on every
+		// retry so a concurrent reconciler write can't surface a 409
+		// (and a concurrent LayerStack set isn't clobbered).
+		_ = s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(r.Context(), rdName,
+			func(rd *apiv1.ResourceDefinition) error {
+				if len(rd.LayerStack) == 0 {
+					rd.LayerStack = append([]string(nil), env.LayerList...)
+				}
+
+				return nil
+			})
 	}
 
 	// Bug 327 (P1, recurring — reported 5×): a bare `linstor r c <node>
@@ -2514,10 +2521,20 @@ func (s *Server) handleResourceMakeAvailable(w http.ResponseWriter, r *http.Requ
 
 	// Pass-through for CSI-supplied layer_list, identical to the
 	// autoplace / explicit-create flows. RD-level LayerStack wins.
+	//
+	// Bug 204b shape: typed-Patch with retry-on-conflict; the "only
+	// if unset" guard re-runs against the live RD on every retry so
+	// a concurrent reconciler write can't surface a 409 to the
+	// make-available caller.
 	if len(req.LayerList) > 0 && len(rd.LayerStack) == 0 {
-		rd.LayerStack = append([]string(nil), req.LayerList...)
+		err = s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(r.Context(), rdName,
+			func(live *apiv1.ResourceDefinition) error {
+				if len(live.LayerStack) == 0 {
+					live.LayerStack = append([]string(nil), req.LayerList...)
+				}
 
-		err = s.Store.ResourceDefinitions().Update(r.Context(), &rd)
+				return nil
+			})
 		if err != nil {
 			writeStoreError(w, err)
 

--- a/pkg/rest/drbd_passphrase.go
+++ b/pkg/rest/drbd_passphrase.go
@@ -55,20 +55,20 @@ func (s *Server) handleDRBDPassphraseSet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	rd, err := s.Store.ResourceDefinitions().Get(r.Context(), rdName)
-	if err != nil {
-		writeStoreError(w, err)
+	// Bug 204b shape: typed-Patch with retry-on-conflict so a
+	// reconciler write on the RD between the read and the write
+	// re-applies the secret onto fresh state instead of surfacing
+	// a 409 to the operator.
+	err := s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(r.Context(), rdName,
+		func(rd *apiv1.ResourceDefinition) error {
+			if rd.Props == nil {
+				rd.Props = map[string]string{}
+			}
 
-		return
-	}
+			rd.Props[drbdSharedSecretKey] = req.Passphrase
 
-	if rd.Props == nil {
-		rd.Props = map[string]string{}
-	}
-
-	rd.Props[drbdSharedSecretKey] = req.Passphrase
-
-	err = s.Store.ResourceDefinitions().Update(r.Context(), &rd)
+			return nil
+		})
 	if err != nil {
 		writeStoreError(w, err)
 

--- a/pkg/rest/node_lifecycle.go
+++ b/pkg/rest/node_lifecycle.go
@@ -620,24 +620,25 @@ func (s *Server) cascadeOrphansForLostNode(ctx context.Context, name string) err
 	return nil
 }
 
-// updateNodeFlags loads the Node, applies each mutator, and persists.
-// Common shape across all three endpoints; lives here so the handler
-// bodies stay one-line.
+// updateNodeFlags applies each mutator to the Node's flag list and
+// persists. Common shape across all three endpoints; lives here so the
+// handler bodies stay one-line.
+//
+// Bug 205 shape: routed through PatchNodeSpec so a satellite Hello /
+// reconciler write landing between the read and the write re-runs the
+// flag mutation against fresh state under RetryOnConflict instead of
+// leaking a 409 to the operator (same conflict class as the
+// activate/deactivate release-gate flake on mutateResourceFlag).
 func updateNodeFlags(w http.ResponseWriter, r *http.Request, s *Server, mutators ...func([]string) []string) {
 	name := r.PathValue("node")
 
-	node, err := s.Store.Nodes().Get(r.Context(), name)
-	if err != nil {
-		writeStoreError(w, err)
+	err := s.Store.Nodes().PatchNodeSpec(r.Context(), name, func(node *apiv1.Node) error {
+		for _, m := range mutators {
+			node.Flags = m(node.Flags)
+		}
 
-		return
-	}
-
-	for _, m := range mutators {
-		node.Flags = m(node.Flags)
-	}
-
-	err = s.Store.Nodes().Update(r.Context(), &node)
+		return nil
+	})
 	if err != nil {
 		writeStoreError(w, err)
 

--- a/pkg/rest/nodes.go
+++ b/pkg/rest/nodes.go
@@ -573,7 +573,16 @@ func (s *Server) upsertNodeAndDiskless(w http.ResponseWriter, r *http.Request, n
 	case err == nil:
 		// fresh create — normal path
 	case errors.Is(err, store.ErrAlreadyExists):
-		err = s.Store.Nodes().Update(r.Context(), n)
+		// Bug 205 shape: the re-register replace is routed through
+		// PatchNodeSpec so a satellite Hello / reconciler write
+		// landing between the AlreadyExists probe and the persist
+		// re-applies the wire snapshot under RetryOnConflict
+		// instead of leaking a 409 into the registration loop.
+		err = s.Store.Nodes().PatchNodeSpec(r.Context(), n.Name, func(live *apiv1.Node) error {
+			*live = *n
+
+			return nil
+		})
 		if err != nil {
 			writeStoreError(w, err)
 
@@ -913,9 +922,14 @@ func (s *Server) handleNodeUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if patch.NodeType != "" && patch.NodeType != existing.Type {
-		existing.Type = patch.NodeType
+		// Bug 205 shape: typed-Patch with retry-on-conflict so a
+		// concurrent satellite Hello / reconciler write can't bounce
+		// the rare node_type toggle with a 409.
+		err = s.Store.Nodes().PatchNodeSpec(r.Context(), name, func(live *apiv1.Node) error {
+			live.Type = patch.NodeType
 
-		err = s.Store.Nodes().Update(r.Context(), &existing)
+			return nil
+		})
 		if err != nil {
 			writeStoreError(w, err)
 

--- a/pkg/rest/rd_clone.go
+++ b/pkg/rest/rd_clone.go
@@ -446,22 +446,24 @@ func (s *Server) applyClonePropEdits(ctx context.Context, req *rdCloneRequest) e
 		return nil
 	}
 
-	rd, err := s.Store.ResourceDefinitions().Get(ctx, req.Name)
-	if err != nil {
-		return err //nolint:wrapcheck // message wrapped by the caller's envelope
-	}
+	// Bug 204b shape: typed-Patch with retry-on-conflict so the
+	// freshly-materialised clone target's reconciler can't race this
+	// prop fold-in into a 409 (the edits re-apply to fresh state).
+	//nolint:wrapcheck // message wrapped by the caller's envelope
+	return s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(ctx, req.Name,
+		func(rd *apiv1.ResourceDefinition) error {
+			if rd.Props == nil {
+				rd.Props = make(map[string]string, len(req.OverrideProps))
+			}
 
-	if rd.Props == nil {
-		rd.Props = make(map[string]string, len(req.OverrideProps))
-	}
+			maps.Copy(rd.Props, req.OverrideProps)
 
-	maps.Copy(rd.Props, req.OverrideProps)
+			for _, k := range req.DeleteProps {
+				delete(rd.Props, k)
+			}
 
-	for _, k := range req.DeleteProps {
-		delete(rd.Props, k)
-	}
-
-	return s.Store.ResourceDefinitions().Update(ctx, &rd) //nolint:wrapcheck // message wrapped by the caller's envelope
+			return nil
+		})
 }
 
 // writeCloneRefused stamps a clone refusal in the CloneStarted OBJECT

--- a/pkg/rest/resource_adjust.go
+++ b/pkg/rest/resource_adjust.go
@@ -145,6 +145,16 @@ func (s *Server) handleResourceDeactivate(w http.ResponseWriter, r *http.Request
 // deactivate. set=true adds the flag; set=false removes every
 // occurrence. Idempotent.
 //
+// Routed through PatchResourceSpec (Bug 204b shape) so a controller
+// reconciler writing the same Resource CRD between the read and the
+// write cannot surface a 409 to the operator: the store re-fetches
+// the live object and re-applies the flag mutation under
+// RetryOnConflict with backoff. Upstream LINSTOR never returns 409
+// on activate/deactivate and the Python CLI does not retry it — the
+// pre-fix Get → mutate → Update shape leaked the optimistic-lock
+// conflict straight onto the wire (release-gate
+// TestGroupFRActivateDeactivate flake).
+//
 // Responds with an `[]ApiCallRc` envelope (Bug 45): golinstor's
 // response parser calls `json.Unmarshal` against this shape
 // unconditionally and fails with "Unable to parse REST json data:
@@ -155,16 +165,12 @@ func mutateResourceFlag(w http.ResponseWriter, r *http.Request, s *Server, flag 
 	rdName := r.PathValue("rd")
 	node := r.PathValue("node")
 
-	res, err := s.Store.Resources().Get(r.Context(), rdName, node)
-	if err != nil {
-		writeStoreError(w, err)
+	err := s.Store.Resources().PatchResourceSpec(r.Context(), rdName, node,
+		func(res *apiv1.Resource) error {
+			res.Flags = applyFlagMutation(res.Flags, flag, set)
 
-		return
-	}
-
-	res.Flags = applyFlagMutation(res.Flags, flag, set)
-
-	err = s.Store.Resources().Update(r.Context(), &res)
+			return nil
+		})
 	if err != nil {
 		writeStoreError(w, err)
 

--- a/pkg/rest/resource_adjust_conflict_test.go
+++ b/pkg/rest/resource_adjust_conflict_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	crdv1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
+	"github.com/cozystack/blockstor/pkg/store/k8s"
+)
+
+// Release-gate regression (TestGroupFRActivateDeactivate, CI job
+// 81060268741): `POST .../resources/{node}/activate` answered
+// `409 conflict: store object was modified, retry the request` when a
+// controller reconciler updated the Resource CRD between the
+// handler's read and write. Upstream LINSTOR never returns 409 on
+// activate/deactivate and the Python CLI does not retry it, so the
+// conflict leaked straight to the operator and failed the suite.
+//
+// The fixture below reproduces the race deterministically against the
+// CRD-backed store: a fake-client interceptor performs an out-of-band
+// "reconciler" write on the same Resource CRD immediately before the
+// handler's first persist attempt, so the optimistic-lock write is
+// guaranteed stale. The handler must absorb the conflict via the
+// store's retry-on-conflict patch path and answer 200; the
+// reconciler's concurrent write must survive (no lost update).
+func TestActivateDeactivateRetriesOnStoreConflict(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		action    string
+		seedFlags []string
+		wantFlag  bool // INACTIVE present after the call
+	}{
+		{action: "activate", seedFlags: []string{"INACTIVE"}, wantFlag: false},
+		{action: "deactivate", seedFlags: nil, wantFlag: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
+			t.Parallel()
+
+			cli, injected := newConflictInjectingResourceClient(t)
+			st := k8s.New(cli)
+			ctx := t.Context()
+
+			if err := st.Resources().Create(ctx, &apiv1.Resource{
+				Name:     "pvc-conflict",
+				NodeName: "n1",
+				Flags:    tc.seedFlags,
+			}); err != nil {
+				t.Fatalf("seed Resource: %v", err)
+			}
+
+			base, stop := startServerWithStore(t, st)
+			defer stop()
+
+			resp := httpPost(t,
+				base+"/v1/resource-definitions/pvc-conflict/resources/n1/"+tc.action, nil)
+			defer func() { _ = resp.Body.Close() }()
+
+			if !injected.Load() {
+				t.Fatalf("fixture rot: no conflicting write was injected — the test proves nothing")
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status: got %d, want 200 — the handler leaked the store conflict to the operator", resp.StatusCode)
+			}
+
+			var rc []apiv1.APICallRc
+
+			if err := json.NewDecoder(resp.Body).Decode(&rc); err != nil {
+				t.Fatalf("decode envelope: %v", err)
+			}
+
+			if len(rc) == 0 || rc[0].RetCode < 0 {
+				t.Fatalf("envelope: got %+v, want non-empty MASK_INFO success", rc)
+			}
+
+			got, err := st.Resources().Get(ctx, "pvc-conflict", "n1")
+			if err != nil {
+				t.Fatalf("Get after %s: %v", tc.action, err)
+			}
+
+			if gotFlag := slices.Contains(got.Flags, "INACTIVE"); gotFlag != tc.wantFlag {
+				t.Errorf("INACTIVE flag after %s: got %v (flags %v), want %v",
+					tc.action, gotFlag, got.Flags, tc.wantFlag)
+			}
+
+			// The injected "reconciler" write must not have been
+			// clobbered by the retried handler write.
+			var crd crdv1alpha1.Resource
+			if err := cli.Get(ctx, types.NamespacedName{Name: resourceConflictCRDName(t, cli)}, &crd); err != nil {
+				t.Fatalf("get Resource CRD: %v", err)
+			}
+
+			if crd.Labels[conflictTouchLabel] != "1" {
+				t.Errorf("concurrent reconciler write lost: label %q missing on the CRD", conflictTouchLabel)
+			}
+		})
+	}
+}
+
+// conflictTouchLabel marks the out-of-band "reconciler" write the
+// interceptor injects between the handler's read and write.
+const conflictTouchLabel = "test.blockstor.io/reconciler-touch"
+
+// newConflictInjectingResourceClient builds a fake controller-runtime
+// client that simulates a controller reconciler racing the REST
+// handler: immediately before the FIRST write (Update or Patch) that
+// targets a Resource CRD, it performs a side-write on the live object
+// through the un-intercepted inner client — bumping resourceVersion so
+// the handler's optimistic-lock write fails with a 409 conflict. Every
+// subsequent write passes through untouched, so a retry that re-reads
+// fresh state succeeds. The returned flag reports whether the
+// injection fired (guards against fixture rot).
+func newConflictInjectingResourceClient(t *testing.T) (ctrlclient.WithWatch, *atomic.Bool) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := crdv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	injected := &atomic.Bool{}
+
+	sideWrite := func(ctx context.Context, inner ctrlclient.WithWatch, name string) error {
+		var live crdv1alpha1.Resource
+
+		if err := inner.Get(ctx, types.NamespacedName{Name: name}, &live); err != nil {
+			return errors.Wrapf(err, "side-write get Resource %q", name)
+		}
+
+		if live.Labels == nil {
+			live.Labels = map[string]string{}
+		}
+
+		live.Labels[conflictTouchLabel] = "1"
+
+		return errors.Wrapf(inner.Update(ctx, &live), "side-write update Resource %q", name)
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&crdv1alpha1.Resource{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, inner ctrlclient.WithWatch, obj ctrlclient.Object, opts ...ctrlclient.UpdateOption) error {
+				if _, isRes := obj.(*crdv1alpha1.Resource); isRes && injected.CompareAndSwap(false, true) {
+					if err := sideWrite(ctx, inner, obj.GetName()); err != nil {
+						return err
+					}
+				}
+
+				return inner.Update(ctx, obj, opts...)
+			},
+			Patch: func(ctx context.Context, inner ctrlclient.WithWatch, obj ctrlclient.Object, patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+				if _, isRes := obj.(*crdv1alpha1.Resource); isRes && injected.CompareAndSwap(false, true) {
+					if err := sideWrite(ctx, inner, obj.GetName()); err != nil {
+						return err
+					}
+				}
+
+				return inner.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	return cli, injected
+}
+
+// resourceConflictCRDName resolves the single Resource CRD's
+// metadata.name without depending on the store's internal naming
+// scheme — the test only ever seeds one Resource.
+func resourceConflictCRDName(t *testing.T, cli ctrlclient.Client) string {
+	t.Helper()
+
+	var list crdv1alpha1.ResourceList
+
+	if err := cli.List(t.Context(), &list); err != nil {
+		t.Fatalf("list Resource CRDs: %v", err)
+	}
+
+	if len(list.Items) != 1 {
+		t.Fatalf("expected exactly 1 Resource CRD, got %d", len(list.Items))
+	}
+
+	return list.Items[0].Name
+}

--- a/pkg/rest/resource_connections.go
+++ b/pkg/rest/resource_connections.go
@@ -348,31 +348,25 @@ func (s *Server) handleResourceConnectionPathDelete(w http.ResponseWriter, r *ht
 	nodeB := r.PathValue("nodeB")
 	name := r.PathValue("name")
 
-	rd, err := s.Store.ResourceDefinitions().Get(r.Context(), rdName)
-	if err != nil {
-		writeStoreError(w, err)
+	// Bug 204b shape: typed-Patch with retry-on-conflict — the
+	// load → delete → store cycle re-runs against the live RD on
+	// every retry so a concurrent reconciler write can't surface a
+	// 409 (mirrors the path-create sibling above). `existed` is
+	// captured from the last (winning) attempt.
+	var existed bool
 
-		return
-	}
+	err := s.Store.ResourceDefinitions().PatchResourceDefinitionSpec(r.Context(), rdName,
+		func(rd *apiv1.ResourceDefinition) error {
+			paths, _, loadErr := loadPaths(rd, nodeA, nodeB)
+			if loadErr != nil {
+				return loadErr
+			}
 
-	paths, _, err := loadPaths(&rd, nodeA, nodeB)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+			existed = containsPathName(paths, name)
+			paths = deleteByName(paths, name)
 
-		return
-	}
-
-	existed := containsPathName(paths, name)
-	paths = deleteByName(paths, name)
-
-	err = storePaths(&rd, nodeA, nodeB, paths)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-
-		return
-	}
-
-	err = s.Store.ResourceDefinitions().Update(r.Context(), &rd)
+			return storePaths(rd, nodeA, nodeB, paths)
+		})
 	if err != nil {
 		writeStoreError(w, err)
 

--- a/pkg/rest/resource_group_extras.go
+++ b/pkg/rest/resource_group_extras.go
@@ -31,6 +31,16 @@ import (
 	"github.com/cozystack/blockstor/pkg/store"
 )
 
+// Sentinels for the VG handlers' Patch closures: they abort the
+// PatchResourceGroup write (no persist happens) and signal the
+// handler to emit the status-specific envelope (409 duplicate / 404
+// or warn-mask absent) instead of the generic writeStoreError
+// mapping. Exported nowhere — wire shape is owned by the handlers.
+var (
+	errVGAlreadyExists    = errors.New("volume group already exists")
+	errVGNotFoundSentinel = errors.New("volume group not found")
+)
+
 // registerResourceGroupExtras wires the secondary ResourceGroup
 // surface the upstream `linstor` CLI exercises beyond CRUD:
 //
@@ -221,25 +231,30 @@ func (s *Server) handleVGCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rg, err := s.Store.ResourceGroups().Get(r.Context(), rgName)
+	// Bug 204b shape: typed-Patch with retry-on-conflict — the
+	// duplicate check and the append both re-run against the live
+	// RG on every retry, so a concurrent reconciler / sibling write
+	// can't surface a 409 and a racing duplicate create can't slip
+	// past the check.
+	err := s.Store.ResourceGroups().PatchResourceGroup(r.Context(), rgName,
+		func(rg *apiv1.ResourceGroup) error {
+			for i := range rg.VolumeGroups {
+				if rg.VolumeGroups[i].VolumeNumber == in.VolumeNumber {
+					return errVGAlreadyExists
+				}
+			}
+
+			rg.VolumeGroups = append(rg.VolumeGroups, in)
+
+			return nil
+		})
 	if err != nil {
-		writeStoreError(w, err)
-
-		return
-	}
-
-	for i := range rg.VolumeGroups {
-		if rg.VolumeGroups[i].VolumeNumber == in.VolumeNumber {
+		if errors.Is(err, errVGAlreadyExists) {
 			writeError(w, http.StatusConflict, "volume group already exists")
 
 			return
 		}
-	}
 
-	rg.VolumeGroups = append(rg.VolumeGroups, in)
-
-	err = s.Store.ResourceGroups().Update(r.Context(), &rg)
-	if err != nil {
 		writeStoreError(w, err)
 
 		return
@@ -271,33 +286,29 @@ func (s *Server) handleVGUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rg, err := s.Store.ResourceGroups().Get(r.Context(), rgName)
+	// Bug 204b shape: typed-Patch with retry-on-conflict — the
+	// vlmNr lookup and the prop merge re-run against the live RG on
+	// every retry, so a concurrent reconciler / sibling write can't
+	// surface a 409 to `linstor rg vg m`.
+	err := s.Store.ResourceGroups().PatchResourceGroup(r.Context(), rgName,
+		func(rg *apiv1.ResourceGroup) error {
+			for i := range rg.VolumeGroups {
+				if rg.VolumeGroups[i].VolumeNumber == vlmNr {
+					mergeVGProps(&rg.VolumeGroups[i], in.OverrideProps, in.DeleteProps)
+
+					return nil
+				}
+			}
+
+			return errVGNotFoundSentinel
+		})
 	if err != nil {
-		writeStoreError(w, err)
+		if errors.Is(err, errVGNotFoundSentinel) {
+			writeError(w, http.StatusNotFound, "volume group not found")
 
-		return
-	}
-
-	idx := -1
-
-	for i := range rg.VolumeGroups {
-		if rg.VolumeGroups[i].VolumeNumber == vlmNr {
-			idx = i
-
-			break
+			return
 		}
-	}
 
-	if idx < 0 {
-		writeError(w, http.StatusNotFound, "volume group not found")
-
-		return
-	}
-
-	mergeVGProps(&rg.VolumeGroups[idx], in.OverrideProps, in.DeleteProps)
-
-	err = s.Store.ResourceGroups().Update(r.Context(), &rg)
-	if err != nil {
 		writeStoreError(w, err)
 
 		return
@@ -333,9 +344,37 @@ func (s *Server) handleVGDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rg, err := s.Store.ResourceGroups().Get(r.Context(), rgName)
+	// Bug 204b shape: typed-Patch with retry-on-conflict — the
+	// membership scan and the removal re-run against the live RG on
+	// every retry, so a concurrent reconciler / sibling write can't
+	// surface a 409. The vlmNr-absent no-op aborts the write via
+	// sentinel so the idempotent warn envelope below still fires
+	// without a spurious persist.
+	err := s.Store.ResourceGroups().PatchResourceGroup(r.Context(), rgName,
+		func(rg *apiv1.ResourceGroup) error {
+			dst := rg.VolumeGroups[:0]
+			found := false
+
+			for i := range rg.VolumeGroups {
+				if rg.VolumeGroups[i].VolumeNumber == vlmNr {
+					found = true
+
+					continue
+				}
+
+				dst = append(dst, rg.VolumeGroups[i])
+			}
+
+			if !found {
+				return errVGNotFoundSentinel
+			}
+
+			rg.VolumeGroups = dst
+
+			return nil
+		})
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
+		if errors.Is(err, store.ErrNotFound) || errors.Is(err, errVGNotFoundSentinel) {
 			writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
 				RetCode: warnVGNotFound,
 				Message: fmt.Sprintf("volume group already absent: %s/%d", rgName, vlmNr),
@@ -344,37 +383,6 @@ func (s *Server) handleVGDelete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		writeStoreError(w, err)
-
-		return
-	}
-
-	dst := rg.VolumeGroups[:0]
-	found := false
-
-	for i := range rg.VolumeGroups {
-		if rg.VolumeGroups[i].VolumeNumber == vlmNr {
-			found = true
-
-			continue
-		}
-
-		dst = append(dst, rg.VolumeGroups[i])
-	}
-
-	if !found {
-		writeJSON(w, http.StatusOK, []apiv1.APICallRc{{
-			RetCode: warnVGNotFound,
-			Message: fmt.Sprintf("volume group already absent: %s/%d", rgName, vlmNr),
-		}})
-
-		return
-	}
-
-	rg.VolumeGroups = dst
-
-	err = s.Store.ResourceGroups().Update(r.Context(), &rg)
-	if err != nil {
 		writeStoreError(w, err)
 
 		return

--- a/pkg/rest/vd_passphrase_bug_233.go
+++ b/pkg/rest/vd_passphrase_bug_233.go
@@ -111,7 +111,10 @@ func (s *Server) handleVDPassphraseRotate(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	vd, err := s.Store.VolumeDefinitions().Get(r.Context(), rdName, int32(vlmNr))
+	// Probe for existence up-front so a missing VD surfaces 404
+	// before the body validation's 400 — preserves the pre-Patch
+	// error-precedence contract.
+	_, err = s.Store.VolumeDefinitions().Get(r.Context(), rdName, int32(vlmNr))
 	if err != nil {
 		writeStoreError(w, err)
 
@@ -136,13 +139,20 @@ func (s *Server) handleVDPassphraseRotate(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if vd.Props == nil {
-		vd.Props = map[string]string{}
-	}
+	// Bug 204b shape: typed-Patch with retry-on-conflict so a
+	// reconciler write on the parent RD between the read and the
+	// write re-applies the rotation onto fresh state instead of
+	// surfacing a 409 to the operator.
+	err = s.Store.VolumeDefinitions().PatchVolumeDefinitionSpec(r.Context(), rdName, int32(vlmNr),
+		func(live *apiv1.VolumeDefinition) error {
+			if live.Props == nil {
+				live.Props = map[string]string{}
+			}
 
-	vd.Props[vdPassphrasePropKey] = want
+			live.Props[vdPassphrasePropKey] = want
 
-	err = s.Store.VolumeDefinitions().Update(r.Context(), rdName, &vd)
+			return nil
+		})
 	if err != nil {
 		writeStoreError(w, err)
 


### PR DESCRIPTION
## What

`POST /v1/resource-definitions/{rd}/resources/{node}/activate` could answer `409 conflict: store object was modified, retry the request` when a controller reconciler updated the Resource CRD between the handler's read and write (release-gate `TestGroupFRActivateDeactivate`). Upstream LINSTOR never returns 409 on activate and the Python CLI does not retry it, so the conflict leaked straight to the operator.

The activate/deactivate handlers persisted the flag toggle via a bare Get -> mutate -> Update with no conflict retry. This PR routes them through the store's established typed-Patch helpers (`PatchResourceSpec` and siblings), which re-fetch the live object and re-apply the mutation under `RetryOnConflict` with backoff — no stale-snapshot re-PUT.

## Audit

The whole REST surface was audited for the same read-modify-write-no-retry shape. Also converted:

- node evict/restore flag toggles, node create upsert, `node_type` modify -> `PatchNodeSpec`
- explicit resource-create and make-available layer-list pass-throughs, rd clone prop edits, resource-connection path delete, per-RD DRBD shared-secret -> `PatchResourceDefinitionSpec`
- per-VD passphrase rotation -> `PatchVolumeDefinitionSpec`
- volume-group create/modify/delete -> `PatchResourceGroup`

Toggle-disk, migrate-disk, resource/RG/VD modify, props endpoints, and the autoplace main paths already used the retrying patch helpers and are unchanged. Wire-visible status envelopes (duplicate VG 409, absent VG warn no-op, 404 precedence) are preserved.

## Testing

- New regression test injects a conflicting concurrent write between the handler's read and write via a fake-client interceptor and asserts activate/deactivate answer 200 with no lost update (fails with 409 on the pre-fix handler).
- `go test ./...` green; `go test -race -count=1 ./pkg/rest/...` green; `golangci-lint run` 0 issues.
- Integration: `go test -tags=integration -run TestGroupF ./tests/integration/...` green; `TestGroupFRActivateDeactivate` passes 5/5 consecutive runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced concurrent update handling across resources, nodes, and resource definitions to prevent data loss during conflicts.
  * Improved robustness of property updates and state changes under contention.

* **Tests**
  * Added regression test for resource activation/deactivation under concurrent modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->