### PR TITLE
chore(codeowners): declare repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Review routing for this repository.
+#
+# The Cozystack maintainers are maintainers of every sub-project by default
+# (https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md). The handles
+# below are the people whose review is requested on changes here. It is a
+# routing list, not a claim about who contributes most: some entries are here
+# because the area is theirs, others because the role carries the repository.
+
+* @kvaps @IvanHunters


### PR DESCRIPTION
Declares who owns this repository, so review routes to them instead of to nobody.

Ownership follows the roster being documented in cozystack/cozystack#3462: the Cozystack maintainers are maintainers of every sub-project by default, and this file names the people who own this one day to day.

Part of aligning code ownership in GitHub with the documented governance roles, which is a required item for the CNCF Incubation review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a repository code-ownership configuration to route reviews through a default ownership and ensure the appropriate reviewers are requested for changes covered by the rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->