### PR TITLE
ci(release): auto-create GitHub Release from CHANGELOG on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ name: Release Images
 #   Pre-release tags (v1.33.0-rc.1) get `1.33.0-rc.1` only — no `latest`.
 # This matches the repo's `vMAJOR.MINOR.PATCH[-rc.N]` tag convention
 # (see `git tag -l`).
+#
+# After the images publish, the workflow ALSO cuts the GitHub Release object
+# for the tag (body taken from the matching CHANGELOG.md section).
 
 on:
   push:
@@ -122,3 +125,57 @@ jobs:
             GIT_HASH=${{ steps.stamp.outputs.git_hash }}
             BUILD_TIME=${{ steps.stamp.outputs.build_time }}
           provenance: false
+
+  github-release:
+    name: Create GitHub Release
+    # After all three images publish, cut the GitHub Release for the tag:
+    # title = the tag, body = the matching "## <tag> — <date>" section of
+    # CHANGELOG.md (the same content used for prior releases). Pre-release tags
+    # (vMAJOR.MINOR.PATCH-rc.N / -alpha / -beta) are marked pre-release and not
+    # "Latest". Idempotent: updates the release if it already exists (re-run).
+    needs: build-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Cut the GitHub Release from the CHANGELOG section
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # vMAJOR.MINOR.PATCH[-rc.N] convention: pre-release tags are not Latest.
+          prerelease=()
+          latest=(--latest)
+          case "$TAG" in
+            *-rc*|*-alpha*|*-beta*) prerelease=(--prerelease); latest=(--latest=false) ;;
+          esac
+
+          # Body = the CHANGELOG.md section under "## <tag> — <date>", up to the
+          # next "## " heading; leading/trailing blank lines trimmed.
+          notes="$(mktemp)"
+          awk -v tag="$TAG" '
+            index($0, "## " tag " ") == 1 { f=1; next }
+            f && /^## / { exit }
+            f { print }
+          ' CHANGELOG.md | sed '/./,$!d' > "$notes"
+          awk 'NF{p=NR} {a[NR]=$0} END{for (i=1;i<=p;i++) print a[i]}' "$notes" > "$notes.trim"
+          mv "$notes.trim" "$notes"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; updating it."
+            edit_body=()
+            [ -s "$notes" ] && edit_body=(--notes-file "$notes")
+            gh release edit "$TAG" --title "$TAG" "${edit_body[@]}" "${prerelease[@]}" "${latest[@]}"
+          elif [ -s "$notes" ]; then
+            gh release create "$TAG" --title "$TAG" --verify-tag --notes-file "$notes" "${prerelease[@]}" "${latest[@]}"
+          else
+            echo "::warning::CHANGELOG.md has no section for $TAG; using auto-generated notes."
+            gh release create "$TAG" --title "$TAG" --verify-tag --generate-notes "${prerelease[@]}" "${latest[@]}"
+          fi


### PR DESCRIPTION
## What
Add a `github-release` job to `.github/workflows/release.yml` that, after the three images publish on a version-tag push, creates the GitHub Release — title = tag, body = the matching `## <tag> — <date>` section of `CHANGELOG.md`.

## Why
Pushing a `v*` tag built and published the ghcr images but did not create the GitHub Release object, so that step was manual. This automates "cutting a release": push the tag → images publish → Release is cut from the CHANGELOG.

## Behaviour
- Runs only after `build-push` succeeds (a Release never points at a tag whose images failed).
- Pre-release tags (`-rc`/`-alpha`/`-beta`) are marked pre-release and not "Latest".
- Idempotent: updates the Release if it already exists (re-run safe).
- Falls back to auto-generated notes (with a warning) if the CHANGELOG has no matching section.
- Note: the job triggers only on tag push, so it is not exercised by this PR's CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to automatically create and manage GitHub Releases. Releases now include extracted changelog entries and appropriate prerelease flags based on version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->