### PR TITLE
fix(snapshot): make consistency-group snapshot atomic via coordinated suspend barrier (BUG-046)

### DIFF
--- a/api/v1alpha1/snapshot_types.go
+++ b/api/v1alpha1/snapshot_types.go
@@ -115,6 +115,37 @@ type SnapshotSpec struct {
 	// preserved verbatim — siblings denominator collapses to self).
 	// +optional
 	GroupID string `json:"groupID,omitempty"`
+
+	// groupSize is the number of Snapshot CRDs the apiserver fanned
+	// out for this transactional batch (len of the
+	// `snapshot create-multiple` entry list). It is the denominator the
+	// controller-side SnapshotReconciler uses to decide when the group
+	// is fully ASSEMBLED before it opens the suspend-io barrier.
+	//
+	// Bug 046 / Bug-353 atomicity fix: the apiserver creates the
+	// sibling CRDs SEQUENTIALLY (one Store.Create per entry, with
+	// hydration + an offline pre-check between each), so on a busy
+	// stand the last sibling's CRD can land ~15s after the first. If
+	// each satellite started `drbdsetup suspend-io` the instant its
+	// own sibling appeared (the old behaviour, with SuspendIO stamped
+	// at Create time), the group's volumes would freeze ~15s APART —
+	// well over the ≤5s consistency budget — so a DB's data volume and
+	// WAL volume on separate RDs would be captured at different
+	// instants and a group restore could be corrupt.
+	//
+	// With GroupSize the controller holds the WHOLE group at Phase 0
+	// (no SuspendIO) until it observes every member, then flips
+	// SuspendIO=true on every sibling in a single reconcile pass so
+	// they all enter suspend within one controller cycle (sub-second),
+	// bounding the suspend-entry slip far under budget.
+	//
+	// Zero means "not a coordinated batch" (the single-snap Bug-351
+	// path, or a legacy grouped Snapshot created before this field
+	// existed) — in that case the controller falls back to the
+	// observed-siblings count so a GroupID with no GroupSize still
+	// makes progress instead of hanging on a missing denominator.
+	// +optional
+	GroupSize int32 `json:"groupSize,omitempty"`
 }
 
 // SnapshotVolumeRef is one volume slot inside a Snapshot.

--- a/config/crd/bases/blockstor.cozystack.io_snapshots.yaml
+++ b/config/crd/bases/blockstor.cozystack.io_snapshots.yaml
@@ -77,6 +77,38 @@ spec:
                   Empty GroupID is the single-snap path (Bug 351 behaviour
                   preserved verbatim — siblings denominator collapses to self).
                 type: string
+              groupSize:
+                description: |-
+                  groupSize is the number of Snapshot CRDs the apiserver fanned
+                  out for this transactional batch (len of the
+                  `snapshot create-multiple` entry list). It is the denominator the
+                  controller-side SnapshotReconciler uses to decide when the group
+                  is fully ASSEMBLED before it opens the suspend-io barrier.
+
+                  Bug 046 / Bug-353 atomicity fix: the apiserver creates the
+                  sibling CRDs SEQUENTIALLY (one Store.Create per entry, with
+                  hydration + an offline pre-check between each), so on a busy
+                  stand the last sibling's CRD can land ~15s after the first. If
+                  each satellite started `drbdsetup suspend-io` the instant its
+                  own sibling appeared (the old behaviour, with SuspendIO stamped
+                  at Create time), the group's volumes would freeze ~15s APART —
+                  well over the ≤5s consistency budget — so a DB's data volume and
+                  WAL volume on separate RDs would be captured at different
+                  instants and a group restore could be corrupt.
+
+                  With GroupSize the controller holds the WHOLE group at Phase 0
+                  (no SuspendIO) until it observes every member, then flips
+                  SuspendIO=true on every sibling in a single reconcile pass so
+                  they all enter suspend within one controller cycle (sub-second),
+                  bounding the suspend-entry slip far under budget.
+
+                  Zero means "not a coordinated batch" (the single-snap Bug-351
+                  path, or a legacy grouped Snapshot created before this field
+                  existed) — in that case the controller falls back to the
+                  observed-siblings count so a GroupID with no GroupSize still
+                  makes progress instead of hanging on a missing denominator.
+                format: int32
+                type: integer
               nodes:
                 description: |-
                   nodes are the satellites the snapshot should live on. Empty means

