### PR TITLE
test(harness): raise CI Eventually scale ×3→×5 to fix autoplace-convergence flake

### DIFF
--- a/tests/integration/harness/asserts.go
+++ b/tests/integration/harness/asserts.go
@@ -68,8 +68,17 @@ func Eventually(t *testing.T, timeout time.Duration, predicate func() bool, msg 
 // positive-convergence asserts — it returns the moment the predicate
 // passes — so green runs pay nothing for the stretch; only genuinely
 // failing runs report slower, still capped by the job-level -timeout.
+//
+// ×3 (90s) still wasn't enough headroom for the heaviest autoplace-
+// convergence cases under full-suite CI contention: GroupFR's
+// ToggleDiskful2DisklessReapsTieBreaker and GroupJ's
+// CSICreateVolumeFromEmpty both timed out at exactly 90s on a loaded
+// runner while completing in ~8s locally — starvation, not a hang. The
+// scale is ×5 (150s) to give the placer/mock-satellite reconcile loop
+// more wall-clock under contention. A genuinely stuck test still fails
+// the job at the -timeout=15m ceiling, and green runs still pay nothing.
 func scaledTimeout(timeout time.Duration) time.Duration {
-	const ciScale = 3
+	const ciScale = 5
 
 	if os.Getenv("CI") == "" {
 		return timeout

--- a/tests/integration/harness/asserts_ci_scale_test.go
+++ b/tests/integration/harness/asserts_ci_scale_test.go
@@ -28,12 +28,15 @@ import (
 // TestScaledTimeoutStretchesOnCI pins the CI budget stretch: the
 // per-group convergence constants are tuned for dev machines, and the
 // Integration lane rotate-flaked on GitHub runners until Eventually
-// budgets were scaled there (GroupI / GroupJ 30s timeouts).
+// budgets were scaled there (GroupI / GroupJ 30s timeouts). The scale
+// is ×5 (30s → 150s): ×3 (90s) still rotate-flaked the heaviest
+// autoplace-convergence cases (GroupFR / GroupJ) under full-suite
+// contention while they complete in ~8s locally.
 func TestScaledTimeoutStretchesOnCI(t *testing.T) {
 	t.Setenv("CI", "true")
 
-	if got := scaledTimeout(30 * time.Second); got != 90*time.Second {
-		t.Fatalf("scaledTimeout on CI: got %s, want 90s", got)
+	if got := scaledTimeout(30 * time.Second); got != 150*time.Second {
+		t.Fatalf("scaledTimeout on CI: got %s, want 150s", got)
 	}
 
 	t.Setenv("CI", "")


### PR DESCRIPTION
## What

Raise the CI `Eventually` budget scale from ×3 to ×5 (per-group base 30s → 150s on CI) in `tests/integration/harness/asserts.go`.

## Why

The ×3 stretch introduced in #173 (30s → 90s on CI) still let the Integration lane rotate-flake under full-suite contention. The heaviest autoplace-convergence cases — `TestGroupFRToggleDiskful2DisklessReapsTieBreaker` and `TestGroupJ/CSICreateVolumeFromEmpty` — both timed out at *exactly* 90s on a loaded GitHub runner (`Eventually timed out after 1m30s: ... never reached 2 diskful replicas` / `autoplace did not converge to placeCount=2`), while the same tests complete in **~8s locally** and pass on other CI runs. That signature is CPU **starvation under load, not a hang** — the placer / mock-satellite reconcile loop is simply not getting scheduled enough within 90s when the whole suite runs concurrently. More wall-clock is the correct, targeted mitigation.

## Fail-safe

`Eventually` returns the instant its predicate passes, so **green runs pay nothing** for the larger budget — only genuinely slow/failing runs report later, and those are still capped by the job-level `-timeout=15m`. So ×5 cannot cause runaway jobs; it only widens the headroom for load-starved convergence.

## Scope

Test-infrastructure only — no product code changes. The pin test `TestScaledTimeoutStretchesOnCI` is updated to the new 150s expectation. The CHANGELOG entry lands in the v0.1.17 release section (this repo writes the CHANGELOG at release time, not per-PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of integration runs by allowing more time for slower CI environments.
  * Reduced the chance of timeout-related test failures in long-running scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->