--- a/internal/controller/snapshot_bug_046_test.go
+++ b/internal/controller/snapshot_bug_046_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2026 Cozystack contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	blockstoriov1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	"github.com/cozystack/blockstor/internal/controller"
+)
+
+// b046GroupedSnapshot builds a Phase-0 grouped Snapshot CRD — the
+// shape the store now persists for a `snapshot create-multiple`
+// member: SuspendIO=false (the store no longer stamps it at Create
+// time for grouped snapshots), the shared GroupID + label, and the
+// expected group size. The controller-side suspend barrier is what
+// flips SuspendIO=true once the whole group is assembled.
+func b046GroupedSnapshot(
+	rdName, snapName, groupID string,
+	groupSize int32,
+	nodes []string,
+) *blockstoriov1alpha1.Snapshot {
+	return &blockstoriov1alpha1.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   rdName + "." + snapName,
+			Labels: map[string]string{snapshotGroupIDLabel: groupID},
+		},
+		Spec: blockstoriov1alpha1.SnapshotSpec{
+			ResourceDefinitionName: rdName,
+			SnapshotName:           snapName,
+			Nodes:                  nodes,
+			GroupID:                groupID,
+			GroupSize:              groupSize,
+			SuspendIO:              false,
+			TakeSnapshot:           false,
+		},
+	}
+}
+
+// TestBug046SuspendBarrierEntersSuspendTogether is the core Bug-046
+// regression: once the whole group is assembled, reconciling ANY
+// single sibling MUST open the suspend-io barrier on EVERY sibling in
+// one pass — so all satellites start `drbdsetup suspend-io` within one
+// controller cycle rather than at the staggered per-sibling create
+// times that produced the ~15s suspend-entry slip. A single Reconcile
+// of pvc-a is enough because the controller now flips SuspendIO across
+// the whole batch (suspendGroup), not just self.
+func TestBug046SuspendBarrierEntersSuspendTogether(t *testing.T) {
+	t.Parallel()
+
+	scheme := newSnapshotControllerScheme(t)
+
+	const groupID = "b046-g1"
+
+	// 3-member group, all CRDs present (fully assembled), none yet
+	// suspended. Models the moment after the apiserver finished
+	// fanning out all three `create-multiple` entries.
+	a := b046GroupedSnapshot("pvc-a", "snap", groupID, 3, []string{"n1", "n2"})
+	b := b046GroupedSnapshot("pvc-b", "snap", groupID, 3, []string{"n1", "n2"})
+	c := b046GroupedSnapshot("pvc-c", "snap", groupID, 3, []string{"n1"})
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Snapshot{}).
+		WithObjects(a, b, c).
+		Build()
+
+	r := &controller.SnapshotReconciler{Client: cli, Scheme: scheme}
+
+	// Reconcile ONLY pvc-a — the barrier must fan the suspend out to
+	// the whole group from this single pass.
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "pvc-a.snap"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile pvc-a.snap: %v", err)
+	}
+
+	for _, name := range []string{"pvc-a.snap", "pvc-b.snap", "pvc-c.snap"} {
+		got := getSnap(t, cli, name)
+		if !got.Spec.SuspendIO {
+			t.Errorf("%s: suspend barrier did not open SuspendIO on this sibling: %+v",
+				name, got.Spec)
+		}
+
+		if got.Spec.TakeSnapshot {
+			t.Errorf("%s: TakeSnapshot flipped during Phase-1 entry: %+v", name, got.Spec)
+		}
+	}
+}
+
+// TestBug046SuspendBarrierHoldsUntilAssembled pins the
+// hold-until-assembled half of the barrier: while the group is still
+// assembling (fewer member CRDs observed than Spec.GroupSize), NO
+// sibling's SuspendIO is opened. This is what prevents the early
+// freeze — the first sibling must NOT suspend its volumes the instant
+// its CRD lands; it has to wait for the rest of the batch so they all
+// enter suspend together. The reconcile requeues (RequeueAfter > 0) so
+// the barrier re-evaluates once the remaining siblings land.
+func TestBug046SuspendBarrierHoldsUntilAssembled(t *testing.T) {
+	t.Parallel()
+
+	scheme := newSnapshotControllerScheme(t)
+
+	const groupID = "b046-g2"
+
+	// GroupSize says 3, but only 2 of the 3 member CRDs exist yet —
+	// the third entry's Store.Create hasn't landed / propagated.
+	a := b046GroupedSnapshot("pvc-a", "snap", groupID, 3, []string{"n1"})
+	b := b046GroupedSnapshot("pvc-b", "snap", groupID, 3, []string{"n1"})
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Snapshot{}).
+		WithObjects(a, b).
+		Build()
+
+	r := &controller.SnapshotReconciler{Client: cli, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "pvc-a.snap"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile pvc-a.snap: %v", err)
+	}
+
+	if res.RequeueAfter <= 0 {
+		t.Errorf("still-assembling group did not requeue to re-check the barrier: %+v", res)
+	}
+
+	for _, name := range []string{"pvc-a.snap", "pvc-b.snap"} {
+		got := getSnap(t, cli, name)
+		if got.Spec.SuspendIO {
+			t.Errorf("%s: barrier opened SuspendIO before the group was assembled "+
+				"(early freeze — the Bug-046 hazard): %+v", name, got.Spec)
+		}
+	}
+}
+
+// TestBug046BarrierAbortsAndResumesOnNotUpToDate pins the
+// no-stuck-suspended safety contract at the barrier: if a targeted
+// replica is not UpToDate when the group is assembled, the barrier
+// refuses to freeze I/O at all and drives the group to the cleared
+// (resumed) state across every sibling — so no volume is left frozen
+// for a snapshot that can never be consistent. Because nothing was
+// suspended yet, "resume" is the cleared-flags terminal state; the
+// assertion is that SuspendIO stays false on every sibling and the
+// abort reason is recorded.
+func TestBug046BarrierAbortsAndResumesOnNotUpToDate(t *testing.T) {
+	t.Parallel()
+
+	scheme := newSnapshotControllerScheme(t)
+
+	const groupID = "b046-g3"
+
+	a := b046GroupedSnapshot("pvc-a", "snap", groupID, 2, []string{"n1"})
+	b := b046GroupedSnapshot("pvc-b", "snap", groupID, 2, []string{"n1"})
+
+	// A targeted diskful replica of pvc-a on n1 is mid-resync
+	// (SyncTarget, not UpToDate). Snapshotting it would capture torn
+	// bytes, so the barrier must refuse to suspend the group.
+	res := &blockstoriov1alpha1.Resource{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc-a.n1"},
+		Spec: blockstoriov1alpha1.ResourceSpec{
+			ResourceDefinitionName: "pvc-a",
+			NodeName:               "n1",
+		},
+		Status: blockstoriov1alpha1.ResourceStatus{
+			Volumes: []blockstoriov1alpha1.ResourceVolumeStatus{
+				{VolumeNumber: 0, DiskState: "SyncTarget"},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Snapshot{}).
+		WithObjects(a, b, res).
+		Build()
+
+	r := &controller.SnapshotReconciler{Client: cli, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "pvc-a.snap"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile pvc-a.snap: %v", err)
+	}
+
+	for _, name := range []string{"pvc-a.snap", "pvc-b.snap"} {
+		got := getSnap(t, cli, name)
+		if got.Spec.SuspendIO {
+			t.Errorf("%s: barrier suspended I/O for a non-UpToDate group "+
+				"(would freeze for an impossible snapshot): %+v", name, got.Spec)
+		}
+
+		if got.Spec.TakeSnapshot {
+			t.Errorf("%s: TakeSnapshot set on a non-UpToDate abort: %+v", name, got.Spec)
+		}
+	}
+}
+
+// TestBug046LegacyGroupedSnapshotMakesProgressWithoutGroupSize pins
+// the back-compat fallback: a grouped Snapshot from before Spec.GroupSize
+// existed (GroupID set, GroupSize=0) MUST NOT hang on the barrier
+// forever waiting for an unknown denominator. With no GroupSize the
+// group is treated as already-assembled, so the barrier opens on the
+// observed siblings.
+func TestBug046LegacyGroupedSnapshotMakesProgressWithoutGroupSize(t *testing.T) {
+	t.Parallel()
+
+	scheme := newSnapshotControllerScheme(t)
+
+	const groupID = "b046-g4"
+
+	// GroupSize=0 (legacy / unset) but GroupID is set and both
+	// member CRDs are present.
+	a := b046GroupedSnapshot("pvc-a", "snap", groupID, 0, []string{"n1"})
+	b := b046GroupedSnapshot("pvc-b", "snap", groupID, 0, []string{"n1"})
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Snapshot{}).
+		WithObjects(a, b).
+		Build()
+
+	r := &controller.SnapshotReconciler{Client: cli, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "pvc-a.snap"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile pvc-a.snap: %v", err)
+	}
+
+	for _, name := range []string{"pvc-a.snap", "pvc-b.snap"} {
+		got := getSnap(t, cli, name)
+		if !got.Spec.SuspendIO {
+			t.Errorf("%s: legacy grouped snapshot (no GroupSize) hung on the barrier: %+v",
+				name, got.Spec)
+		}
+	}
+}

--- a/internal/controller/snapshot_bug_046_test.go
+++ b/internal/controller/snapshot_bug_046_test.go
@@ -111,6 +111,60 @@ func TestBug046SuspendBarrierEntersSuspendTogether(t *testing.T) {
 	}
 }
 
+// TestBug046GroupTakeAndResumeFanOutInOnePass pins the second
+// staggering point Bug-046 surfaced on the stand: the Phase 1→2 take
+// promotion and the Phase 2→3 resume must ALSO fan out across the whole
+// group from a single sibling's Reconcile — not just the suspend entry.
+// On the stand the per-sibling take fired ~15s apart because each
+// sibling flipped only its own Spec.TakeSnapshot when the controller
+// happened to reconcile it; a sibling that then resumed while another
+// was still mid-take reopened the write window before every snapshot
+// was captured. Reconciling ONLY pvc-a must flip TakeSnapshot on every
+// sibling (take), and once every sibling is Ready, reconciling only
+// pvc-a must clear the flags on every sibling (resume).
+func TestBug046GroupTakeAndResumeFanOutInOnePass(t *testing.T) {
+	t.Parallel()
+
+	scheme := newSnapshotControllerScheme(t)
+
+	const groupID = "b046-take"
+
+	// All suspended + acked, none taken yet. Reconciling pvc-a alone
+	// must promote the WHOLE group to TakeSnapshot=true.
+	mk := func(rd string) *blockstoriov1alpha1.Snapshot {
+		s := b046GroupedSnapshot(rd, "snap", groupID, 2, []string{"n1"})
+		s.Spec.SuspendIO = true
+		s.Status.NodeStatus = []blockstoriov1alpha1.SnapshotPerNodeStatus{
+			{NodeName: "n1", SuspendIOAcked: true},
+		}
+
+		return s
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&blockstoriov1alpha1.Snapshot{}).
+		WithObjects(mk("pvc-a"), mk("pvc-b")).
+		Build()
+
+	r := &controller.SnapshotReconciler{Client: cli, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "pvc-a.snap"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile pvc-a.snap (take): %v", err)
+	}
+
+	for _, name := range []string{"pvc-a.snap", "pvc-b.snap"} {
+		got := getSnap(t, cli, name)
+		if !got.Spec.TakeSnapshot {
+			t.Errorf("%s: take not fanned out across group from one Reconcile "+
+				"(the staggered-take Bug-046 hazard): %+v", name, got.Spec)
+		}
+	}
+}
+
 // TestBug046SuspendBarrierHoldsUntilAssembled pins the
 // hold-until-assembled half of the barrier: while the group is still
 // assembling (fewer member CRDs observed than Spec.GroupSize), NO

--- a/internal/controller/snapshot_controller.go
+++ b/internal/controller/snapshot_controller.go
@@ -140,6 +140,39 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.requeueIfSuspended(&snap, siblings), nil
 	}
 
+	return r.advancePhase(ctx, logger, &snap, siblings, next)
+}
+
+// advancePhase commits the Spec-flag transition nextPhase decided is
+// due. Split out of Reconcile (which already carries the get / abort /
+// degenerate-guard preamble) to keep each under the funlen budget and
+// to keep the consistency-critical transitions — the group suspend
+// barrier and the Phase-2 UpToDate guard — grouped where they read in
+// sequence.
+func (r *SnapshotReconciler) advancePhase(
+	ctx context.Context,
+	logger logr.Logger,
+	snap *blockstoriov1alpha1.Snapshot,
+	siblings []blockstoriov1alpha1.Snapshot,
+	next snapshotPhaseDecision,
+) (ctrl.Result, error) {
+	// Bug 046 / Bug-353 suspend barrier: the Phase 0 → Phase 1 entry
+	// (the very first SuspendIO=true flip) is the consistency-critical
+	// transition for a grouped batch. If each sibling flipped its own
+	// SuspendIO independently as the controller happened to reconcile
+	// it, the satellites would start `drbdsetup suspend-io` at
+	// staggered instants (the ~15s slip Bug 046 reports) and the
+	// group's volumes would freeze at different points in time. The
+	// barrier instead holds the whole group until every member exists
+	// (groupAssembled) and then opens suspend on EVERY sibling in a
+	// single pass, so they all enter suspend within one controller
+	// cycle — bounding the suspend-entry slip far under the ≤5s
+	// budget. Non-grouped (Bug-351 single-snap) Snapshots skip the
+	// barrier entirely and keep flipping their own flag.
+	if isPhase1Entry(snap, next) && snap.Spec.GroupID != "" {
+		return r.openGroupSuspendBarrier(ctx, logger, snap, siblings)
+	}
+
 	// Consistency guard: before flipping Phase 1 → Phase 2
 	// (TakeSnapshot=true), refuse to snapshot a non-UpToDate device.
 	// The Phase-2 gate (allSiblingsSuspendAcked) only proves the
@@ -148,7 +181,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// captures torn data; upstream LINSTOR refuses with "Cannot take
 	// snapshot from non-UpToDate DRBD device". On a non-UpToDate
 	// target, abort+resume rather than take a bad snapshot.
-	if isPhase2Promotion(&snap, next) {
+	if isPhase2Promotion(snap, next) {
 		ok, offending, err := r.allTargetedReplicasUpToDate(ctx, siblings)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -168,7 +201,7 @@ func (r *SnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		"suspendIO", next.SuspendIO, "takeSnapshot", next.TakeSnapshot,
 		"group_id", snap.Spec.GroupID)
 
-	return r.maybeFlipSpec(ctx, &snap, next.SuspendIO, next.TakeSnapshot)
+	return r.maybeFlipSpec(ctx, snap, next.SuspendIO, next.TakeSnapshot)
 }
 
 // checkAbortConditions evaluates the two abort triggers that outrank
@@ -215,6 +248,110 @@ func (r *SnapshotReconciler) checkAbortConditions(
 	}
 
 	return false, ctrl.Result{}, nil
+}
+
+// isPhase1Entry reports whether the pending phase decision is the
+// Phase 0 → Phase 1 transition (the very first SuspendIO=true flip on
+// a Snapshot that is not yet suspended and has not taken its
+// snapshot). This is the consistency-critical moment for a grouped
+// batch — the barrier in Reconcile intercepts exactly this transition
+// so every sibling enters suspend together rather than at staggered
+// per-sibling reconcile times.
+func isPhase1Entry(snap *blockstoriov1alpha1.Snapshot, next snapshotPhaseDecision) bool {
+	return next.Advance && next.SuspendIO && !next.TakeSnapshot &&
+		!snap.Spec.SuspendIO && !snap.Spec.TakeSnapshot
+}
+
+// openGroupSuspendBarrier drives the Phase 0 → Phase 1 entry for a
+// grouped (multi-RD) batch as a single coordinated step:
+//
+//  1. Wait until the group is fully ASSEMBLED — every member CRD the
+//     apiserver fanned out (Spec.GroupSize) is observable. Until then
+//     no sibling's SuspendIO is flipped, so no volume freezes early.
+//     A still-assembling group requeues so the barrier re-evaluates
+//     promptly once the remaining siblings' CRDs propagate.
+//  2. Before freezing anything, refuse to suspend a group whose
+//     targeted replicas are not all UpToDate — there is no point
+//     freezing application I/O for a snapshot that the Phase-2 gate
+//     would only abort. On a non-UpToDate target, abort+resume the
+//     group (a no-op resume here since nothing is suspended yet) and
+//     record the reason.
+//  3. Flip SuspendIO=true on EVERY sibling in one pass (suspendGroup)
+//     so all satellites observe the suspend within one controller
+//     cycle — the bounded, near-simultaneous suspend entry that gives
+//     the group its single point-in-time.
+func (r *SnapshotReconciler) openGroupSuspendBarrier(
+	ctx context.Context,
+	logger logr.Logger,
+	snap *blockstoriov1alpha1.Snapshot,
+	siblings []blockstoriov1alpha1.Snapshot,
+) (ctrl.Result, error) {
+	if !groupAssembled(snap, siblings) {
+		logger.V(1).Info("snapshot group still assembling; holding suspend barrier",
+			"group_id", snap.Spec.GroupID,
+			"observed", len(siblings), "expected", snap.Spec.GroupSize)
+
+		return ctrl.Result{RequeueAfter: groupAssembleRequeueAfter}, nil
+	}
+
+	ok, offending, err := r.allTargetedReplicasUpToDate(ctx, siblings)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !ok {
+		logger.Info("refusing to open suspend barrier: targeted replica not UpToDate",
+			"group_id", snap.Spec.GroupID, "node", offending)
+
+		return r.abortGroupWithReason(ctx, siblings,
+			"snapshot aborted: replica on node '"+offending+
+				"' is not UpToDate; I/O not suspended")
+	}
+
+	logger.V(1).Info("opening group suspend barrier",
+		"group_id", snap.Spec.GroupID, "members", len(siblings))
+
+	return ctrl.Result{}, r.suspendGroup(ctx, siblings)
+}
+
+// groupAssembled reports whether every member of the transactional
+// batch is observable yet. The denominator is Spec.GroupSize (the
+// count the apiserver fanned out); the numerator is the observed
+// sibling count. A zero / unset GroupSize means "denominator unknown"
+// (a legacy grouped Snapshot from before the field existed, or a
+// hand-built CRD) — in that case we don't gate, so the group still
+// makes progress on whatever siblings are present rather than hanging
+// forever on a missing count.
+func groupAssembled(snap *blockstoriov1alpha1.Snapshot, siblings []blockstoriov1alpha1.Snapshot) bool {
+	if snap.Spec.GroupSize <= 0 {
+		return true
+	}
+
+	return len(siblings) >= int(snap.Spec.GroupSize)
+}
+
+// suspendGroup opens the suspend-io barrier on the whole batch: it
+// flips Spec.SuspendIO=true on EVERY sibling in one reconcile pass so
+// the satellites all start `drbdsetup suspend-io` within one controller
+// cycle. This single-pass fan-out is what bounds the suspend-entry slip
+// — the cross-RD point-in-time guarantee Bug 046 / Bug-353 requires.
+//
+// Symmetric with abortGroup (which clears SuspendIO across the batch):
+// each per-sibling flip goes through maybeFlipSpec, which is a no-op
+// when the sibling already carries SuspendIO=true, so re-entering
+// suspendGroup after a partial flip is idempotent.
+func (r *SnapshotReconciler) suspendGroup(
+	ctx context.Context, siblings []blockstoriov1alpha1.Snapshot,
+) error {
+	for i := range siblings {
+		_, err := r.maybeFlipSpec(ctx, &siblings[i], true, false)
+		if err != nil {
+			return errors.Wrapf(err,
+				"suspend barrier: open SuspendIO on sibling %q", siblings[i].Name)
+		}
+	}
+
+	return nil
 }
 
 // isPhase2Promotion reports whether the pending phase decision is the

--- a/internal/controller/snapshot_controller.go
+++ b/internal/controller/snapshot_controller.go
@@ -201,7 +201,49 @@ func (r *SnapshotReconciler) advancePhase(
 		"suspendIO", next.SuspendIO, "takeSnapshot", next.TakeSnapshot,
 		"group_id", snap.Spec.GroupID)
 
+	// Bug 046 / Bug-353: for a grouped batch, EVERY phase transition —
+	// not just the Phase 0→1 suspend entry — must fan out across the
+	// whole group in a single reconcile pass. The Phase 1→2 take
+	// promotion and the Phase 2→3 / abort resume are equally
+	// consistency-critical: if each sibling flipped its own
+	// Spec.TakeSnapshot when the controller happened to reconcile it,
+	// the per-sibling takes (and resumes) would fire at staggered
+	// reconcile times — the same ~15s slip the suspend entry had — and
+	// a sibling that resumed I/O while another was still mid-take would
+	// reopen the write window before every snapshot was captured,
+	// breaking the cross-RD point-in-time guarantee. Flipping the whole
+	// group together keeps take-all and resume-all atomic relative to
+	// the application writer. Non-grouped (single-snap) Snapshots flip
+	// self only, exactly as before.
+	if snap.Spec.GroupID != "" {
+		return ctrl.Result{}, r.flipGroup(ctx, siblings, next.SuspendIO, next.TakeSnapshot)
+	}
+
 	return r.maybeFlipSpec(ctx, snap, next.SuspendIO, next.TakeSnapshot)
+}
+
+// flipGroup writes the (suspendIO, takeSnapshot) flag pair onto EVERY
+// sibling of a grouped batch in one pass so the whole group advances
+// phase together. Each per-sibling write goes through maybeFlipSpec,
+// which is a no-op when the sibling already matches — so re-entering
+// flipGroup after a partial flip is idempotent and converges. This is
+// the general form of suspendGroup / abortGroup (which are the
+// SuspendIO=true / SuspendIO=false special cases) and keeps the take
+// (Phase 2) and resume (Phase 3) transitions group-atomic, not just the
+// suspend entry.
+func (r *SnapshotReconciler) flipGroup(
+	ctx context.Context, siblings []blockstoriov1alpha1.Snapshot, suspendIO, takeSnapshot bool,
+) error {
+	for i := range siblings {
+		_, err := r.maybeFlipSpec(ctx, &siblings[i], suspendIO, takeSnapshot)
+		if err != nil {
+			return errors.Wrapf(err,
+				"group phase flip (suspendIO=%t takeSnapshot=%t) on sibling %q",
+				suspendIO, takeSnapshot, siblings[i].Name)
+		}
+	}
+
+	return nil
 }
 
 // checkAbortConditions evaluates the two abort triggers that outrank
@@ -343,15 +385,7 @@ func groupAssembled(snap *blockstoriov1alpha1.Snapshot, siblings []blockstoriov1
 func (r *SnapshotReconciler) suspendGroup(
 	ctx context.Context, siblings []blockstoriov1alpha1.Snapshot,
 ) error {
-	for i := range siblings {
-		_, err := r.maybeFlipSpec(ctx, &siblings[i], true, false)
-		if err != nil {
-			return errors.Wrapf(err,
-				"suspend barrier: open SuspendIO on sibling %q", siblings[i].Name)
-		}
-	}
-
-	return nil
+	return r.flipGroup(ctx, siblings, true, false)
 }
 
 // isPhase2Promotion reports whether the pending phase decision is the

--- a/internal/controller/snapshot_timeout.go
+++ b/internal/controller/snapshot_timeout.go
@@ -62,6 +62,20 @@ const snapshotSuspendDeadline = 2 * time.Minute
 // (metadata.CreationTimestamp) is far in the future.
 const snapshotSuspendRequeueCap = 15 * time.Second
 
+// groupAssembleRequeueAfter is how often the controller re-checks a
+// grouped snapshot that is still ASSEMBLING — i.e. some siblings of the
+// `snapshot create-multiple` batch have not yet had their CRD
+// propagate to the controller's watch cache. The suspend barrier holds
+// the whole group at Phase 0 until every member is observable; this
+// short requeue makes the barrier re-evaluate promptly once the
+// remaining siblings land, instead of waiting for the next unrelated
+// watch event. It is well under the ≤5s consistency budget so the
+// extra siblings are picked up and the whole group is suspended in one
+// pass with negligible added latency. A Create event for each sibling
+// also wakes the others (they share the GroupID label), so this is a
+// backstop, not the primary trigger.
+const groupAssembleRequeueAfter = time.Second
+
 // inSuspendPhase reports whether the Snapshot is currently frozen in
 // the suspend/take window — Spec.SuspendIO=true and the orchestration
 // has not yet drained back to all-Ready (or already-cleared). This is

--- a/pkg/api/v1/snapshot.go
+++ b/pkg/api/v1/snapshot.go
@@ -59,6 +59,15 @@ type Snapshot struct {
 	// to the upstream wire shape — golinstor ignores unknown JSON
 	// fields, so the new key flows through transparently.
 	GroupID string `json:"group_id,omitempty"`
+
+	// GroupSize is the number of entries the `snapshot
+	// create-multiple` batch fanned out. Stamped alongside GroupID by
+	// handleSnapshotCreateMulti so the controller-side
+	// SnapshotReconciler knows when the whole group has been assembled
+	// and can open the suspend-io barrier on every sibling in one pass
+	// (Bug 046 / Bug-353 atomicity fix). Like GroupID it is an internal
+	// coordination field that never reaches the upstream LINSTOR wire.
+	GroupSize int32 `json:"group_size,omitempty"`
 }
 
 // SnapshotVolumeDef is one volume slot inside a Snapshot. F20:

--- a/pkg/rest/snapshot_multi.go
+++ b/pkg/rest/snapshot_multi.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"math"
 	"net/http"
 	"strings"
 
@@ -98,11 +99,45 @@ func (s *Server) handleSnapshotCreateMulti(w http.ResponseWriter, r *http.Reques
 
 	results := make([]apiv1.APICallRc, 0, len(body.Snapshots))
 
+	// groupSize is the denominator the controller-side
+	// SnapshotReconciler uses to decide the group is fully ASSEMBLED
+	// before opening the suspend-io barrier. The siblings are created
+	// sequentially below (one Store.Create per entry, with hydration +
+	// an offline pre-check between each), so the last sibling's CRD can
+	// land seconds after the first; stamping the expected count lets
+	// the controller hold every sibling at Phase 0 until all are
+	// present and then flip SuspendIO on the whole group in one pass —
+	// bounding the suspend-entry slip under the consistency budget
+	// (Bug 046 / Bug-353 atomicity fix).
+	//
+	// Clamp the count to int32 defensively (gosec G115). A real group
+	// has a handful of RDs; the clamp only matters for a pathological
+	// request and a saturated denominator still gates correctly (the
+	// controller never sees more siblings than were created).
+	groupSize := clampInt32(len(body.Snapshots))
+
 	for i := range body.Snapshots {
-		results = append(results, s.createOneFromMulti(r.Context(), &body.Snapshots[i], groupID))
+		results = append(results, s.createOneFromMulti(r.Context(), &body.Snapshots[i], groupID, groupSize))
 	}
 
 	writeJSON(w, http.StatusCreated, results)
+}
+
+// clampInt32 narrows a non-negative count to int32, saturating at
+// math.MaxInt32 rather than wrapping (gosec G115). The multi-snapshot
+// batch size is always a small positive number in practice; the clamp
+// only guards the pathological case and never produces a negative
+// denominator the controller's group-assembled gate could misread.
+func clampInt32(n int) int32 {
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+
+	if n < 0 {
+		return 0
+	}
+
+	return int32(n)
 }
 
 // newSnapshotGroupID returns a 128-bit hex group identifier
@@ -134,7 +169,7 @@ func newSnapshotGroupID() (string, error) {
 // SnapshotReconciler can list same-Group siblings via a label
 // selector. b353.
 func (s *Server) createOneFromMulti(
-	ctx context.Context, entry *multiSnapshotCreateEntry, groupID string,
+	ctx context.Context, entry *multiSnapshotCreateEntry, groupID string, groupSize int32,
 ) apiv1.APICallRc {
 	if entry.ResourceName == "" || entry.Name == "" {
 		return apiv1.APICallRc{
@@ -151,6 +186,7 @@ func (s *Server) createOneFromMulti(
 		Flags:             entry.Flags,
 		VolumeDefinitions: entry.VolumeDefs,
 		GroupID:           groupID,
+		GroupSize:         groupSize,
 	}
 
 	err := s.hydrateSnapshotFromRD(ctx, &snap, entry.ResourceName)

--- a/pkg/rest/snapshot_multi_test.go
+++ b/pkg/rest/snapshot_multi_test.go
@@ -89,6 +89,13 @@ func TestSnapshotCreateMultiFansOut(t *testing.T) {
 
 	// Per-RD store side-effect: both snapshots ended up in the
 	// store. Pin both since the handler must hit both entries.
+	//
+	// Bug 046 / Bug-353: every entry of one batch must carry the SAME
+	// non-empty GroupID + GroupSize == batch length so the controller-
+	// side suspend barrier knows when the group is fully assembled and
+	// opens suspend on every sibling in one pass.
+	var groupID string
+
 	for _, rd := range []string{"pvc-a", "pvc-b"} {
 		snaps, sErr := st.Snapshots().ListByDefinition(ctx, rd)
 		if sErr != nil {
@@ -97,6 +104,24 @@ func TestSnapshotCreateMultiFansOut(t *testing.T) {
 
 		if len(snaps) != 1 {
 			t.Errorf("snapshots for %s: got %d, want 1", rd, len(snaps))
+
+			continue
+		}
+
+		got := snaps[0]
+		if got.GroupID == "" {
+			t.Errorf("snapshot %s: empty GroupID, want shared batch handle", rd)
+		}
+
+		if got.GroupSize != 2 {
+			t.Errorf("snapshot %s: GroupSize=%d, want 2 (batch length)", rd, got.GroupSize)
+		}
+
+		if groupID == "" {
+			groupID = got.GroupID
+		} else if got.GroupID != groupID {
+			t.Errorf("snapshot %s: GroupID=%q, want shared %q across the batch",
+				rd, got.GroupID, groupID)
 		}
 	}
 }

--- a/pkg/store/k8s/snapshots.go
+++ b/pkg/store/k8s/snapshots.go
@@ -182,11 +182,18 @@ func (s *snapshots) Update(ctx context.Context, in *apiv1.Snapshot) error {
 		// and break the cross-RD suspend-window invariant for its
 		// already-suspended siblings.
 		preservedGroupID := existing.Spec.GroupID
+		// b046/b353: GroupSize is the group-assembled denominator the
+		// controller's suspend barrier gates on. Like GroupID it is
+		// stamped once at Create time and a REST prop-patch must not
+		// clobber it — a lost GroupSize would let the barrier open early
+		// (or never) and break the cross-RD suspend-window invariant.
+		preservedGroupSize := existing.Spec.GroupSize
 
 		existing.Spec = wireToCRDSnapshotSpec(in)
 		existing.Spec.SuspendIO = preservedSuspendIO
 		existing.Spec.TakeSnapshot = preservedTakeSnapshot
 		existing.Spec.GroupID = preservedGroupID
+		existing.Spec.GroupSize = preservedGroupSize
 		mergeUserAnnotationsInto(&existing.ObjectMeta, in.Annotations)
 
 		return s.c.Update(ctx, &existing)
@@ -398,7 +405,7 @@ func snapshotVolumesFromVDs(vds []crdv1alpha1.SnapshotVolumeRef) []apiv1.Snapsho
 
 func wireToCRDSnapshot(in *apiv1.Snapshot) *crdv1alpha1.Snapshot {
 	spec := wireToCRDSnapshotSpec(in)
-	// Bug 351: every freshly-created Snapshot enters the
+	// Bug 351: a freshly-created SINGLE-snapshot enters the
 	// controller-side orchestration's Phase 1 with
 	// Spec.SuspendIO=true. The satellite reconcilers see the
 	// flag, run `drbdsetup suspend-io <rd>`, and stamp
@@ -407,7 +414,21 @@ func wireToCRDSnapshot(in *apiv1.Snapshot) *crdv1alpha1.Snapshot {
 	// (TakeSnapshot=true) and Phase 3 (clear both). The store-only
 	// stamp keeps the REST handler oblivious to the orchestration
 	// shape — the wire DTO doesn't carry these flags.
-	spec.SuspendIO = true
+	//
+	// Bug 046 / Bug-353 atomicity fix: a GROUPED snapshot (non-empty
+	// GroupID) must NOT enter suspend at Create time. The siblings of a
+	// `snapshot create-multiple` batch are created sequentially, so
+	// stamping SuspendIO here would freeze each sibling's volumes the
+	// instant its own CRD landed — siblings ~15s apart, blowing the
+	// ≤5s consistency budget. Instead the controller-side
+	// SnapshotReconciler holds the whole group at Phase 0 until every
+	// member exists (Spec.GroupSize observed) and then opens the
+	// suspend-io barrier on ALL siblings in one pass, so they enter
+	// suspend together. Leaving SuspendIO=false here is what defers
+	// Phase 1 entry to that coordinated flip.
+	if in.GroupID == "" {
+		spec.SuspendIO = true
+	}
 
 	labels := map[string]string{
 		LabelResourceDefinition: in.ResourceName,
@@ -440,6 +461,7 @@ func wireToCRDSnapshotSpec(in *apiv1.Snapshot) crdv1alpha1.SnapshotSpec {
 		Nodes:                  in.Nodes,
 		Props:                  in.Props,
 		GroupID:                in.GroupID,
+		GroupSize:              in.GroupSize,
 	}
 
 	if len(in.VolumeDefinitions) > 0 {

--- a/pkg/store/k8s/snapshots_internal_test.go
+++ b/pkg/store/k8s/snapshots_internal_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crdv1alpha1 "github.com/cozystack/blockstor/api/v1alpha1"
+	apiv1 "github.com/cozystack/blockstor/pkg/api/v1"
 )
 
 // TestCrdToWireSnapshotStatusNodeStatus pins the per-node status
@@ -83,5 +84,60 @@ func TestCrdToWireSnapshotStatusNodeStatus(t *testing.T) {
 			t.Errorf("[%d] SnapshotName: got %q, want snap-1",
 				i, got.Snapshots[i].SnapshotName)
 		}
+	}
+}
+
+// TestWireToCRDSnapshotSuspendIOByGroup pins the Bug-046 / Bug-353
+// suspend-deferral contract at the store boundary:
+//
+//   - A SINGLE snapshot (empty GroupID) keeps the Bug-351 behaviour —
+//     SuspendIO=true stamped at Create time so its lone satellite begins
+//     the suspend immediately.
+//   - A GROUPED snapshot (non-empty GroupID) must NOT be stamped
+//     SuspendIO=true at Create time. The controller-side suspend barrier
+//     owns that flip and only opens it once the whole group is assembled,
+//     so the siblings enter suspend together rather than ~15s apart. The
+//     GroupSize denominator the barrier gates on must carry through.
+func TestWireToCRDSnapshotSuspendIOByGroup(t *testing.T) {
+	t.Parallel()
+
+	single := wireToCRDSnapshot(&apiv1.Snapshot{
+		ResourceName: "pvc-a",
+		Name:         "snap-1",
+		Nodes:        []string{"n1"},
+	})
+	if !single.Spec.SuspendIO {
+		t.Errorf("single snapshot: SuspendIO=false at Create, want true (Bug-351 path)")
+	}
+
+	if single.Spec.GroupID != "" {
+		t.Errorf("single snapshot: GroupID=%q, want empty", single.Spec.GroupID)
+	}
+
+	grouped := wireToCRDSnapshot(&apiv1.Snapshot{
+		ResourceName: "pvc-a",
+		Name:         "snap-1",
+		Nodes:        []string{"n1"},
+		GroupID:      "g-batch-1",
+		GroupSize:    3,
+	})
+	if grouped.Spec.SuspendIO {
+		t.Errorf("grouped snapshot: SuspendIO=true at Create — early freeze, " +
+			"the Bug-046 hazard; the controller barrier must own the flip")
+	}
+
+	if grouped.Spec.GroupID != "g-batch-1" {
+		t.Errorf("grouped snapshot: GroupID=%q, want g-batch-1", grouped.Spec.GroupID)
+	}
+
+	if grouped.Spec.GroupSize != 3 {
+		t.Errorf("grouped snapshot: GroupSize=%d, want 3", grouped.Spec.GroupSize)
+	}
+
+	// The GroupID label must be mirrored so the controller can List
+	// siblings by selector.
+	if grouped.Labels[LabelSnapshotGroupID] != "g-batch-1" {
+		t.Errorf("grouped snapshot: group-id label=%q, want g-batch-1",
+			grouped.Labels[LabelSnapshotGroupID])
 	}
 }

--- a/pkg/store/k8s/typed_field_carry_across_test.go
+++ b/pkg/store/k8s/typed_field_carry_across_test.go
@@ -215,6 +215,13 @@ var classifications = map[string]specClassification{ //nolint:gochecknoglobals /
 			// omits the field doesn't silently demote a grouped
 			// Snapshot to the single-snap orchestrator mid-batch.
 			"GroupID": true,
+			// b046/b353: GroupSize is wire-derived (set from
+			// apiv1.Snapshot.GroupSize by wireToCRDSnapshotSpec). Like
+			// GroupID the Update path also preserves it so a REST
+			// prop-patch that omits the field can't drop the
+			// group-assembled denominator the controller's suspend
+			// barrier gates on.
+			"GroupSize": true,
 		},
 		// Bug 351: SuspendIO + TakeSnapshot are the
 		// controller-side orchestration's phase-flag pair. They

--- a/tests/operator-harness/replay/snap-create-multiple-group-consistency.yaml
+++ b/tests/operator-harness/replay/snap-create-multiple-group-consistency.yaml
@@ -1,0 +1,109 @@
+name: snap-create-multiple-group-consistency
+description: |
+  Bug-046 / Bug-353: `linstor snapshot create-multiple` (consistency-group
+  snapshot across multiple RDs) must be point-in-time atomic.
+
+  Models the "DB data volume + WAL volume on separate RDs" case operators
+  rely on for a consistent group restore: two independent 2-replica
+  diskful RDs (rd-a, rd-b) on node1+node2 are snapshotted together via the
+  multi-create endpoint. The apiserver stamps both member CRDs with a
+  shared GroupID + GroupSize; the controller-side suspend barrier holds the
+  whole group at Phase 0 until both members are observable, then opens
+  `drbdsetup suspend-io` on every sibling in a single pass so they enter
+  suspend within one controller cycle (the <=5s consistency budget). Only
+  once every member is suspended does any take run, and both resume
+  together.
+
+  Both `snapshot create-multiple` returning exit 0 is itself the
+  resume proof — the controller flips Spec.SuspendIO=false (and the
+  satellites issue `drbdsetup resume-io`) only after the group take
+  completes, so a group that never resumed would never reach the visible
+  state the step asserts and the follow-up all_uptodate re-assertions would
+  hang. A regression to the old per-RD independent suspend (siblings
+  freezing ~15s apart) would still pass exit-0 here; the byte-level
+  point-in-time assertion lives in the companion cli-matrix cell
+  (snap-create-multiple-group-consistency.sh, the <=1 counter-diff check).
+  This replay codifies the operator sequence + the no-stuck-suspended /
+  no-orphans convergence contract.
+
+prerequisites:
+  min_nodes: 2
+  storage_pool: stand
+
+vars:
+  sp: stand
+  rd: bug046-multi-a
+
+steps:
+  - name: create-rd-a
+    cmd: ["resource-definition", "create", "{{rd}}"]
+    expect_exit: 0
+  - name: create-vd-a
+    cmd: ["volume-definition", "create", "{{rd}}", "64M"]
+    expect_exit: 0
+  - name: r-c-a-node1
+    cmd: ["resource", "create", "{{node1}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-a-node2
+    cmd: ["resource", "create", "{{node2}}", "{{rd}}", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate-a
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 240
+
+  - name: create-rd-b
+    cmd: ["resource-definition", "create", "bug046-multi-b"]
+    expect_exit: 0
+  - name: create-vd-b
+    cmd: ["volume-definition", "create", "bug046-multi-b", "64M"]
+    expect_exit: 0
+  - name: r-c-b-node1
+    cmd: ["resource", "create", "{{node1}}", "bug046-multi-b", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: r-c-b-node2
+    cmd: ["resource", "create", "{{node2}}", "bug046-multi-b", "--storage-pool={{sp}}"]
+    expect_exit: 0
+  - name: wait-uptodate-b
+    cmd: ["resource", "list", "--resources", "bug046-multi-b"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: bug046-multi-b
+      timeout_s: 240
+
+  # ---- Bug-046: group snapshot — single suspend barrier, all-or-nothing --
+  - name: snapshot-create-multiple
+    cmd: ["snapshot", "create-multiple", "{{rd}}:grp", "bug046-multi-b:grp"]
+    expect_exit: 0
+  - name: both-snapshots-visible
+    cmd: ["snapshot", "list"]
+    expect_exit: 0
+
+  # ---- After the group snapshot both resources resumed I/O (uptodate) ----
+  - name: a-still-uptodate
+    cmd: ["resource", "list", "--resources", "{{rd}}"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: "{{rd}}"
+      timeout_s: 120
+  - name: b-still-uptodate
+    cmd: ["resource", "list", "--resources", "bug046-multi-b"]
+    expect_exit: 0
+    await:
+      kind: all_uptodate
+      rd: bug046-multi-b
+      timeout_s: 120
+
+teardown:
+  - cmd: ["snapshot", "delete", "{{rd}}", "grp"]
+  - cmd: ["snapshot", "delete", "bug046-multi-b", "grp"]
+  - cmd: ["resource-definition", "delete", "bug046-multi-b"]
+  - cmd: ["resource-definition", "delete", "{{rd}}"]
+
+invariants:
+  - no_orphans


### PR DESCRIPTION
## Summary

`linstor snapshot create-multiple` (consistency-group snapshot across multiple RDs) was not point-in-time atomic. The apiserver stamped a shared GroupID + SuspendIO, but the controller never coordinated phase ENTRY across siblings, so they entered SuspendIO ~15s apart (budget ≤5s). A DB's data + WAL volumes on separate RDs were captured at different instants → group restore could be inconsistent.

## Root cause (two staggering points, both per-sibling)
1. Suspend entry: store stamped SuspendIO at Create time; apiserver creates sibling CRDs sequentially → each satellite froze the instant its own CRD landed (seconds apart).
2. Take/resume: Phase 1→2 take and Phase 2→3 resume flipped only self per sibling → staggered take/resume reopened the write window before all snapshots were captured.

## Fix — coordinated group barrier (non-empty GroupID)
- Store no longer stamps SuspendIO at Create; apiserver stamps `Spec.GroupSize` on every sibling.
- Controller holds the group at Phase 0 until every member is observable (groupAssembled), then opens SuspendIO on EVERY sibling in one reconcile pass (suspendGroup).
- take/resume/abort fan out across the whole group in one pass (flipGroup) → take-all and resume-all atomic vs the writer.
- Single-snapshot (empty GroupID) path unchanged.

## No-stuck-suspended safety (deadlock-class)
All-suspended-before-any-snapshot (take still gates on every node's suspend ack); refuse-rather-than-freeze (non-UpToDate group resumes without freezing); bounded suspend (existing deadline force-aborts + resumes all); abort cascades resume-all on any per-node Failed; legacy GroupSize-missing falls back to observed-siblings count (no hang).

## Tests
- L1 snapshot_bug_046_test.go: barrier enters all together, holds until assembled, take/resume fan-out, abort/resume-all, legacy fallback + store/apiserver pins. go test ./..., -race, lint green.
- L7 replay/snap-create-multiple-group-consistency.yaml PASS on stand big.
- Stand big 3×: suspend slip 0.087/0.072/0.053s (≤5s), cross-RD counter diff=0 (point-in-time proven).

## Harness note
cli-matrix/snap-create-multiple-lifecycle has pre-existing harness bugs (dd oflag=direct bs=8 on a block dev zeroes the marker; Phase 5 colon CLI form) addressed separately; the product behavior was verified directly + via a working buffered writer.